### PR TITLE
Add two tests testing for embedding Dash in Flask and arbitrary WSGI apps

### DIFF
--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -39,7 +39,7 @@ class IntegrationTests(unittest.TestCase):
             return _error.apply(console, arguments);
         };
         '''
-    
+
     def percy_snapshot(cls, name=''):
         snapshot_name = '{} - {}'.format(name, sys.version_info)
         print(snapshot_name)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -566,16 +566,14 @@ class Tests(IntegrationTests):
         app1 = dash.Dash(
             __name__,
             server=server,
-            requests_pathname_prefix='/app1/',
-            routes_pathname_prefix='/app1/',
+            routes_pathname_prefix='/app1/'
         )
         app1.layout = html.Div("Dash app 1", id="content")
 
         app2 = dash.Dash(
             __name__,
             server=server,
-            requests_pathname_prefix='/app2/',
-            routes_pathname_prefix='/app2/',
+            routes_pathname_prefix='/app2/'
         )
         app2.layout = html.Div("Dash app 2", id="content")
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -598,7 +598,7 @@ class Tests(IntegrationTests):
         # check that the assets were loaded for one of the apps
         content_padding = content.value_of_css_property('padding')
         self.assertEqual('8px', content_padding)
-        
+
     def test_wsgi_integration(self):
         flask_app = Flask(__name__)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -555,7 +555,7 @@ class Tests(IntegrationTests):
         time.sleep(1)
 
         self.wait_for_element_by_css_selector('#inserted-input')
-        
+
     def test_flask_integration(self):
         server = Flask(__name__)
 
@@ -584,7 +584,7 @@ class Tests(IntegrationTests):
 
         content = self.wait_for_element_by_id('content')
         self.assertEqual('Flask app', content.text)
-        
+
         self.driver.get('http://localhost:8050/app1')
         time.sleep(0.5)
         content = self.wait_for_element_by_id('content')
@@ -613,14 +613,14 @@ class Tests(IntegrationTests):
 
         application = DispatcherMiddleware(flask_app, {
             '/app1': app1.server,
-            '/app2': app2.server,    
+            '/app2': app2.server,
         })
 
         self.startWerkzeugServer(application)
 
         content = self.wait_for_element_by_id('content')
         self.assertEqual('Flask app', content.text)
-        
+
         self.driver.get('http://localhost:8050/app1')
         time.sleep(0.5)
         content = self.wait_for_element_by_id('content')

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,15 +3,15 @@ import datetime
 import itertools
 import re
 import time
-from flask import Flask
 from multiprocessing import Value
-from werkzeug.wsgi import DispatcherMiddleware
 
-import dash
+from flask import Flask
+from werkzeug.wsgi import DispatcherMiddleware
 import dash_html_components as html
-import dash_dangerously_set_inner_html
 import dash_core_components as dcc
+import dash_dangerously_set_inner_html
 import dash_flow_example
+import dash
 from dash.dependencies import Input, Output
 from dash.exceptions import PreventUpdate
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -564,6 +564,7 @@ class Tests(IntegrationTests):
             return '<div id="content">Flask app</div>'
 
         app1 = dash.Dash(
+            __name__,
             server=server,
             requests_pathname_prefix='/app1/',
             routes_pathname_prefix='/app1/',
@@ -571,6 +572,7 @@ class Tests(IntegrationTests):
         app1.layout = html.Div("Dash app 1", id="content")
 
         app2 = dash.Dash(
+            __name__,
             server=server,
             requests_pathname_prefix='/app2/',
             routes_pathname_prefix='/app2/',
@@ -595,6 +597,10 @@ class Tests(IntegrationTests):
         content = self.wait_for_element_by_id('content')
         self.assertEqual('Dash app 2', content.text)
 
+        # check that the assets were loaded for one of the apps
+        content_padding = content.value_of_css_property('padding')
+        self.assertEqual('8px', content_padding)
+        
     def test_wsgi_integration(self):
         flask_app = Flask(__name__)
 
@@ -602,10 +608,16 @@ class Tests(IntegrationTests):
         def index():
             return '<div id="content">Flask app</div>'
 
-        app1 = dash.Dash(requests_pathname_prefix='/app1/')
+        app1 = dash.Dash(
+            __name__,
+            requests_pathname_prefix='/app1/'
+        )
         app1.layout = html.Div("Dash app 1", id="content")
 
-        app2 = dash.Dash(requests_pathname_prefix='/app2/')
+        app2 = dash.Dash(
+            __name__,
+            requests_pathname_prefix='/app2/'
+        )
         app2.layout = html.Div("Dash app 2", id="content")
 
         app1.scripts.config.serve_locally = True


### PR DESCRIPTION
These two tests cover the examples included in plotly/dash-docs#357

 - test_flask_integration: Test two Dash apps being mounted at routes within an
   existing Flask app
 - test_wsgi_integration: Test two Dash apps being mounted at routes alongside
   a Flask app using DispatcherMiddleware, which can support routing to any WSGI
   app

