### PR TITLE
integration tests

### DIFF
--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -1,0 +1,94 @@
+from selenium import webdriver
+from selenium.webdriver.common.keys import Keys
+import dash
+import dash_core_components
+import dash_core_components as dcc
+import dash_html_components as html
+import importlib
+import multiprocessing
+import percy
+import time
+import unittest
+import os
+import sys
+
+
+class IntegrationTests(unittest.TestCase):
+
+    def percy_snapshot(cls, name=''):
+        snapshot_name = '{} - {}'.format(name, sys.version_info)
+        print(snapshot_name)
+        cls.percy_runner.snapshot(
+            name=snapshot_name
+        )
+
+    @classmethod
+    def setUpClass(cls):
+        super(IntegrationTests, cls).setUpClass()
+        cls.driver = webdriver.Chrome()
+
+        loader = percy.ResourceLoader(
+          webdriver=cls.driver
+        )
+        cls.percy_runner = percy.Runner(loader=loader)
+
+        cls.percy_runner.initialize_build()
+
+
+    @classmethod
+    def tearDownClass(cls):
+        super(IntegrationTests, cls).tearDownClass()
+        cls.driver.quit()
+        cls.percy_runner.finalize_build()
+
+    def setUp(s):
+        pass
+
+    def tearDown(s):
+        time.sleep(2)
+        s.server_process.terminate()
+        time.sleep(2)
+
+    def startServer(s, dash):
+        def run():
+            dash.scripts.config.serve_locally = True
+            dash.run_server(
+                port=8050,
+                debug=False,
+                processes=4
+            )
+
+        # Run on a separate process so that it doesn't block
+        s.server_process = multiprocessing.Process(target=run)
+        s.server_process.start()
+        time.sleep(0.5)
+
+        # Visit the dash page
+        s.driver.get('http://localhost:8050')
+        time.sleep(0.5)
+
+        # Inject an error and warning logger
+        logger = '''
+        window.tests = {};
+        window.tests.console = {error: [], warn: [], log: []};
+
+        var _log = console.log;
+        var _warn = console.warn;
+        var _error = console.error;
+
+        console.log = function() {
+            window.tests.console.log.push({method: 'log', arguments: arguments});
+            return _log.apply(console, arguments);
+        };
+
+        console.warn = function() {
+            window.tests.console.warn.push({method: 'warn', arguments: arguments});
+            return _warn.apply(console, arguments);
+        };
+
+        console.error = function() {
+            window.tests.console.error.push({method: 'error', arguments: arguments});
+            return _error.apply(console, arguments);
+        };
+        '''
+        s.driver.execute_script(logger)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,0 +1,76 @@
+from dash import Dash
+from dash.dependencies import Input, Output, State, Event
+import dash
+import dash_html_components as html
+import dash_core_components as dcc
+from .IntegrationTests import IntegrationTests
+from .utils import assert_clean_console, invincible, wait_for
+from multiprocessing import Value
+import time
+import re
+import itertools
+import json
+
+
+class Tests(IntegrationTests):
+    def setUp(self):
+        def wait_for_element_by_id(id):
+            wait_for(lambda: None is not invincible(
+                lambda: self.driver.find_element_by_id(id)
+            ))
+            return self.driver.find_element_by_id(id)
+        self.wait_for_element_by_id = wait_for_element_by_id
+
+
+    def test_simple_callback(self):
+        app = Dash(__name__)
+        app.layout = html.Div([
+            dcc.Input(
+                id='input',
+                value='initial value'
+            ),
+            html.Div(
+                html.Div([
+                    1.5,
+                    None,
+                    'string',
+                    html.Div(id='output-1')
+                ])
+            )
+        ])
+
+        call_count = Value('i', 0)
+
+        @app.callback(Output('output-1', 'children'), [Input('input', 'value')])
+        def update_output(value):
+            call_count.value = call_count.value + 1
+            return value
+
+        self.startServer(app)
+
+        output1 = self.wait_for_element_by_id('output-1')
+        wait_for(lambda: output1.text == 'initial value')
+        self.percy_snapshot(name='simple-callback-1')
+
+        input1 = self.wait_for_element_by_id('input')
+        input1.clear()
+
+        input1.send_keys('hello world')
+
+        output1 = lambda: self.wait_for_element_by_id('output-1')
+        wait_for(lambda: output1().text == 'hello world')
+        self.percy_snapshot(name='simple-callback-2')
+
+        self.assertEqual(
+            call_count.value,
+            # an initial call to retrieve the first value
+            1 +
+            # one for each hello world character
+            len('hello world')
+        )
+
+        self.request_queue_assertions(
+            expected_length=1,
+            check_rejected=False)
+
+        assert_clean_console(self)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -69,8 +69,4 @@ class Tests(IntegrationTests):
             len('hello world')
         )
 
-        self.request_queue_assertions(
-            expected_length=1,
-            check_rejected=False)
-
         assert_clean_console(self)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,84 @@
+import json
+import time
+
+
+TIMEOUT = 5  # Seconds
+
+
+def invincible(func):
+    def wrap():
+        try:
+            return func()
+        except:
+            pass
+    return wrap
+
+
+
+class WaitForTimeout(Exception):
+    """This should only be raised inside the `wait_for` function."""
+    pass
+
+
+def wait_for(condition_function, get_message=lambda: '', *args, **kwargs):
+    """
+    Waits for condition_function to return True or raises WaitForTimeout.
+    :param (function) condition_function: Should return True on success.
+    :param args: Optional args to pass to condition_function.
+    :param kwargs: Optional kwargs to pass to condition_function.
+        if `timeout` is in kwargs, it will be used to override TIMEOUT
+    :raises: WaitForTimeout If condition_function doesn't return True in time.
+    Usage:
+        def get_element(selector):
+            # some code to get some element or return a `False`-y value.
+        selector = '.js-plotly-plot'
+        try:
+            wait_for(get_element, selector)
+        except WaitForTimeout:
+            self.fail('element never appeared...')
+        plot = get_element(selector)  # we know it exists.
+    """
+    def wrapped_condition_function():
+        """We wrap this to alter the call base on the closure."""
+        if args and kwargs:
+            return condition_function(*args, **kwargs)
+        if args:
+            return condition_function(*args)
+        if kwargs:
+            return condition_function(**kwargs)
+        return condition_function()
+
+    if 'timeout' in kwargs:
+        timeout = kwargs['timeout']
+        del kwargs['timeout']
+    else:
+        timeout = TIMEOUT
+
+    start_time = time.time()
+    while time.time() < start_time + timeout:
+        if wrapped_condition_function():
+            return True
+        time.sleep(0.5)
+
+    raise WaitForTimeout(get_message())
+
+
+def assert_clean_console(TestClass):
+    def assert_no_console_errors(TestClass):
+        TestClass.assertEqual(
+            TestClass.driver.execute_script(
+                'return window.tests.console.error.length'
+            ),
+            0
+        )
+
+    def assert_no_console_warnings(TestClass):
+        TestClass.assertEqual(
+            TestClass.driver.execute_script(
+                'return window.tests.console.warn.length'
+            ),
+            0
+        )
+
+    assert_no_console_warnings(TestClass)
+    assert_no_console_errors(TestClass)

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,17 @@ passenv = *
 basepython={env:TOX_PYTHON_27}
 commands =
     python --version
-    python -m unittest discover -s tests/
+    python -m unittest tests.test_integration
+    python -m unittest tests.test_react
+    python -m unittest tests.test_resources
+
     flake8 dash setup.py
 
 [testenv:py36]
 basepython={env:TOX_PYTHON_36}
 commands =
     python --version
-    python -m unittest discover -s tests/
+    python -m unittest tests.test_integration
+    python -m unittest tests.test_react
+    python -m unittest tests.test_resources
     flake8 dash setup.py

--- a/tox.ini
+++ b/tox.ini
@@ -3,9 +3,7 @@ envlist = py27,py36
 
 [testenv]
 deps = -rdev-requirements.txt
-passenv =
-  HOME
-  DISPLAY
+passenv = *
 
 [testenv:py27]
 basepython={env:TOX_PYTHON_27}


### PR DESCRIPTION
Most of Dash’s integration tests are in Dash’s front-end library: https://github.com/plotly/dash-renderer.

This PR adds an integration test framework to this repository and a simple integration test. This enables future Python functionality that affects the front-end and backend, like https://github.com/plotly/dash/pull/183, to be tested.