### PR TITLE
setuptools installation fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include README.md
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ setup(
     install_requires=[
         'Flask>=0.12',
         'flask-compress',
-        'plotly'
+        'plotly',
+        'dash_renderer',
     ],
     url='https://plot.ly/dash',
     classifiers=[


### PR DESCRIPTION
- Added dash_renderer as a dependency in setup.py.
- Added the LICENSE to MANIFEST.in.

Came across these when packaging for conda forge: https://github.com/conda-forge/dash-feedstock