### PR TITLE
Generate integrity hash for scripts/link tags on the index.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -57,7 +57,8 @@ confidence=
 disable=fixme,
         missing-docstring,
         invalid-name,
-        too-many-lines
+        too-many-lines,
+        old-style-class
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -70,23 +70,23 @@ def first_key(data, *keys):
     return None, None
 
 
-@memoize
-def integrity_hash_from_file(filename):
-    with open(filename, 'rb') as f:
-        h = hashlib.sha384(f.read())
+def _integrity_hash(bytes):
+    h = hashlib.sha384(bytes)
 
     return 'sha384-{}'.format(
         base64.b64encode(h.digest()).decode()
     )
+
+
+@memoize
+def integrity_hash_from_file(filename):
+    with open(filename, 'rb') as f:
+        return _integrity_hash(f.read())
 
 
 @memoize
 def integrity_hash_from_package(namespace, path):
-    h = hashlib.sha384(pkgutil.get_data(namespace, path))
-
-    return 'sha384-{}'.format(
-        base64.b64encode(h.digest()).decode()
-    )
+    return _integrity_hash(pkgutil.get_data(namespace, path))
 
 
 class AttributeDict(dict):

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -1,3 +1,9 @@
+import functools
+import hashlib
+import base64
+import pkgutil
+
+
 def interpolate_str(template, **data):
     s = template
     for k, v in data.items():
@@ -35,6 +41,37 @@ def get_asset_path(
         asset_url_path,
         asset_path
     ])
+
+
+def pluck(obj, *props, **additions):
+    return dict({k: v for k, v in obj.items() if k in props}, **additions)
+
+
+def first_key(data, *keys):
+    for key in keys:
+        value = data.get(key)
+        if value:
+            return key, value
+    return None, None
+
+
+@functools.lru_cache()
+def integrity_hash_from_file(filename):
+    with open(filename, 'rb') as f:
+        h = hashlib.sha384(f.read())
+
+    return 'sha384-{}'.format(
+        base64.b64encode(h.digest()).decode()
+    )
+
+
+@functools.lru_cache()
+def integrity_hash_from_package(namespace, path):
+    h = hashlib.sha384(pkgutil.get_data(namespace, path))
+
+    return 'sha384-{}'.format(
+        base64.b64encode(h.digest()).decode()
+    )
 
 
 class AttributeDict(dict):

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -4,6 +4,21 @@ import base64
 import pkgutil
 
 
+def memoize(func):
+    results = {}
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        key = hash((args, frozenset(kwargs)))
+        cached = results.get(key)
+        if cached:
+            return cached
+        results[key] = r = func(*args, **kwargs)
+        return r
+
+    return wrapper
+
+
 def interpolate_str(template, **data):
     s = template
     for k, v in data.items():
@@ -55,7 +70,7 @@ def first_key(data, *keys):
     return None, None
 
 
-@functools.lru_cache()
+@memoize
 def integrity_hash_from_file(filename):
     with open(filename, 'rb') as f:
         h = hashlib.sha384(f.read())
@@ -65,7 +80,7 @@ def integrity_hash_from_file(filename):
     )
 
 
-@functools.lru_cache()
+@memoize
 def integrity_hash_from_package(namespace, path):
     h = hashlib.sha384(pkgutil.get_data(namespace, path))
 

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -9,7 +9,7 @@ def memoize(func):
 
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        key = hash((args, frozenset(kwargs)))
+        key = hash((args, frozenset(kwargs.items())))
         cached = results.get(key)
         if cached:
             return cached

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -70,8 +70,8 @@ def first_key(data, *keys):
     return None, None
 
 
-def _integrity_hash(bytes):
-    h = hashlib.sha384(bytes)
+def _integrity_hash(b):
+    h = hashlib.sha384(b)
 
     return 'sha384-{}'.format(
         base64.b64encode(h.digest()).decode()

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -389,7 +389,7 @@ class Dash(object):
                     'rev',
                     'target',
                     'type',
-                    href=link.get('src'),
+                    href=link.get('src', link.get('href')),
                     rel='stylesheet'
                 ),
                 opened=True

--- a/dash/resources.py
+++ b/dash/resources.py
@@ -4,7 +4,8 @@ import warnings
 import os
 
 from .development.base_component import Component
-from ._utils import first_key, integrity_hash_from_file, integrity_hash_from_package
+from ._utils import \
+    first_key, integrity_hash_from_file, integrity_hash_from_package
 
 
 # pylint: disable=old-style-class
@@ -75,17 +76,19 @@ class Resources:
                         filtered_resources.append({
                             key: f,
                             'integrity': integrity_hash_from_package(
-                                filtered_resource['namespace'], f.split('/')[-1]),
+                                filtered_resource['namespace'],
+                                f.split('/')[-1]),
                             'crossorigin': 'anonymous',
                             'namespace': filtered_resource['namespace']
                         })
                         added = True
                 else:
                     filename = filename.split('/')[-1]
-                    filtered_resource['integrity'] = integrity_hash_from_package(
-                        filtered_resource['namespace'],
-                        filename
-                    )
+                    filtered_resource['integrity'] = \
+                        integrity_hash_from_package(
+                            filtered_resource['namespace'],
+                            filename
+                        )
                     filtered_resource['crossorigin'] = 'anonymous'
 
             if not added:

--- a/dash/resources.py
+++ b/dash/resources.py
@@ -17,6 +17,7 @@ class Resources:
     def append_resource(self, resource):
         self._resources.append(resource)
 
+    # pylint: disable=too-many-branches
     def _filter_resources(self, all_resources, dev_bundles=False):
         filtered_resources = []
         for s in all_resources:

--- a/dash/resources.py
+++ b/dash/resources.py
@@ -8,6 +8,7 @@ from ._utils import \
     first_key, integrity_hash_from_file, integrity_hash_from_package
 
 
+# pylint: disable=inconsistent-return-statements
 def find_unpkg(value, relative_package_paths):
     # find the local file for a unpkg url.
     # The structure of the _js_dist/_css_dist does not allow
@@ -19,8 +20,7 @@ def find_unpkg(value, relative_package_paths):
     ext = filename.split('.')[-1]
 
     for i in relative_package_paths:
-        if (i == filename
-            and i not in [
+        if (i == filename and i not in [
                 'index.js', 'index.css', 'style.css', 'style.min.css',
                 'styles.css', 'styles.min.css']) \
                 or (lib in i and version in i and i.endswith(ext)):


### PR DESCRIPTION
- Generate a sha384 hash from the local copy of the file.
- Format the tags with `integrity` and `crossorigin` attributes.
- Flattened the resources collection from the dist.
- Map external unpkg to local host file.

As the version of plotly.js hosted locally and externally was not the same, this breaks dash-core-components Graph component.

The files hosted locally must be downloaded from the external source so they match 1:1. Same for the component libs bundles, do `npm publish` first so you have the builds with the `prepublish` hook, then do `python setup.py sdist` and `twine upload dist/*` without rebuilding the bundles so they have the same hash, all version of dcc I tested had the right bundles, but it needs to be said somewhere.

Closes #422