### PR TITLE
Import submodules into __init__.py for IDE code completion

### DIFF
--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -1,5 +1,4 @@
 from .dash import Dash  # noqa: F401
-from . import authentication  # noqa: F401
 from . import dependencies  # noqa: F401
 from . import development  # noqa: F401
 from . import exceptions  # noqa: F401

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -1,3 +1,7 @@
 from .dash import Dash  # noqa: F401
+from . import authentication  # noqa: F401
+from . import dependencies  # noqa: F401
 from . import development  # noqa: F401
+from . import exceptions  # noqa: F401
+from . import resources  # noqa: F401
 from .version import __version__  # noqa: F401


### PR DESCRIPTION
Fix for #144, but only for the dash library itself.

I was also looking to add IDE completion for [dash-core-components](https://github.com/plotly/dash-core-components), but this seems a bit more difficult as component data is loaded from `metadata.json`.

```python
import dash_core_components as dcc
print(dir(dcc))
```
We see all the core components in the namespace (and, therefore, in IPython), but they do not show up in the IDE. Hardcoding `__all__` is a workaround, but not something I want to do.

@chriddyp do you have any thoughts on this?