### PR TITLE
Update tests dcc

### DIFF
--- a/.circleci/requirements/dev-requirements-py37.txt
+++ b/.circleci/requirements/dev-requirements-py37.txt
@@ -1,4 +1,4 @@
-dash_core_components>=0.40.0
+dash_core_components>=0.40.2
 dash_html_components==0.12.0rc3
 dash-flow-example==0.0.3
 dash-dangerously-set-inner-html

--- a/.circleci/requirements/dev-requirements-py37.txt
+++ b/.circleci/requirements/dev-requirements-py37.txt
@@ -1,4 +1,4 @@
-dash_core_components==0.35.1
+dash_core_components>=0.40.0
 dash_html_components==0.12.0rc3
 dash-flow-example==0.0.3
 dash-dangerously-set-inner-html

--- a/.circleci/requirements/dev-requirements.txt
+++ b/.circleci/requirements/dev-requirements.txt
@@ -1,4 +1,4 @@
-dash_core_components==0.35.1
+dash_core_components>=0.40.0
 dash_html_components>=0.12.0rc3
 dash_flow_example==0.0.3
 dash-dangerously-set-inner-html

--- a/.circleci/requirements/dev-requirements.txt
+++ b/.circleci/requirements/dev-requirements.txt
@@ -1,4 +1,4 @@
-dash_core_components>=0.40.0
+dash_core_components>=0.40.2
 dash_html_components>=0.12.0rc3
 dash_flow_example==0.0.3
 dash-dangerously-set-inner-html


### PR DESCRIPTION
Unlocked dash-core-components >= 0.40.1, the call counts tests are now back to how it was. plotly/dash-core-components#384