### PR TITLE
PyPi README markdown setting added to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     description=('A Python framework for building reactive web-apps. '
                  'Developed by Plotly.'),
     long_description=io.open('README.md', encoding='utf-8').read(),
+    long_description_content_type='text/markdown',
     install_requires=[
         'Flask>=0.12',
         'flask-compress',


### PR DESCRIPTION
Fixes #180

This adds the new setting to setup.py so that PyPi will render the
markdown formatted README.