### PR TITLE
Point to existing install instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,16 @@
 
 ## Getting Started
 
-Refer to the Dash User Guide for [installation](https://dash.plot.ly/installation) instructions.
+To set up your development environment, run the following commands:
+```bash
+# Create a virtualenv (name it, say, dash-dev)
+python3 -m venv dash-dev
+# Activate this virtualenv
+. dash-dev/bin/activate
+# (On Windows, the above would be: dash-dev\scripts\activate)
+# Install the dev dependencies
+pip install -r .circleci/requirements/dev-requirements.txt
+```
 
 ## Coding Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Getting Started
 
-Refer to the [readme](README.md) for installation and development instructions.
+Refer to the Dash User Guide for [installation](https://dash.plot.ly/installation) instructions.
 
 ## Coding Style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,15 +2,19 @@
 
 ## Getting Started
 
+Fork and clone the dash [repo](https://github.com/plotly/dash).
+
 To set up your development environment, run the following commands:
 ```bash
-# Create a virtualenv (name it, say, dash-dev)
-python3 -m venv dash-dev
-# Activate this virtualenv
-. dash-dev/bin/activate
-# (On Windows, the above would be: dash-dev\scripts\activate)
+# Move into the clone
+$ cd dash
+# Create a virtualenv
+$ python3 -m venv venv
+# Activate the virtualenv
+$ . venv/bin/activate
+# (On Windows, the above would be: venv\scripts\activate)
 # Install the dev dependencies
-pip install -r .circleci/requirements/dev-requirements.txt
+$ pip install -r .circleci/requirements/dev-requirements.txt
 ```
 
 ## Coding Style


### PR DESCRIPTION
Hello @plotly/dash @rmarren1 and @T4rk1n!

I'm trying to document the installation of dash-bio, so I came here for inspiration! In the current version of the README, there are no installation (let alone development) instructions. That's why I'm suggesting pointing to the user guide.