### PR TITLE
Callback context

### DIFF
--- a/.circleci/requirements/dev-requirements-py37.txt
+++ b/.circleci/requirements/dev-requirements-py37.txt
@@ -2,7 +2,7 @@ dash_core_components==0.43.1
 dash_html_components==0.13.5
 dash-flow-example==0.0.5
 dash-dangerously-set-inner-html
--e git://github.com/plotly/dash-renderer.git@callback-context#egg=dash_renderer
+-e git://github.com/plotly/dash-renderer.git@master#egg=dash_renderer
 percy
 selenium
 mock

--- a/.circleci/requirements/dev-requirements-py37.txt
+++ b/.circleci/requirements/dev-requirements-py37.txt
@@ -2,7 +2,7 @@ dash_core_components==0.43.1
 dash_html_components==0.13.5
 dash-flow-example==0.0.5
 dash-dangerously-set-inner-html
-dash_renderer==0.18.0
+-e git://github.com/plotly/dash-renderer.git@callback-context#egg=dash_renderer
 percy
 selenium
 mock

--- a/.circleci/requirements/dev-requirements.txt
+++ b/.circleci/requirements/dev-requirements.txt
@@ -2,7 +2,7 @@ dash_core_components==0.43.1
 dash_html_components==0.13.5
 dash_flow_example==0.0.5
 dash-dangerously-set-inner-html
-dash_renderer==0.18.0
+-e git://github.com/plotly/dash-renderer.git@callback-context#egg=dash_renderer
 percy
 selenium
 mock

--- a/.circleci/requirements/dev-requirements.txt
+++ b/.circleci/requirements/dev-requirements.txt
@@ -2,7 +2,7 @@ dash_core_components==0.43.1
 dash_html_components==0.13.5
 dash_flow_example==0.0.5
 dash-dangerously-set-inner-html
--e git://github.com/plotly/dash-renderer.git@callback-context#egg=dash_renderer
+-e git://github.com/plotly/dash-renderer.git@master#egg=dash_renderer
 percy
 selenium
 mock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## Added
 - Added components libraries js/css distribution to hot reload watch. [#603](https://github.com/plotly/dash/pull/603)
+- Callback context [#608](https://github.com/plotly/dash/pull/608)
+  - Know which inputs fired in a callback `dash.callback.triggered`
+  - Input/State values by name `dash.callback.states.get('btn.n_clicks')`
 
 ## [0.37.0] - 2019-02-11
 ## Fixed

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -4,3 +4,6 @@ from . import development  # noqa: F401
 from . import exceptions  # noqa: F401
 from . import resources  # noqa: F401
 from .version import __version__  # noqa: F401
+from ._callback_context import CallbackContext as _CallbackContext
+
+callback = _CallbackContext()

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -6,4 +6,4 @@ from . import resources  # noqa: F401
 from .version import __version__  # noqa: F401
 from ._callback_context import CallbackContext as _CallbackContext
 
-callback = _CallbackContext()
+callback_context = _CallbackContext()

--- a/dash/_callback_context.py
+++ b/dash/_callback_context.py
@@ -1,0 +1,34 @@
+import functools
+import flask
+
+from . import exceptions
+
+
+def has_context(func):
+    @functools.wraps(func)
+    def assert_context(*args, **kwargs):
+        if not flask.has_request_context():
+            raise exceptions.MissingCallbackContextException(
+                'dash.callback.{} is only available from a callback!'.format(
+                    getattr(func, '__name__')
+                )
+            )
+        return func(*args, **kwargs)
+    return assert_context
+
+
+class CallbackContext:
+    @property
+    @has_context
+    def inputs(self):
+        return getattr(flask.g, 'input_values', {})
+
+    @property
+    @has_context
+    def states(self):
+        return getattr(flask.g, 'state_values', {})
+
+    @property
+    @has_context
+    def triggered(self):
+        return getattr(flask.g, 'triggered_inputs', [])

--- a/dash/_callback_context.py
+++ b/dash/_callback_context.py
@@ -17,6 +17,7 @@ def has_context(func):
     return assert_context
 
 
+# pylint: disable=no-init
 class CallbackContext:
     @property
     @has_context

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -950,7 +950,7 @@ class Dash(object):
         target_id = '{}.{}'.format(output['id'], output['property'])
         args = []
 
-        flask.g.input_values = {
+        flask.g.input_values = input_values = {
             '{}.{}'.format(x['id'], x['property']): x.get('value')
             for x in inputs
         }
@@ -958,7 +958,11 @@ class Dash(object):
             '{}.{}'.format(x['id'], x['property']): x.get('value')
             for x in state
         }
-        flask.g.triggered_inputs = body.get('changedPropIds')
+        changed_props = body.get('changedPropIds')
+        flask.g.triggered_inputs = [
+            {'prop_id': x, 'value': input_values[x]}
+            for x in changed_props
+        ] if changed_props else []
 
         for component_registration in self.callback_map[target_id]['inputs']:
             args.append([

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -949,6 +949,17 @@ class Dash(object):
 
         target_id = '{}.{}'.format(output['id'], output['property'])
         args = []
+
+        flask.g.input_values = {
+            '{}.{}'.format(x['id'], x['property']): x.get('value')
+            for x in inputs
+        }
+        flask.g.state_values = {
+            '{}.{}'.format(x['id'], x['property']): x.get('value')
+            for x in state
+        }
+        flask.g.triggered_inputs = body.get('changedProps')
+
         for component_registration in self.callback_map[target_id]['inputs']:
             args.append([
                 c.get('value', None) for c in inputs if

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -958,7 +958,7 @@ class Dash(object):
             '{}.{}'.format(x['id'], x['property']): x.get('value')
             for x in state
         }
-        flask.g.triggered_inputs = body.get('changedProps')
+        flask.g.triggered_inputs = body.get('changedPropIds')
 
         for component_registration in self.callback_map[target_id]['inputs']:
             args.append([

--- a/dash/exceptions.py
+++ b/dash/exceptions.py
@@ -80,3 +80,7 @@ class ResourceException(DashException):
 
 class SameInputOutputException(CallbackException):
     pass
+
+
+class MissingCallbackContextException(CallbackException):
+    pass

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -589,11 +589,10 @@ class Tests(IntegrationTests):
         @app.callback(Output('output', 'children'),
                       [Input(x, 'n_clicks') for x in btns])
         def on_click(*args):
-            print('wtf')
-            if not dash.callback.triggered:
+            if not dash.callback_context.triggered:
                 raise PreventUpdate
-            trigger = dash.callback.triggered[0]
-            input_value = dash.callback.inputs.get(trigger)
+            trigger = dash.callback_context.triggered[0]
+            input_value = dash.callback_context.inputs.get(trigger)
             return 'Just clicked {} for the {} time!'.format(
                 trigger.split('.')[0], input_value
             )
@@ -616,4 +615,4 @@ class Tests(IntegrationTests):
 
     def test_no_callback_context(self):
         with self.assertRaises(MissingCallbackContextException):
-            no_context = dash.callback.inputs
+            no_context = dash.callback_context.inputs

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -617,4 +617,3 @@ class Tests(IntegrationTests):
     def test_no_callback_context(self):
         with self.assertRaises(MissingCallbackContextException):
             no_context = dash.callback.inputs
-

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -592,9 +592,8 @@ class Tests(IntegrationTests):
             if not dash.callback_context.triggered:
                 raise PreventUpdate
             trigger = dash.callback_context.triggered[0]
-            input_value = dash.callback_context.inputs.get(trigger)
             return 'Just clicked {} for the {} time!'.format(
-                trigger.split('.')[0], input_value
+                trigger['prop_id'].split('.')[0], trigger['value']
             )
 
         self.startServer(app)
@@ -603,7 +602,7 @@ class Tests(IntegrationTests):
             self.wait_for_element_by_id(x) for x in btns
         ]
 
-        for i in range(1, 10):
+        for i in range(1, 5):
             for j, btn in enumerate(btns):
                 btn_elements[j].click()
                 self.wait_for_text_to_equal(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -12,7 +12,9 @@ import dash_flow_example
 import dash
 
 from dash.dependencies import Input, Output
-from dash.exceptions import PreventUpdate, CallbackException
+from dash.exceptions import (
+    PreventUpdate, CallbackException, MissingCallbackContextException
+)
 from .IntegrationTests import IntegrationTests
 from .utils import assert_clean_console, invincible, wait_for
 
@@ -571,3 +573,48 @@ class Tests(IntegrationTests):
             'Same output and input: input-output.children',
             context.exception.args[0]
         )
+
+    def test_callback_context(self):
+        app = dash.Dash(__name__)
+
+        btns = ['btn-{}'.format(x) for x in range(1, 6)]
+
+        app.layout = html.Div([
+            html.Div([
+                html.Button(x, id=x) for x in btns
+            ]),
+            html.Div(id='output'),
+        ])
+
+        @app.callback(Output('output', 'children'),
+                      [Input(x, 'n_clicks') for x in btns])
+        def on_click(*args):
+            print('wtf')
+            if not dash.callback.triggered:
+                raise PreventUpdate
+            trigger = dash.callback.triggered[0]
+            input_value = dash.callback.inputs.get(trigger)
+            return 'Just clicked {} for the {} time!'.format(
+                trigger.split('.')[0], input_value
+            )
+
+        self.startServer(app)
+
+        btn_elements = [
+            self.wait_for_element_by_id(x) for x in btns
+        ]
+
+        for i in range(1, 10):
+            for j, btn in enumerate(btns):
+                btn_elements[j].click()
+                self.wait_for_text_to_equal(
+                    '#output',
+                    'Just clicked {} for the {} time!'.format(
+                        btn, i
+                    )
+                )
+
+    def test_no_callback_context(self):
+        with self.assertRaises(MissingCallbackContextException):
+            no_context = dash.callback.inputs
+


### PR DESCRIPTION
Add a callback context object for the dash package.

- `dash.callback.inputs/states` a dict with the id and prop as key for the inputs/states value of a callback.
- `dash.callback.triggered` which inputs has fired (called `setProps`)

These properties are only available inside a callback.

Basic example:

```python
import dash
import dash_html_components as html

from dash.dependencies import Output, Input
from dash.exceptions import PreventUpdate

app = dash.Dash(__name__)

BUTTONS = ['btn-{}'.format(x) for x in range(1, 6)]

app.layout = html.Div([
    html.Div([
        html.Button(x, id=x) for x in BUTTONS
    ]),
    html.Div(id='output'),
])


@app.callback(Output('output', 'children'),
              [Input(x, 'n_clicks') for x in BUTTONS])
def on_click(*args):
    if not dash.callback.triggered:
        raise PreventUpdate
    trigger = dash.callback.triggered[0]
    input_value = dash.callback.inputs.get(trigger)
    return 'Just clicked {} for the {} time!'.format(
        trigger.split('.')[0], input_value)


if __name__ == '__main__':
    app.run_server(debug=True, port=9091)

```

Closes #291, Closes #59