### PR TITLE
Improve callback decorator

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -6,6 +6,7 @@ import importlib
 import json
 import pkgutil
 import warnings
+from functools import wraps
 
 import plotly
 import dash_renderer
@@ -503,6 +504,7 @@ class Dash(object):
         }
 
         def wrap_func(func):
+            @wraps(func)
             def add_context(*args, **kwargs):
 
                 output_value = func(*args, **kwargs)

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -6,12 +6,12 @@ import importlib
 import json
 import pkgutil
 import warnings
-from flask import Flask, Response
-import flask
-from flask_compress import Compress
-import plotly
 
+import plotly
 import dash_renderer
+import flask
+from flask import Flask, Response
+from flask_compress import Compress
 
 from .dependencies import Event, Input, Output, State
 from .resources import Scripts, Css


### PR DESCRIPTION
The function objects stored in a `Dash` instance's `callback_map` are currently not useful for introspecting:

```
>>> app.callback_map['dash-container.children']['callback'].__name__
'add_context'
```

The `functools.wraps` decorator passes various attributes of a decorated function onto the resulting function object, making introspection work as expected:

```
>>> app.callback_map['dash-container.children']['callback'].__name__
'add_context'
```

The `callback_map` can now be used for more useful profiling of all registered callbacks in an app. 


