### PR TITLE
Fix ci path issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
           name: Install dependencies
           command: |
               sudo pip install virtualenv
-              python -m venv venv || virtualenv venv
+              virtualenv venv
               . venv/bin/activate
               pip install -r $REQUIREMENTS_FILE
 

--- a/tests/development/test_component_loader.py
+++ b/tests/development/test_component_loader.py
@@ -165,8 +165,6 @@ class TestGenerateClasses(unittest.TestCase):
         init_file_path = 'default_namespace/__init__.py'
         with open(init_file_path, 'a'):
             os.utime(init_file_path, None)
-        # This is not the case on Python 3 CI boxes for some reason
-        sys.path.append(os.getcwd() + '/')
 
     def tearDown(self):
         os.remove(METADATA_PATH)

--- a/tests/development/test_component_loader.py
+++ b/tests/development/test_component_loader.py
@@ -1,7 +1,6 @@
 import collections
 import json
 import os
-import sys
 import shutil
 import unittest
 from dash.development.component_loader import load_components, generate_classes

--- a/tests/development/test_component_loader.py
+++ b/tests/development/test_component_loader.py
@@ -1,6 +1,7 @@
 import collections
 import json
 import os
+import sys
 import shutil
 import unittest
 from dash.development.component_loader import load_components, generate_classes
@@ -164,12 +165,13 @@ class TestGenerateClasses(unittest.TestCase):
         init_file_path = 'default_namespace/__init__.py'
         with open(init_file_path, 'a'):
             os.utime(init_file_path, None)
+        # This is not the case on Python 3 CI boxes for some reason
+        sys.path.append(os.getcwd() + '/')
 
     def tearDown(self):
         os.remove(METADATA_PATH)
         shutil.rmtree('default_namespace')
 
-    @unittest.skip('Broken - https://github.com/plotly/dash/issues/419')
     def test_loadcomponents(self):
         MyComponent_runtime = generate_class(
             'MyComponent',


### PR DESCRIPTION
Fixes https://github.com/plotly/dash/issues/419

This one was tricky to figure out.

For some reason, the Python 3 `venv` package behaves differently from the `virtualenv` package. The current working directory was not included in the `PYTHONPATH` and needed to be manually added back using `sys.path.append`. (Not sure why the `dash` module is available, I think this is because the new `default_namespace` module is created during execution rather than before).

Just getting rid of `python -m venv` and using `virtualenv` works.

Is there a good reason to be using `venv` rather than `virtualenv`?