### PR TITLE
Always sort `prop_ names`

### DIFF
--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -28,7 +28,7 @@ class Component(collections.MutableMapping):
     def to_plotly_json(self):
         as_json = {
             'props': {p: getattr(self, p)
-                      for p in sorted(self._prop_names)
+                      for p in self._prop_names
                       if hasattr(self, p)},
             'type': self._type,
             'namespace': self._namespace
@@ -226,7 +226,7 @@ def generate_class(typename, props, description, namespace):
                    if c is not self._prop_names[0])):
 
                 return '{typename}('+', '.join([c+'='+repr(getattr(self, c, None))
-                                                for c in sorted(self._prop_names)
+                                                for c in self._prop_names
                                                 if getattr(self, c, None) is not None])+')'
 
             else:

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -20,7 +20,7 @@ class Component(collections.MutableMapping):
                 raise Exception(
                     'Unexpected keyword argument `{}`'.format(k) +
                     '\nAllowed arguments: {}'.format(
-                        ', '.join(self._prop_names)
+                        ', '.join(sorted(self._prop_names))
                     )
                 )
             setattr(self, k, v)
@@ -28,7 +28,7 @@ class Component(collections.MutableMapping):
     def to_plotly_json(self):
         as_json = {
             'props': {p: getattr(self, p)
-                      for p in self._prop_names
+                      for p in sorted(self._prop_names)
                       if hasattr(self, p)},
             'type': self._type,
             'namespace': self._namespace
@@ -226,7 +226,8 @@ def generate_class(typename, props, description, namespace):
                    if c is not self._prop_names[0])):
 
                 return '{typename}('+', '.join([c+'='+repr(getattr(self, c, None))
-                                                for c in self._prop_names if getattr(self, c, None) is not None])+')'
+                                                for c in sorted(self._prop_names)
+                                                if getattr(self, c, None) is not None])+')'
 
             else:
                 return '{typename}(' + repr(getattr(self, self._prop_names[0], None)) + ')'


### PR DESCRIPTION
It's hard to find the property you want in the unsorted dict key so always sort the names before printing them. E.g. `rel` is not in the place I would expect here - I expected it before `spellCheck`:

```
Traceback (most recent call last):
  File "app.py", line 31, in <module>
    html.Link(rel="shortcut icon", href="favicon.ico", type="image/x-icon")
  File "<string>", line 45, in __init__
  File "/Users/olgabot/anaconda3/envs/maca-dash/lib/python3.6/site-packages/dash/development/base_component.py", line 23, in __init__
    ', '.join(self._prop_names)
Exception: Unexpected keyword argument `type`
Allowed arguments: children, crossOrigin, href, hrefLang, integrity, media, rel, sizes, accessKey, className, contentEditable, contextMenu, dir, draggable, hidden, lang, spellCheck, style, tabIndex, title, id
```