### PR TITLE
more robust error message for callback return validation

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -839,7 +839,7 @@ class Dash(object):
                 if getattr(outer_val, 'id', False) else ''
             outer_type = type(outer_val).__name__
             raise exceptions.InvalidCallbackReturnValue('''
-            The callback for property `{property:s}` of component `{id:s}`
+            The callback for `{output:s}`
             returned a {object:s} having type `{type:s}`
             which is not JSON serializable.
 
@@ -851,8 +851,7 @@ class Dash(object):
             dash components, strings, dictionaries, numbers, None,
             or lists of those.
             '''.format(
-                property=output.component_property,
-                id=output.component_id,
+                output=repr(output),
                 object='tree with one value' if not toplevel else 'value',
                 type=bad_type,
                 location_header=(


### PR DESCRIPTION
Fixes #621 
Uses the `__repr__` @T4rk1n introduced in #605 to more simply construct the error message:
```
InvalidCallbackReturnValue: 
The callback for `[<Output `c.children`>, <Output `d.children`>]`
returned a value having type `instance`
which is not JSON serializable.
...
```