### PR TITLE
[WIP] Dash Dev Tools -- backend

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -15,9 +15,8 @@ from functools import wraps
 import plotly
 import dash_renderer
 import flask
-from flask import Flask, Response
+from flask import Flask, Response, got_request_exception
 from flask_compress import Compress
-from flask import got_request_exception
 from flask_socketio import SocketIO
 
 from .dependencies import Event, Input, Output, State
@@ -768,6 +767,7 @@ class Dash(object):
             socketio = SocketIO(self.server)
 
             @got_request_exception.connect_via(self.server)
+            # pylint: disable=unused-variable
             def when_dash_gets_exception(server, exception, **extra):
                 socketio.emit(
                     'error',
@@ -777,8 +777,8 @@ class Dash(object):
                         'errorTraceback': traceback.format_exc(),
                     },
                     namespace=(
-                       '{}_dash-errors'
-                       .format(self.config['routes_pathname_prefix'])
+                        '{}_dash-errors'
+                        .format(self.config['routes_pathname_prefix'])
                     )
                 )
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,4 @@ plotly>=2.0.8
 requests[security]
 flake8
 pylint==1.9.2
+Flask-SocketIO==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ enum34==1.1.6
 Flask==0.12
 Flask-Compress==1.4.0
 Flask-SeaSurf==0.2.2
+Flask-SocketIO==3.0.1
 funcsigs==1.0.2
 functools32==3.2.3.post2
 ipdb==0.10.2


### PR DESCRIPTION
This solution uses the flask `got_request_exception` method to call a block of code before an exception is raised in the Dash backend when `debug=True`. In this block of code, we use socket.io (Flask-SocketIO) to emit an 'error' event from the namespace `/{prefix}_dash-errors` endpoint which includes error information like the Exception name, message, and traceback.

Still need to figure out:
* socket.io prints logs every couple of seconds which is annoying, can't figure out how to turn them off.
* does wrapping the server in a SocketIO instance in this line: `socketio = SocketIO(self.server)` break anything in servers which use Dash plus some other Flask plugins?