### PR TITLE
For HTML5 script tags you can omit the type attribute when its value …

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -236,7 +236,7 @@ class Dash(object):
         )
 
         return '\n'.join([
-            '<script type="text/JavaScript" src="{}"></script>'.format(src)
+            '<script src="{}"></script>'.format(src)
             for src in srcs
         ])
 

--- a/tests/test_react.py
+++ b/tests/test_react.py
@@ -20,7 +20,7 @@ def generate_css(css_links):
 
 def generate_js(js_links):
     return '\n'.join([
-        '<script type="text/JavaScript" src="{}"></script>'.format(l)
+        '<script src="{}"></script>'.format(l)
         for l in js_links
     ])
 


### PR DESCRIPTION
…is JavaScript. From MDN -> https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script - Omitted or a JavaScript MIME type: For HTML5-compliant browsers this indicates the script is JavaScript. HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type.

Example from MDN:
HTML4 and (x)HTML
<script type="text/javascript" src="javascript.js"></script>
HTML5
<script src="javascript.js"></script>
  
 https://www.w3.org/TR/2011/WD-html5-20110405/scripting-1.html#script