### PR TITLE
[wip] previous state support

### DIFF
--- a/dash/dependencies.py
+++ b/dash/dependencies.py
@@ -20,3 +20,15 @@ class Event:
     def __init__(self, component_id, component_event):
         self.component_id = component_id
         self.component_event = component_event
+
+
+class PrevInput:
+    def __init__(self, component_id, component_property):
+        self.component_id = component_id
+        self.component_property = component_property
+
+
+class PrevState:
+    def __init__(self, component_id, component_property):
+        self.component_id = component_id
+        self.component_property = component_property


### PR DESCRIPTION
depends on https://github.com/plotly/dash-renderer/pull/25

experimental usage
```python
# -*- coding: utf-8 -*-
import dash
from dash.dependencies import Input, Output, PrevInput
import dash_html_components as html
import dash_core_components as dcc

app = dash.Dash()
app.scripts.config.serve_locally = True

app.layout = html.Div([
    html.Button('Button 1', id='button-1', n_clicks=0),
    html.Button('Button 2', id='button-2', n_clicks=0),
    html.Pre(id='output')
])


@app.callback(
    Output('output', 'children'),
    [Input('button-1', 'n_clicks'), Input('button-2', 'n_clicks')],
    prev_inputs=[
        PrevInput('button-1', 'n_clicks'),
        PrevInput('button-2', 'n_clicks')
    ])
def update_output(b1, b2, prev_b1, prev_b2):
    s = '''
        Button 1 was clicked {} → {} times and
        Button 2 was clicked {} → {} times
    '''.format(prev_b1, b1, prev_b2, b2)
    if b1 > prev_b1:
        s += '\nWhich means that Button 1 was clicked'
    elif b2 > prev_b2:
        s += '\nWhich means that Button 2 was clicked'
    return s



if __name__ == '__main__':
    app.run_server(debug=True)
```

![previous-state](https://user-images.githubusercontent.com/1280389/31202577-2209d536-a931-11e7-8f84-239f948a5674.gif)
