### PR TITLE
Fix undefined reference to __version__ in setup.py and remove '# noqa…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ dist
 *egg-info*
 npm-debug*
 /.tox
+.idea

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,12 @@
 import io
 from setuptools import setup, find_packages
 
-
-exec(open('dash/version.py').read())  # pylint: disable=exec-used
+main_ns = {}
+exec(open('dash/version.py').read(), main_ns)  # pylint: disable=exec-used
 
 setup(
     name='dash',
-    version=__version__,  # noqa: F821 pylint: disable=undefined-variable
+    version=main_ns['__version__'],
     author='chris p',
     author_email='chris@plot.ly',
     packages=find_packages(exclude=['tests*']),


### PR DESCRIPTION
…: F821 pylint: disable=undefined-variable'. You can test this fix by changing the 'version' in version.py and then running from the command line: python3 setup.py --version