### PR TITLE
Falsey values ("", 0, [], {},  False) are as bad as None

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -35,13 +35,8 @@ class Dash(object):
         csrf_protect=True
     ):
         # allow users to supply their own flask server
-        if server is not None:
-            self.server = server
-        else:
-            if name is None:
-                name = 'dash'
-            self.server = Flask(name)
-
+        name = name or 'dash'
+        self.server = server or Flask(name)
         if self.server.secret_key is None:
             # If user supplied their own server, they might've supplied a
             # secret_key with it
@@ -55,7 +50,7 @@ class Dash(object):
             os.environ[secret_key_name] = secret_key
             self.server.secret_key = secret_key
 
-        if filename is not None:
+        if filename:
             fid = plotly_api.create_or_overwrite_dash_app(
                 filename, sharing, app_url
             )


### PR DESCRIPTION
In these instances, all other falsey values ("", 0, [], {},  False, etc.) are just as dangerous as `None` so we should treat them as if they were `None`.

This approach replaces an empty `name` with 'dash' even if the caller provides a `server`.