### PR TITLE
Remove loading... text from index string

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -57,9 +57,6 @@ _default_index = '''<!DOCTYPE html>
 
 _app_entry = '''
 <div id="react-entry-point">
-    <div class="_dash-loading">
-        Loading...
-    </div>
 </div>
 '''
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -57,6 +57,7 @@ _default_index = '''<!DOCTYPE html>
 
 _app_entry = '''
 <div id="react-entry-point">
+    <div class="_dash-loading"/>
 </div>
 '''
 


### PR DESCRIPTION
This removes the `Loading...` text that is added to the index string. With the new loading states and Loading component, I think this is no longer needed and could be confusing. I've decided to keep the `_dash-loading` div in, since users could still be using that in their apps. Let me know what you think!