### PR TITLE
Add a 'compress' param to Dash class's __init__()

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -21,6 +21,7 @@ from ._utils import AttributeDict as _AttributeDict
 
 
 # pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-arguments
 class Dash(object):
     def __init__(
             self,
@@ -28,6 +29,7 @@ class Dash(object):
             server=None,
             static_folder=None,
             url_base_pathname='/',
+            compress=True,
             **kwargs):
 
         # pylint-disable: too-many-instance-attributes
@@ -53,8 +55,9 @@ class Dash(object):
         # list of dependencies
         self.callback_map = {}
 
-        # gzip
-        Compress(self.server)
+        if compress:
+            # gzip
+            Compress(self.server)
 
         @self.server.errorhandler(exceptions.PreventUpdate)
         def _handle_error(error):


### PR DESCRIPTION
Adding a `compress` param provides the ability to opt out of automatically having all responses gzipped.

This is desirable because it is less efficient to be doing compression within the Python process than for the web server to handle it. Dash apps that care about scalability can now opt out.

Addresses #202 