### PR TITLE
Use HTML5 syntax for the meta tag

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -385,7 +385,7 @@ class Dash(object):
         if not has_ie_compat:
             tags.append('<meta equiv="X-UA-Compatible" content="IE=edge">')
         if not has_charset:
-            tags.append('<meta charset="UTF-8"/>')
+            tags.append('<meta charset="UTF-8">')
 
         tags = tags + [
             _format_tag('meta', x, opened=True) for x in self._meta_tags


### PR DESCRIPTION
Examples of the HTML5 meta tags here -> https://www.w3schools.com/tags/tag_meta.asp
shows that it does not have an ending slash.
