### PR TITLE
Enhance default support for custom static assets

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -26,9 +26,9 @@ from ._utils import AttributeDict as _AttributeDict
 class Dash(object):
     def __init__(
             self,
-            name=None,
+            name='__main__',
             server=None,
-            static_folder=None,
+            static_folder='static',
             url_base_pathname='/',
             compress=True,
             **kwargs):


### PR DESCRIPTION
This is a proposal for adding better support for custom static assets to that addresses a couple of current friction points.

I've noticed on the Dash forums that a question that keeps arising is how to add custom CSS assets. Besides from adding them to the app, they also need to be configured to be served by Flask. Currently, the way to set this up with is not particularly intuitive and there is at least one potential gotcha. The most straightforward way to make Flask serve static assets is for users to create a folder such as 'static' in the same directory as their Dash app, and then initialize their app like this:

`app = dash.Dash(__name__, static_folder='static')`

As discussed in #198, confusingly, this will not work if users omit the initial `name` param, or supply an incorrect value for it. This is because this param becomes the `import_name` param to the `Flask` instance, which it uses to for deriving the location of your static folder. So the default value of `dash` is not useful here (however this does mean you could serve a static folder from your installed Dash package in eg site-packages).

My proposal is to firstly make the default value of `static_folder` to be `static`, which brings it inline with Flask's default and then secondly make the default value of the `name` param be `__main__`, which is the value it will take when a script is being run from the command line, which I suspect corresponds to most frequently used layout of a Dash app. Most users will then simply be able to create a `static` directory in the same directory as their app and static assets will served (although they still need to be added to the app itself). For users with more complex apps they will need to ensure they specify the name param correctly. The documentation can also be enhanced to make the significance of the `name` param to the `static_folder` clear.

Perhaps there is an argument to only change the static_folder param, however by making name optional and providing a default value, there will inevitably be some contexts where the value is incorrect for the Flask `import_name`. So I guess my suggestion is to choose a default that is more likely to be right most of the time for users. 