### PR TITLE
Add used by dcc.Location to catch-all route comment.

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -211,7 +211,7 @@ class Dash(object):
             self.config['routes_pathname_prefix'],
             self.index)
 
-        # catch-all for front-end routes
+        # catch-all for front-end routes, used by dcc.Location
         add_url(
             '{}<path:path>'.format(self.config['routes_pathname_prefix']),
             self.index)

--- a/dev-requirements-py37.txt
+++ b/dev-requirements-py37.txt
@@ -1,5 +1,5 @@
 dash_core_components>=0.27.2
-dash_html_components>=0.12.0
+dash_html_components==0.12.0rc3
 dash-flow-example==0.0.3
 dash-dangerously-set-inner-html
 dash_renderer


### PR DESCRIPTION
Add more detail to the catch-all routes comment so it is more evident that it is useful. #397.