### PR TITLE
Fix assets blueprint path management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [UNRELEASED] - 2019-01-23
+## Fixed
+- Asset blueprint takes routes prefix into it's static path. [#547](https://github.com/plotly/dash/pull/547)
+- Asset url path no longer strip routes from requests. [#547](https://github.com/plotly/dash/pull/547)
+
+## Changed
+- `assets_folder` argument now default to 'assets' [#547](https://github.com/plotly/dash/pull/547)
+- The assets folder is now always relative to the given root path of `name` argument, the default of `__main__` will get the `cwd`. [#547](https://github.com/plotly/dash/pull/547)
+- No longer coerce the name argument from the server if the server argument is provided. [#547](https://github.com/plotly/dash/pull/547)
+
 ## [0.35.2] - 2019-01-11
 ## Fixed
 - Fix typo in some exception names [#522](https://github.com/plotly/dash/pull/522)

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -29,15 +29,12 @@ def generate_hash():
 
 def get_asset_path(
         requests_pathname,
-        routes_pathname,
         asset_path,
         asset_url_path):
-    i = requests_pathname.rfind(routes_pathname)
-    req = requests_pathname[:i]
 
     return '/'.join([
         # Only take the first part of the pathname
-        req,
+        requests_pathname.rstrip('/'),
         asset_url_path,
         asset_path
     ])

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -79,7 +79,6 @@ class Dash(object):
             assets_folder='assets',
             assets_url_path='/assets',
             assets_ignore='',
-            assets_blueprint_name='assets',
             include_assets_files=True,
             url_base_pathname=None,
             assets_external_path=None,
@@ -144,7 +143,7 @@ class Dash(object):
 
         assets_blueprint_name = '{}{}'.format(
             self.config.routes_pathname_prefix.replace('/', '_'),
-            assets_blueprint_name
+            'dash_assets'
         )
 
         self.server.register_blueprint(

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -76,9 +76,10 @@ class Dash(object):
             name='__main__',
             server=None,
             static_folder='static',
-            assets_folder=None,
+            assets_folder='assets',
             assets_url_path='/assets',
             assets_ignore='',
+            assets_blueprint_name='assets',
             include_assets_files=True,
             url_base_pathname=None,
             assets_external_path=None,
@@ -103,19 +104,14 @@ class Dash(object):
                 ''', DeprecationWarning)
 
         name = name if server is None else server.name
-        self._assets_folder = assets_folder or os.path.join(
-            flask.helpers.get_root_path(name), 'assets'
+        self._assets_folder = os.path.join(
+            flask.helpers.get_root_path(name),
+            assets_folder,
         )
         self._assets_url_path = assets_url_path
 
         # allow users to supply their own flask server
         self.server = server or Flask(name, static_folder=static_folder)
-
-        if 'assets' not in self.server.blueprints:
-            self.server.register_blueprint(
-                flask.Blueprint('assets', 'assets',
-                                static_folder=self._assets_folder,
-                                static_url_path=assets_url_path))
 
         env_configs = _configs.env_configs()
 
@@ -145,6 +141,22 @@ class Dash(object):
                 'components_cache_max_age', components_cache_max_age,
                 env_configs, 2678400))
         })
+
+        assets_blueprint_name = '{}{}'.format(
+            self.config.routes_pathname_prefix.replace('/', '_'),
+            assets_blueprint_name
+        )
+
+        self.server.register_blueprint(
+            flask.Blueprint(
+                assets_blueprint_name, name,
+                static_folder='assets',
+                static_url_path='{}{}'.format(
+                    self.config.routes_pathname_prefix,
+                    assets_url_path.lstrip('/')
+                )
+            )
+        )
 
         # list of dependencies
         self.callback_map = {}
@@ -1056,7 +1068,6 @@ class Dash(object):
     def get_asset_url(self, path):
         asset = _get_asset_path(
             self.config.requests_pathname_prefix,
-            self.config.routes_pathname_prefix,
             path,
             self._assets_url_path.lstrip('/')
         )

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -150,7 +150,7 @@ class Dash(object):
         self.server.register_blueprint(
             flask.Blueprint(
                 assets_blueprint_name, name,
-                static_folder='assets',
+                static_folder=self._assets_folder,
                 static_url_path='{}{}'.format(
                     self.config.routes_pathname_prefix,
                     assets_url_path.lstrip('/')

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -102,7 +102,6 @@ class Dash(object):
                 See https://github.com/plotly/dash/issues/141 for details.
                 ''', DeprecationWarning)
 
-        name = name if server is None else server.name
         self._assets_folder = os.path.join(
             flask.helpers.get_root_path(name),
             assets_folder,

--- a/tests/test_configs.py
+++ b/tests/test_configs.py
@@ -91,18 +91,16 @@ class MyTestCase(unittest.TestCase):
 
     def test_pathname_prefix_assets(self):
         req = '/'
-        routes = '/'
-        path = get_asset_path(req, routes, 'reset.css', 'assets')
+        path = get_asset_path(req, 'reset.css', 'assets')
         self.assertEqual('/assets/reset.css', path)
 
         req = '/requests/'
-        path = get_asset_path(req, routes, 'reset.css', 'assets')
+        path = get_asset_path(req, 'reset.css', 'assets')
         self.assertEqual('/requests/assets/reset.css', path)
 
         req = '/requests/routes/'
-        routes = '/routes/'
-        path = get_asset_path(req, routes, 'reset.css', 'assets')
-        self.assertEqual('/requests/assets/reset.css', path)
+        path = get_asset_path(req, 'reset.css', 'assets')
+        self.assertEqual('/requests/routes/assets/reset.css', path)
 
 
 if __name__ == '__main__':

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -361,7 +361,6 @@ class Tests(IntegrationTests):
 
     def test_assets(self):
         app = dash.Dash(__name__,
-                        assets_folder='tests/assets',
                         assets_ignore='.*ignored.*')
         app.index_string = '''
         <!DOCTYPE html>


### PR DESCRIPTION
## Fixed
- Asset blueprint takes routes prefix into it's static path.
- Asset url path no longer strip routes from requests.

## Changed
- `assets_folder` argument now default to 'assets'
- The assets folder is now always relative to the given root path of `name` argument, the default of `__main__` will get the `cwd`.
- No longer coerce the name argument from the server if the server argument is provided.

Fixes #529