### PR TITLE
A patch proposal for multi-app setups

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -32,6 +32,7 @@ class Dash(object):
         filename=None,
         sharing=None,
         app_url=None,
+        app_path='',
         url_base_pathname='/',
         csrf_protect=True
     ):
@@ -69,6 +70,7 @@ class Dash(object):
             self.access_codes = None
 
         self.url_base_pathname = url_base_pathname
+        self.app_path = app_path
 
         # list of dependencies
         self.callback_map = {}
@@ -214,7 +216,7 @@ class Dash(object):
             ),
             'oauth_client_id': 'RcXzjux4DGfb8bWG9UNGpJUGsTaS0pUVHoEf7Ecl',
             'redirect_uri': 'http://localhost:9595',
-            'url_base_pathname': self.url_base_pathname
+            'url_base_pathname': self.app_path + self.url_base_pathname
         }
 
     @_requires_auth
@@ -238,7 +240,7 @@ class Dash(object):
                 self.registered_paths[namespace] = [relative_package_path]
 
             return '{}_dash-component-suites/{}/{}?v={}'.format(
-                self.url_base_pathname,
+                self.app_path + self.url_base_pathname,
                 namespace,
                 relative_package_path,
                 importlib.import_module(namespace).__version__


### PR DESCRIPTION
This patch address my question on SO
https://stackoverflow.com/questions/44744709/how-to-organise-a-plotly-dash-project

In order to serve multiple apps with one interpreter, I am using a DispatcherMiddleware from werkzeug.wsgi:
http://flask.pocoo.org/docs/0.12/patterns/appdispatch/

I'd like to avoid running multiple gunicorns on different ports, as this will complicate the setup unnecessary, IMO.

So my structure is as follows:

`run.py`

```
from werkzeug.serving import run_simple
from werkzeug.wsgi import DispatcherMiddleware

# importing apps
from index_app import app as app_ix
from app1 import app as app1
from app2 import app as app2
from app3 import app as app3

application = DispatcherMiddleware(app_ix, {
    '/app1': app1.server,
    '/app2': app2.server,
    '/app3': app3.server
})

# local debug
if __name__ == '__main__':
    run_simple('localhost', 5001, application)
```

and `app1.py`

```
import dash
import dash_core_components as dcc
import dash_html_components as html

from dash.dependencies import Input, Output
app = dash.Dash(app_path='/{}'.format(__name__))
...
```

Without my changes, however, individual apps don't know that they are served on a separate URL path and couldn't find resources, such as layout, etc.

Let me know if there is a better way to build a multi-page dash apps.