### PR TITLE
Enable custom response support for callback functions

### DIFF
--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -1,4 +1,5 @@
 from .dash import Dash  # noqa: F401
+from .response import DashResponse  # noqa: F401
 from . import dependencies  # noqa: F401
 from . import development  # noqa: F401
 from . import exceptions  # noqa: F401

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -12,6 +12,7 @@ import dash_renderer
 
 from .dependencies import Event, Input, Output, State
 from .resources import Scripts, Css
+from .response import DashResponse
 from .development.base_component import Component
 from . import exceptions
 from ._utils import AttributeDict as _AttributeDict
@@ -491,6 +492,11 @@ class Dash(object):
             def add_context(*args, **kwargs):
 
                 output_value = func(*args, **kwargs)
+
+                if isinstance(output_value, DashResponse):
+                    output_value.jsonify_response(output)
+                    return output_value
+
                 response = {
                     'response': {
                         'props': {

--- a/dash/response.py
+++ b/dash/response.py
@@ -1,0 +1,34 @@
+"""
+Extended Flask Response for using inside a callbacks
+"""
+import json
+import plotly
+from flask import Response
+
+
+class DashResponse(Response):
+    """
+    Flask Response extended with option to convert a regular response to
+    valid Dash json-encoded
+    """
+    def __init__(self, *args, **kwargs):
+        self.dash_response = args[0] if args else None
+        super(DashResponse, self).__init__(
+            mimetype='application/json', *args, **kwargs)
+
+    def jsonify_response(self, output):
+        """
+        convert response to valid Dash json-encoded
+        :param output: output element for the callback
+        :return:
+        """
+        response = {
+            'response': {
+                'props': {
+                    output.component_property: self.dash_response
+                }
+            }
+        }
+        self.set_data(
+            json.dumps(response, cls=plotly.utils.PlotlyJSONEncoder)
+        )


### PR DESCRIPTION
Based on issue #182 (Set a cookie from callback function).

With the following functionality callback function can return not only Dash components tree, but a customizable DashResponse with cookies, headers etc. 

```
from dash import DashResponse
...

@app.callback(
    dash.dependencies.Output('content-block', 'children'),
    [dash.dependencies.Input('comparison-filter', 'value')])
def on_filter_change(comparison_value):
    response = DashResponse(html.Div('foo', className="test"))
    response.set_cookie('bar', 'baz')
    return response
```