### PR TITLE
Custom response support via callback_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [Unreleased]
+## Added
+- Allow multiple outputs from a single callback. [#436](https://github.com/plotly/dash/pull/436)
+- Support for custom javascript hooks to modify callback payloads and responses. [#367](https://github.com/plotly/dash/pull/367)
+- Modify the flask response with custom cookies or headers, using `dash.callback_context.response`. [#623](https://github.com/plotly/dash/pull/623)
+
 ## [0.38.0] - 2019-02-25
 ## Fixed
 - Fix missing indentation for generated metadata.json [#600](https://github.com/plotly/dash/issues/600)

--- a/dash/_callback_context.py
+++ b/dash/_callback_context.py
@@ -9,9 +9,10 @@ def has_context(func):
     def assert_context(*args, **kwargs):
         if not flask.has_request_context():
             raise exceptions.MissingCallbackContextException(
-                'dash.callback.{} is only available from a callback!'.format(
-                    getattr(func, '__name__')
-                )
+                (
+                    'dash.callback_context.{} '
+                    'is only available from a callback!'
+                ).format(getattr(func, '__name__'))
             )
         return func(*args, **kwargs)
     return assert_context
@@ -33,3 +34,8 @@ class CallbackContext:
     @has_context
     def triggered(self):
         return getattr(flask.g, 'triggered_inputs', [])
+
+    @property
+    @has_context
+    def response(self):
+        return getattr(flask.g, 'dash_response')

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1023,10 +1023,7 @@ class Dash(object):
                     '''.format(property=output.component_property,
                                id=output.component_id))
 
-                return flask.Response(
-                    jsonResponse,
-                    mimetype='application/json'
-                )
+                return jsonResponse
 
             self.callback_map[callback_id]['callback'] = add_context
 
@@ -1056,6 +1053,9 @@ class Dash(object):
             for x in changed_props
         ] if changed_props else []
 
+        response = flask.g.dash_response = flask.Response(
+            mimetype='application/json')
+
         for component_registration in self.callback_map[output]['inputs']:
             args.append([
                 c.get('value', None) for c in inputs if
@@ -1070,7 +1070,8 @@ class Dash(object):
                 c['id'] == component_registration['id']
             ][0])
 
-        return self.callback_map[output]['callback'](*args)
+        response.set_data(self.callback_map[output]['callback'](*args))
+        return response
 
     def _validate_layout(self):
         if self.layout is None:


### PR DESCRIPTION
Closes #182 using an alternative approach to #401 as mentioned in https://github.com/plotly/dash/pull/401#issuecomment-468877351 - instead of making your own response object to return in place of the callback result, this PR makes a global object available that you can modify inside the callback (setting cookies or headers, for example)

I put this inside the `dash.callback_context` object, rather than making a new `dash.callback_response`, mainly to take advantage of the nice protection @T4rk1n built in there against using these outside of the callback, or accidentally clobbering them.

Per the example in the test, usage is like:
```py
@app.callback(Output('output', 'children'), [Input('input', 'value')])
def update_output(value):
    dash.callback_context.response.set_cookie(
        'dash cookie', value + ' - cookie')
    return value + ' - output'
```

cc @jkseppan @plotly/dash-core 