### PR TITLE
Add meta http-equiv for ie compatibility to the index by default.

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -339,16 +339,21 @@ class Dash(object):
         ).format(json.dumps(self._config()))
 
     def _generate_meta_html(self):
+        has_ie_compat = any(
+            x.get('http-equiv', '') == 'X-UA-Compatible'
+            for x in self._meta_tags)
         has_charset = any('charset' in x for x in self._meta_tags)
 
         tags = []
+        if not has_ie_compat:
+            tags.append('<meta equiv="X-UA-Compatible" content="IE=edge">')
         if not has_charset:
-            tags.append('<meta charset="UTF-8"/>')
+            tags.append('<meta charset="UTF-8">')
         for meta in self._meta_tags:
             attributes = []
             for k, v in meta.items():
                 attributes.append('{}="{}"'.format(k, v))
-            tags.append('<meta {} />'.format(' '.join(attributes)))
+            tags.append('<meta {}>'.format(' '.join(attributes)))
 
         return '\n      '.join(tags)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -272,10 +272,10 @@ class Tests(IntegrationTests):
         self.percy_snapshot(name='flowtype')
 
     def test_meta_tags(self):
-        metas = (
+        metas = [
             {'name': 'description', 'content': 'my dash app'},
-            {'name': 'custom', 'content': 'customized'}
-        )
+            {'name': 'custom', 'content': 'customized'},
+        ]
 
         app = dash.Dash(meta_tags=metas)
 
@@ -285,12 +285,12 @@ class Tests(IntegrationTests):
 
         meta = self.driver.find_elements_by_tag_name('meta')
 
-        # -1 for the meta charset.
-        self.assertEqual(len(metas), len(meta) - 1, 'Not enough meta tags')
+        # -2 for the meta charset and http-equiv.
+        self.assertEqual(len(metas), len(meta) - 2, 'Not enough meta tags')
 
-        for i in range(1, len(meta)):
+        for i in range(2, len(meta)):
             meta_tag = meta[i]
-            meta_info = metas[i - 1]
+            meta_info = metas[i - 2]
             name = meta_tag.get_attribute('name')
             content = meta_tag.get_attribute('content')
             self.assertEqual(name, meta_info['name'])


### PR DESCRIPTION
As discussed in #275, add `<meta http-equiv="X-UA-Compatible" content="IE=8">` to the index if it's not specified in the `meta_tags`.

Should the meta tags be closed with '`/>` or just `>`  ? The HTML5 specification says it doesn't need it but it's needed by `xhtml`. We have `<!DOCTYPE html>` by default, but if someone changes it to something else it might needs it.