### PR TITLE
Default to `debug=False`

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -603,7 +603,7 @@ class Dash(object):
 
     def run_server(self,
                    port=8050,
-                   debug=True,
+                   debug=False,
                    threaded=True,
                    **flask_run_options):
         self.server.run(port=port, debug=debug, **flask_run_options)


### PR DESCRIPTION
Require users to explicitly set `debug=True` so that they are better aware of the security implications.

Partially fixes #16. 