### PR TITLE
allow optional header and footer

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -112,6 +112,8 @@ class Dash(object):
         self._layout = None
         self._cached_layout = None
         self.routes = []
+        self.head = None
+        self.footer = None
 
     @property
     def layout(self):

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -283,14 +283,16 @@ class Dash(object):
         scripts = self._generate_scripts_html()
         css = self._generate_css_dist_html()
         config = self._generate_config_html()
-        title = getattr(self, 'title', 'Dash')
+        custom_head_html = self._generate_head()
+        custom_footer_html = self._generate_footer()
+
         return '''
         <!DOCTYPE html>
         <html>
             <head>
                 <meta charset="UTF-8">
-                <title>{}</title>
-                {}
+                {component_css}
+                {custom_head_html}
             </head>
             <body>
                 <div id="react-entry-point">
@@ -299,12 +301,18 @@ class Dash(object):
                     </div>
                 </div>
                 <footer>
-                    {}
-                    {}
+                    {config}
+                    {component_scripts}
+                    {custom_footer_html}
                 </footer>
             </body>
         </html>
-        '''.format(title, css, config, scripts)
+        '''.format(
+            component_css=css,
+            config=config,
+            component_scripts=scripts,
+            custom_head_html=custom_head_html,
+            custom_footer_html=custom_footer_html)
 
     def dependencies(self):
         return flask.jsonify([
@@ -324,6 +332,40 @@ class Dash(object):
             'Yo! `react` is no longer used. \n'
             'Use `callback` instead. `callback` has a new syntax too, '
             'so make sure to call `help(app.callback)` to learn more.')
+
+    def _generate_footer_or_header_html(self, footer_or_header):
+        section = getattr(self, footer_or_header)
+        if isinstance(section, collections.Callable):
+            section_instance = section()
+        else:
+            section_instance = section
+
+        def convert_to_html(element):
+            if isinstance(element, Component):
+                element_html = element.to_html5()
+            elif isinstance(element, basestring):
+                element_html = element
+            elif element is None:
+                element_html = ''
+            return element_html
+
+        if isinstance(section_instance, collections.Iterable):
+            section_html = '\n'.join(
+                [convert_to_html(element) for element in section_instance])
+        else:
+            section_html = convert_to_html(section_instance)
+
+        return section_html
+
+    def _generate_footer(self):
+        return self._generate_footer_or_header_html('footer')
+
+    def _generate_head(self):
+        head_html = self._generate_footer_or_header_html('head')
+        if head_html == '':
+            head_html = '<title>{}</title>'.format(
+                getattr(self, 'title', 'Dash'))
+        return head_html
 
     def _validate_callback(self, output, inputs, state, events):
         layout = self._cached_layout or self._layout_value()


### PR DESCRIPTION
This PR depends on html components having a HTML serializer, see
https://github.com/plotly/dash-html-components/pull/29

This PR simplifies adding custom JavaScript and CSS to Dash apps - a more flexible and declarative alternative to `app.css.append_css` and `app.scripts.append_script`

Example usage:
```python
app.head = [
    html.Link(
        href='https://codepen.io/chriddyp/pen/bWLwgP.css',
        rel='stylesheet'
    ),
    ('''
    <style type="text/css">
    html {
        font-size: 50px;
    }
    </style>
    '''),
    html.Title(path)
]

app.footer = [
    html.Script(type='text/javascript', children='alert("hello world")')
]
```

`app.head` and `app.footer` can also be functions, which enables setting variables dynamically based off of the URL (i.e. unique page titles)

```python
def head():
    path = request.path
    return html.Title(path)

app.head = head
```

Unlike `app.layout`, `app.head` and `app.footer` are templated directly into the HTML (as HTML!) rather than generated in Dash’s front-end. This allows the components to be rendered immediately on page load rather than after page load (required for things like page title and meta descriptions and for preventing a “Flash of Unstyled Content” https://en.wikipedia.org/wiki/Flash_of_unstyled_content).

 This makes the components in `app.head` and `app.footer` different than the components in `app.layout`. In particular:
- Callbacks can’t be applied to components rendered in `app.head` or `app.footer`
- Only `dash_html_components` can be applied to the `app.head` and `app.footer` as these are the only valid HTML tags (a `dash_core_components.Graph is not a valid HTML tag, it’s a rich component generated by React.js with dynamic javascript and CSS)

Fixes #https://github.com/plotly/dash/issues/170 and several issues brought up in the dash community forum (https://community.plot.ly/c/dash)