### PR TITLE
[WIP] Add internal_styles argument to Dash.__init__() for passing custom CSS

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -8,7 +8,6 @@ import json
 import pkgutil
 import warnings
 import re
-import six
 
 from functools import wraps
 
@@ -17,6 +16,7 @@ import dash_renderer
 import flask
 from flask import Flask, Response
 from flask_compress import Compress
+import six
 
 from .dependencies import Event, Input, Output, State
 from .resources import Scripts, Css
@@ -371,7 +371,7 @@ class Dash(object):
         # text for a head <style> block. The dictionary should look like eg
         # {'._dash-undo-redo': {'display': 'none'}}
         lines = ['{tag} {{ {attr}: {val} }};'.format(
-                 tag=tag, attr=attr, val=val)
+            tag=tag, attr=attr, val=val)
                  for tag in six.iterkeys(self._internal_styles)
                  for attr, val in six.iteritems(self._internal_styles[tag])]
 


### PR DESCRIPTION
This PR adds an optional kwarg to the `Dash` constructor to allow passing CSS as a nested dictionary. This CSS gets included in a `<style>` block in the document head.

The use case I have in mind is hiding the Undo button, as in #234. With these changes you can do something like this
```
hide_undo_css = {'._dash-undo-redo': {'display': 'none'}}

app = dash.Dash('app', internal_styles=hide_undo_css)
``` 
instead of requiring an external stylesheet or messing around with `serve_locally`.

If this seems like a reasonable addition I'll take a stab at writing some tests. If not, I'm happy to try another approach, or if you're not interested in adding something like this then just let me know and I can close the PR. Also if there's a better place to put this configuration option than kwargs in the constructor please let me know.

Thanks!