### PR TITLE
Fix unicode error on Py3.6.1 during install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 
+import io
 exec (open('dash/version.py').read())
 
 setup(
@@ -10,7 +11,7 @@ setup(
     packages=find_packages(exclude=['tests*']),
     license='MIT',
     description='A Python framework for building reactive web-apps. Developed by Plotly.',
-    long_description=open('README.md').read(),
+    long_description=io.open('README.md', encoding='utf-8').read(),
     install_requires=[
         'Flask>=0.12',
         'flask-compress',


### PR DESCRIPTION
Fix a unicode handling error during installation
on Python 3.6.1 by forcing Py27 and Py3 to use
the compatible io.open method on both versions.