### PR TITLE
Update tests for Flask 1.0

### DIFF
--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -47,7 +47,8 @@ class IntegrationTests(unittest.TestCase):
             dash.run_server(
                 port=8050,
                 debug=False,
-                processes=4
+                processes=4,
+                threaded=False
             )
 
         # Run on a separate process so that it doesn't block


### PR DESCRIPTION
`threaded` is now `True` by default in flask 1.0 and `threaded=True` can’t
be set if `processes>1`