### PR TITLE
Fix DeprecationWarning when importing ABCs.

### DIFF
--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -1,14 +1,14 @@
 import abc
 import inspect
 import sys
-try:
-    from collections.abc import MutableSequence
-except ImportError:
-    from collections import MutableSequence
-
 import six
 
 from .._utils import patch_collections_abc
+
+if six.PY2:
+    from collections import MutableSequence
+else:
+    from collections.abc import MutableSequence
 
 
 # pylint: disable=no-init,too-few-public-methods

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -5,10 +5,11 @@ import six
 
 from .._utils import patch_collections_abc
 
+# pylint: disable=no-name-in-module, import-error
 if six.PY2:
-    from collections import MutableSequence  # pylint: disable=E0611
+    from collections import MutableSequence
 else:
-    from collections.abc import MutableSequence  # pylint: disable=E0611, E0401
+    from collections.abc import MutableSequence
 
 
 # pylint: disable=no-init,too-few-public-methods

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -1,7 +1,10 @@
-import collections
 import abc
 import inspect
 import sys
+try:
+    from collections.abc import MutableSequence
+except ImportError:
+    from collections import MutableSequence
 
 import six
 
@@ -53,8 +56,7 @@ def is_number(s):
 def _check_if_has_indexable_children(item):
     if (not hasattr(item, 'children') or
             (not isinstance(item.children, Component) and
-             not isinstance(item.children, (tuple,
-                                            collections.MutableSequence)))):
+             not isinstance(item.children, (tuple, MutableSequence)))):
 
         raise KeyError
 
@@ -153,7 +155,7 @@ class Component(patch_collections_abc('MutableMapping')):
                 pass
 
         # if children is like a list
-        if isinstance(self.children, (tuple, collections.MutableSequence)):
+        if isinstance(self.children, (tuple, MutableSequence)):
             for i, item in enumerate(self.children):
                 # If the item itself is the one we're looking for
                 if getattr(item, 'id', None) == id:
@@ -229,7 +231,7 @@ class Component(patch_collections_abc('MutableMapping')):
                 yield "\n".join(["[*] " + children_string, p]), t
 
         # children is a list of components
-        elif isinstance(children, (tuple, collections.MutableSequence)):
+        elif isinstance(children, (tuple, MutableSequence)):
             for idx, i in enumerate(children):
                 list_path = "[{:d}] {:s} {}".format(
                     idx,
@@ -262,7 +264,7 @@ class Component(patch_collections_abc('MutableMapping')):
         elif isinstance(self.children, Component):
             length = 1
             length += len(self.children)
-        elif isinstance(self.children, (tuple, collections.MutableSequence)):
+        elif isinstance(self.children, (tuple, MutableSequence)):
             for c in self.children:
                 length += 1
                 if isinstance(c, Component):

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -6,9 +6,9 @@ import six
 from .._utils import patch_collections_abc
 
 if six.PY2:
-    from collections import MutableSequence  # pylint: disable=no-name-in-module
+    from collections import MutableSequence  # pylint: disable=E0611
 else:
-    from collections.abc import MutableSequence
+    from collections.abc import MutableSequence  # pylint: disable=E0611, E0401
 
 
 # pylint: disable=no-init,too-few-public-methods

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -6,7 +6,7 @@ import six
 from .._utils import patch_collections_abc
 
 if six.PY2:
-    from collections import MutableSequence
+    from collections import MutableSequence  # pylint: disable=no-name-in-module
 else:
     from collections.abc import MutableSequence
 

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -5,11 +5,7 @@ import six
 
 from .._utils import patch_collections_abc
 
-# pylint: disable=no-name-in-module, import-error
-if six.PY2:
-    from collections import MutableSequence
-else:
-    from collections.abc import MutableSequence
+MutableSequence = patch_collections_abc('MutableSequence')
 
 
 # pylint: disable=no-init,too-few-public-methods


### PR DESCRIPTION
Hi,

I'm addressing the warning I get whenever I run the tests locally:
```bash
<path>/dash/dash/development/base_component.py:265: DeprecationWarning:

Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
```
I have just transposed https://github.com/plotly/plotly.py/pull/1417 to this repo.