### PR TITLE
Fix position of HTML footer tag to be inside the HTML body tag.  

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -298,12 +298,11 @@ class Dash(object):
                         Loading...
                     </div>
                 </div>
+                <footer>
+                    {}
+                    {}
+                </footer>
             </body>
-
-            <footer>
-                {}
-                {}
-            </footer>
         </html>
         '''.format(title, css, config, scripts))
 


### PR DESCRIPTION
You can see the error at https://validator.w3.org/ when validating a Dash app.