### PR TITLE
added PreventUpdate exception and attached handler to Flask server

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import sys
 import collections
 import importlib

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1,3 +1,4 @@
+import sys
 import collections
 import importlib
 import json
@@ -52,6 +53,12 @@ class Dash(object):
 
         # gzip
         Compress(self.server)
+
+        @self.server.errorhandler(exceptions.PreventUpdate)
+        def handle_error(error):
+            """Handle a halted callback and return an empty 204 response"""
+            print(error, file=sys.stderr)
+            return ('', 204)
 
         # static files from the packages
         self.css = Css()

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -57,7 +57,7 @@ class Dash(object):
         Compress(self.server)
 
         @self.server.errorhandler(exceptions.PreventUpdate)
-        def handle_error(error):
+        def _handle_error(error):
             """Handle a halted callback and return an empty 204 response"""
             print(error, file=sys.stderr)
             return ('', 204)

--- a/dash/exceptions.py
+++ b/dash/exceptions.py
@@ -41,5 +41,6 @@ class IDsCantContainPeriods(CallbackException):
 class CantHaveMultipleOutputs(CallbackException):
     pass
 
+
 class PreventUpdate(CallbackException):
     pass

--- a/dash/exceptions.py
+++ b/dash/exceptions.py
@@ -40,3 +40,6 @@ class IDsCantContainPeriods(CallbackException):
 
 class CantHaveMultipleOutputs(CallbackException):
     pass
+
+class PreventUpdate(CallbackException):
+    pass


### PR DESCRIPTION
create a new exception `PreventUpdate` for use when a callback needs to be aborted without updating the state of the client.

This exception is registered with the Flask server using an `errorhandler` such that on catching this exception Flask will print any message included in the exception to standard error and then return an empty 204 NO CONTENT response.  