### PR TITLE
Removing outdated reference to NYC masterclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Dash
 
-***
-
 #### Dash is a Python framework for building analytical web applications. No JavaScript required.
 
 Build on top of Plotly.js, React, and Flask, Dash ties modern UI elements like dropdowns, sliders, and graphs directly to your analytical python code.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Dash
 
-#### 📢 Announcement!
-#### Seats are still available for a 2 day, Dash master class in NYC, November 18-19. 
-#### [Registration here](https://plotcon.plot.ly/workshops) 🎚 📈 🗽
-
 ***
 
 #### Dash is a Python framework for building analytical web applications. No JavaScript required.


### PR DESCRIPTION
Now that the masterclass has been and gone, I'm suggesting removing the reference to it from the README (I got confused and tried to sign up because I didn't read the dates on the link in the README carefully enough).