### PR TITLE
Give a more informative error for JSON not serializable. (#269)

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -545,7 +545,7 @@ class Dash(object):
                                 bad_val=child,
                                 outer_val=val,
                                 bad_type=type(child).__name__,
-                                path=p + "\n" + type(child).__name__,
+                                path=p + "\n-   " + type(child).__name__,
                                 index=index
                             )
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -617,7 +617,6 @@ class Dash(object):
             def add_context(*args, **kwargs):
 
                 output_value = func(*args, **kwargs)
-                self._validate_callback_output(output_value, output)
                 response = {
                     'response': {
                         'props': {
@@ -626,9 +625,16 @@ class Dash(object):
                     }
                 }
 
+                try:
+                    jsonResponse = json.dumps(
+                        response,
+                        cls=plotly.utils.PlotlyJSONEncoder
+                    )
+                except TypeError:
+                    self._validate_callback_output(output_value, output)
+
                 return flask.Response(
-                    json.dumps(response,
-                               cls=plotly.utils.PlotlyJSONEncoder),
+                    jsonResponse,
                     mimetype='application/json'
                 )
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -478,34 +478,41 @@ class Dash(object):
     def _validate_callback_output(self, output_value, output):
         valid = [str, dict, int, float, type(None), Component]
 
-        def _raise_invalid(bad_val, outer_type, bad_type, path, index=None):
+        def _raise_invalid(bad_val, outer_val, bad_type, path, index=None,
+                           toplevel=False):
+            outer_id = "id={:s}".format(outer_val.id) \
+                        if getattr(outer_val, 'id', False) else ''
+            outer_type = type(outer_val).__name__
             raise exceptions.ReturnValueNotJSONSerializable('''
-            The callback for property `{:s}` of component `{:s}`
-            returned a tree with one value having type `{:s}`
+            The callback for property `{property:s}` of component `{id:s}`
+            returned a {object:s} having type `{type:s}`
             which is not JSON serializable.
 
-            The value in question is located at
-
-            `{:s}`
-
+            {location_header:s}{location:s}
             and has string representation
-
-            `{}`.
+            `{bad_val}`
 
             In general, Dash properties can only be
             dash components, strings, dictionaries, numbers, None,
             or lists of those.
             '''.format(
-                output.component_property,
-                output.component_id,
-                bad_type,
-                (
-                    "outer list index {:d} ({:s}) -> "
-                    .format(index, outer_type)
-                    if index is not None
-                    else (outer_type + " -> ")
-                ) + path,
-                bad_val).replace('    ', ''))
+                property=output.component_property,
+                id=output.component_id,
+                object='tree with one value' if not toplevel else 'value',
+                type=bad_type,
+                location_header=(
+                    'The value in question is located at'
+                    if not toplevel else
+                    '''The value in question is either the only value returned,
+                    or is in the top level of the returned list,'''
+                ),
+                location=(
+                    "\n" +
+                    ("[{:d}] {:s} {:s}\n".format(index, outer_type, outer_id)
+                     if index is not None
+                     else (outer_type + ' ' + outer_id + "\n")) + path + "\n"
+                ) if not toplevel else '',
+                bad_val=bad_val).replace('    ', ''))
 
         def _value_is_valid(val):
             return (
@@ -515,15 +522,55 @@ class Dash(object):
             )
 
         def _validate_value(val, index=None):
+            # val is a Component
             if isinstance(val, Component):
                 for p, j in val.traverse_with_paths():
+                    # check each component value in the tree
                     if not _value_is_valid(j):
-                        _raise_invalid(j, type(val).__name__, type(j).__name__,
-                                       p, index)
+                        _raise_invalid(
+                            bad_val=j,
+                            outer_val=val,
+                            bad_type=type(j).__name__,
+                            path=p,
+                            index=index
+                        )
+
+                    # Children that are not of type Component or
+                    # collections.MutableSequence not returned by traverse
+                    child = getattr(j, 'children', None)
+                    if not isinstance(child, collections.MutableSequence):
+                        if child and not _value_is_valid(child):
+                            _raise_invalid(
+                                bad_val=child,
+                                outer_val=val,
+                                bad_type=type(child).__name__,
+                                path=p + type(child).__name__,
+                                index=index
+                            )
+
+                # Also check the child of val, as it will not be returned
+                child = getattr(val, 'children', None)
+                if not isinstance(child, collections.MutableSequence):
+                    if child and not _value_is_valid(child):
+                        _raise_invalid(
+                            bad_val=child,
+                            outer_val=val,
+                            bad_type=type(child).__name__,
+                            path=type(child).__name__,
+                            index=index
+                        )
+
+            # val is not a Component, but is at the top level of tree
             else:
                 if not _value_is_valid(val):
-                    _raise_invalid(val, type(val).__name__, type(val).__name__,
-                                   '', index)
+                    _raise_invalid(
+                        bad_val=val,
+                        outer_val=type(val).__name__,
+                        bad_type=type(val).__name__,
+                        path='',
+                        index=index,
+                        toplevel=True
+                    )
 
         if isinstance(output_value, list):
             for i, val in enumerate(output_value):

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -632,6 +632,16 @@ class Dash(object):
                     )
                 except TypeError:
                     self._validate_callback_output(output_value, output)
+                    raise exceptions.ReturnValueNotJSONSerializable('''
+                    The callback for property `{property:s}`
+                    of component `{id:s}` returned a value
+                    which is not JSON serializable.
+
+                    In general, Dash properties can only be
+                    dash components, strings, dictionaries, numbers, None,
+                    or lists of those.
+                    '''.format(property=output.component_property,
+                               id=output.component_id))
 
                 return flask.Response(
                     jsonResponse,

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -480,7 +480,7 @@ class Dash(object):
 
         def _raise_invalid(bad_val, outer_val, bad_type, path, index=None,
                            toplevel=False):
-            outer_id = "id={:s}".format(outer_val.id) \
+            outer_id = "(id={:s})".format(outer_val.id) \
                         if getattr(outer_val, 'id', False) else ''
             outer_type = type(outer_val).__name__
             raise exceptions.ReturnValueNotJSONSerializable('''
@@ -508,9 +508,10 @@ class Dash(object):
                 ),
                 location=(
                     "\n" +
-                    ("[{:d}] {:s} {:s}\n".format(index, outer_type, outer_id)
+                    ("[{:d}] {:s} {:s}".format(index, outer_type, outer_id)
                      if index is not None
-                     else (outer_type + ' ' + outer_id + "\n")) + path + "\n"
+                     else ('-   ' + outer_type + ' ' + outer_id))
+                    + "\n" + path + "\n"
                 ) if not toplevel else '',
                 bad_val=bad_val).replace('    ', ''))
 
@@ -544,7 +545,7 @@ class Dash(object):
                                 bad_val=child,
                                 outer_val=val,
                                 bad_type=type(child).__name__,
-                                path=p + type(child).__name__,
+                                path=p + "\n" + type(child).__name__,
                                 index=index
                             )
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -483,7 +483,7 @@ class Dash(object):
             outer_id = "(id={:s})".format(outer_val.id) \
                         if getattr(outer_val, 'id', False) else ''
             outer_type = type(outer_val).__name__
-            raise exceptions.ReturnValueNotJSONSerializable('''
+            raise exceptions.InvalidCallbackReturnValue('''
             The callback for property `{property:s}` of component `{id:s}`
             returned a {object:s} having type `{type:s}`
             which is not JSON serializable.
@@ -632,7 +632,7 @@ class Dash(object):
                     )
                 except TypeError:
                     self._validate_callback_output(output_value, output)
-                    raise exceptions.ReturnValueNotJSONSerializable('''
+                    raise exceptions.InvalidCallbackReturnValue('''
                     The callback for property `{property:s}`
                     of component `{id:s}` returned a value
                     which is not JSON serializable.

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -510,7 +510,7 @@ class Dash(object):
                     "\n" +
                     ("[{:d}] {:s} {:s}".format(index, outer_type, outer_id)
                      if index is not None
-                     else ('-   ' + outer_type + ' ' + outer_id))
+                     else ('[*] ' + outer_type + ' ' + outer_id))
                     + "\n" + path + "\n"
                 ) if not toplevel else '',
                 bad_val=bad_val).replace('    ', ''))
@@ -545,7 +545,7 @@ class Dash(object):
                                 bad_val=child,
                                 outer_val=val,
                                 bad_type=type(child).__name__,
-                                path=p + "\n-   " + type(child).__name__,
+                                path=p + "\n" + "[*] " + type(child).__name__,
                                 index=index
                             )
 

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -164,9 +164,9 @@ class Component(collections.MutableMapping):
 
         # children is just a component
         if isinstance(children, Component):
-            yield children_string, children
+            yield "-   " + children_string, children
             for p, t in children.traverse_with_paths():
-                yield "\n".join([children_string, p]), t
+                yield "\n".join(["-   " + children_string, p]), t
 
         # children is a list of components
         elif isinstance(children, collections.MutableSequence):

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -164,9 +164,9 @@ class Component(collections.MutableMapping):
 
         # children is just a component
         if isinstance(children, Component):
-            yield "-   " + children_string, children
+            yield "[*] " + children_string, children
             for p, t in children.traverse_with_paths():
-                yield "\n".join(["-   " + children_string, p]), t
+                yield "\n".join(["[*] " + children_string, p]), t
 
         # children is a list of components
         elif isinstance(children, collections.MutableSequence):

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -151,22 +151,33 @@ class Component(collections.MutableMapping):
 
     def traverse(self):
         """Yield each item in the tree."""
+        for t in self.traverse_with_paths():
+            yield t[1]
+
+    def traverse_with_paths(self):
+        """Yield each item with its path in the tree."""
         children = getattr(self, 'children', None)
+        children_type = type(children).__name__
 
         # children is just a component
         if isinstance(children, Component):
-            yield children
-            for t in children.traverse():
-                yield t
+            yield children_type, children
+            for p, t in children.traverse_with_paths():
+                yield " -> ".join([children_type, p]), t
 
         # children is a list of components
         elif isinstance(children, collections.MutableSequence):
-            for i in children:  # pylint: disable=not-an-iterable
-                yield i
+            for idx, i in enumerate(children):
+                list_path = "{:s} index {:d} (type {:s})".format(
+                    children_type,
+                    idx,
+                    type(i).__name__
+                )
+                yield list_path, i
 
                 if isinstance(i, Component):
-                    for t in i.traverse():
-                        yield t
+                    for p, t in i.traverse_with_paths():
+                        yield " -> ".join([list_path, p]), t
 
     def __iter__(self):
         """Yield IDs in the tree of children."""

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -158,15 +158,15 @@ class Component(collections.MutableMapping):
         """Yield each item with its path in the tree."""
         children = getattr(self, 'children', None)
         children_type = type(children).__name__
-        children_id = "id={:s}".format(children.id) \
+        children_id = "(id={:s})".format(children.id) \
                       if getattr(children, 'id', False) else ''
         children_string = children_type + ' ' + children_id
 
         # children is just a component
         if isinstance(children, Component):
-            yield children_string + "\n", children
+            yield children_string, children
             for p, t in children.traverse_with_paths():
-                yield "\n".join([children_string, p]) + "\n", t
+                yield "\n".join([children_string, p]), t
 
         # children is a list of components
         elif isinstance(children, collections.MutableSequence):
@@ -174,13 +174,13 @@ class Component(collections.MutableMapping):
                 list_path = "[{:d}] {:s} {}".format(
                     idx,
                     type(i).__name__,
-                    "id={:s}".format(i.id) if getattr(i, 'id', False) else ''
+                    "(id={:s})".format(i.id) if getattr(i, 'id', False) else ''
                 )
-                yield list_path + "\n", i
+                yield list_path, i
 
                 if isinstance(i, Component):
                     for p, t in i.traverse_with_paths():
-                        yield "\n".join([list_path, p]) + "\n", t
+                        yield "\n".join([list_path, p]), t
 
     def __iter__(self):
         """Yield IDs in the tree of children."""

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -158,26 +158,29 @@ class Component(collections.MutableMapping):
         """Yield each item with its path in the tree."""
         children = getattr(self, 'children', None)
         children_type = type(children).__name__
+        children_id = "id={:s}".format(children.id) \
+                      if getattr(children, 'id', False) else ''
+        children_string = children_type + ' ' + children_id
 
         # children is just a component
         if isinstance(children, Component):
-            yield children_type, children
+            yield children_string + "\n", children
             for p, t in children.traverse_with_paths():
-                yield " -> ".join([children_type, p]), t
+                yield "\n".join([children_string, p]) + "\n", t
 
         # children is a list of components
         elif isinstance(children, collections.MutableSequence):
             for idx, i in enumerate(children):
-                list_path = "{:s} index {:d} (type {:s})".format(
-                    children_type,
+                list_path = "[{:d}] {:s} {}".format(
                     idx,
-                    type(i).__name__
+                    type(i).__name__,
+                    "id={:s}".format(i.id) if getattr(i, 'id', False) else ''
                 )
-                yield list_path, i
+                yield list_path + "\n", i
 
                 if isinstance(i, Component):
                     for p, t in i.traverse_with_paths():
-                        yield " -> ".join([list_path, p]), t
+                        yield "\n".join([list_path, p]) + "\n", t
 
     def __iter__(self):
         """Yield IDs in the tree of children."""

--- a/dash/exceptions.py
+++ b/dash/exceptions.py
@@ -46,5 +46,5 @@ class PreventUpdate(CallbackException):
     pass
 
 
-class ReturnValueNotJSONSerializable(CallbackException):
+class InvalidCallbackReturnValue(CallbackException):
     pass

--- a/dash/exceptions.py
+++ b/dash/exceptions.py
@@ -44,3 +44,7 @@ class CantHaveMultipleOutputs(CallbackException):
 
 class PreventUpdate(CallbackException):
     pass
+
+
+class ReturnValueNotJSONSerializable(CallbackException):
+    pass

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,4 +12,4 @@ six
 plotly>=2.0.8
 requests[security]
 flake8
-pylint
+pylint==1.9.2


### PR DESCRIPTION
Fix for #269 
when a non JSON serializable object is returned from a dash callback, the following exception is raised:
```
dash.exceptions.ReturnValueNotJSONSerializable:
Callback for property `<property>` from component id `<id>`
returned a value `<value>` of type `<type>`,
which is not JSON serializable.
```

an example app:
```
import dash
import dash_html_components as html
from dash.dependencies import Input, Output

app = dash.Dash("")

app.layout = html.Div([
    html.Div(id='output'),
    html.Button(id='button')
])


@app.callback(Output('output', 'children'),
              [Input('button', 'n_clicks')])
def test(n_clicks):
    if n_clicks:
        return dash
    return "HELLO WORLD"


app.run_server()
```
results in:
```
dash.exceptions.ReturnValueNotJSONSerializable:
Callback for property `children` from component id `output`
returned a value `<module 'dash' from '/home/ryan/Dash/dash/dash/__init__.py'>` of type `module`,
which is not JSON serializable.
```

when the button is clicked (and returns the dash module rather than a value).