### PR TITLE
Update circleci

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   post:
-    - pyenv global 2.7.10 3.3.3 3.4.3 3.5.0
+    - pyenv global 2.7.10 3.3.6 3.4.3 3.5.1
   environment:
     TOX_PYTHON_27: python2.7
     TOX_PYTHON_33: python3.3


### PR DESCRIPTION
Update python versions for the default circleci image (https://circleci.com/docs/1.0/build-image-trusty/#python). Other possibility would be to update the circleci config to install the missing python versions.