### PR TITLE
added id to KeyError for get and set on Components

### DIFF
--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -103,7 +103,7 @@ class Component(collections.MutableMapping):
 
         # The end of our branch
         # If we were in a list, then this exception will get caught
-        raise KeyError
+        raise KeyError(id)
 
     # Supply ABC methods for a MutableMapping:
     # - __getitem__


### PR DESCRIPTION
When building up a Component tree layout using an id setter (eg `layout['some-id'] = some_component`), this propagates the missing id value into the traceback, making debugging much easier