### PR TITLE
Pylint and Flake8 enabled for the tests folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,9 @@ jobs:
           command: |
               . venv/bin/activate
               pylint dash setup.py --rcfile=$PYLINTRC
+              pylint tests -d all -e C0410,C0411,C0412,C0413,W0109
               flake8 dash setup.py
+              flake8 --ignore=E123,E126,E501,E722,E731,F401,F841,W503,W504 --exclude=metadata_test.py tests
 
       - run:
           name: Run tests

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -359,7 +359,7 @@ class Dash(object):
 
     def _generate_css_dist_html(self):
         links = self._external_stylesheets + \
-                self._collect_and_register_resources(self.css.get_all_css())
+            self._collect_and_register_resources(self.css.get_all_css())
 
         return '\n'.join([
             _format_tag('link', link, opened=True)
@@ -716,7 +716,7 @@ class Dash(object):
         def _raise_invalid(bad_val, outer_val, bad_type, path, index=None,
                            toplevel=False):
             outer_id = "(id={:s})".format(outer_val.id) \
-                        if getattr(outer_val, 'id', False) else ''
+                if getattr(outer_val, 'id', False) else ''
             outer_type = type(outer_val).__name__
             raise exceptions.InvalidCallbackReturnValue('''
             The callback for property `{property:s}` of component `{id:s}`

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -2,9 +2,9 @@ import multiprocessing
 import sys
 import time
 import unittest
-from selenium import webdriver
 import percy
 
+from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC

--- a/tests/development/test_component_loader.py
+++ b/tests/development/test_component_loader.py
@@ -195,7 +195,6 @@ class TestGenerateClasses(unittest.TestCase):
             'baz': 'Lemons',
             'data-foo': 'Blah',
             'aria-bar': 'Seven',
-            'baz': 'Lemons',
             'children': 'Child'
         }
         AKwargs = {

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -1,9 +1,9 @@
+import os
 import unittest
 # noinspection PyProtectedMember
 from dash import _configs
 from dash import exceptions as _exc
 from dash._utils import get_asset_path
-import os
 
 
 class MyTestCase(unittest.TestCase):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,13 +3,13 @@ from multiprocessing import Value
 import datetime
 import itertools
 import re
+import time
 import dash_html_components as html
+import dash_dangerously_set_inner_html
 import dash_core_components as dcc
 import dash_flow_example
-import dash_dangerously_set_inner_html
 
 import dash
-import time
 
 from dash.dependencies import Input, Output, State
 from dash.exceptions import PreventUpdate
@@ -199,7 +199,7 @@ class Tests(IntegrationTests):
 
         # React wraps text and numbers with e.g. <!-- react-text: 20 -->
         # Remove those
-        comment_regex = '<!--[^\[](.*?)-->'
+        comment_regex = '<!--[^\[](.*?)-->'  # noqa: W605
 
         # Somehow the html attributes are unordered.
         # Try different combinations (they're all valid html)

--- a/tests/test_react.py
+++ b/tests/test_react.py
@@ -2,9 +2,9 @@ import unittest
 import json
 import pkgutil
 import plotly
-import dash_core_components as dcc
 from dash_html_components import Div
 import dash_renderer
+import dash_core_components as dcc
 import dash
 
 from dash.dependencies import Event, Input, Output, State
@@ -36,7 +36,7 @@ class IntegrationTest(unittest.TestCase):
 
         self.client = self.app.server.test_client()
 
-        self.maxDiff = 100*1000
+        self.maxDiff = 100 * 1000
 
     @unittest.skip('')
     def test_route_list(self):


### PR DESCRIPTION
Remove duplicate key value pair from python dictionary.  Order imports.

Pylint testing now added for the 'tests' folder with 5 rules enabled.

duplicate-key (W0109):
 Duplicate key %r in dictionary Used when a dictionary expression binds the same key multiple times.

multiple-imports (C0410):
 Multiple imports on one line (%s) Used when import statement importing multiple modules is detected.

wrong-import-order (C0411): Used when PEP8 import order is not respected (standard imports first, then third-party libraries, then local imports)

wrong-import-position (C0413):
 Import “%s” should be placed at the top of the module Used when code and imports are mixed

ungrouped-imports (C0412):
Imports from package %s are not grouped Used when imports are not grouped by packages

Flake8 rules have all been added as well.

https://lintlyci.github.io/Flake8Rules/