### PR TITLE
:sparkles: add dev_tools_ui in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Added
+
+- add `dev_tools_ui` in `<script id="_dash-config" type="application/json">`,
+  so renderer can know if it should enable the UI. [#676](https://github.com/plotly/dash/pull/676)
+
+
 ## [0.40.0] - 2019-03-25
 ### Changed
 - Bumped dash-core-components version from 0.44.0 to [0.45.0](https://github.com/plotly/dash-core-components/blob/master/CHANGELOG.md#0450---2019-03-25)

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -237,7 +237,8 @@ class Dash(object):
             'hot_reload': False,
             'hot_reload_interval': 3000,
             'hot_reload_watch_interval': 0.5,
-            'hot_reload_max_retry': 8
+            'hot_reload_max_retry': 8,
+            'dev_tools_ui': False,
         })
 
         # add a handler for components suites errors to return 404
@@ -328,8 +329,9 @@ class Dash(object):
     def _config(self):
         config = {
             'url_base_pathname': self.url_base_pathname,
-            'requests_pathname_prefix': self.config['requests_pathname_prefix']
-        }
+            'requests_pathname_prefix': self.config['requests_pathname_prefix'],
+            'dev_tools_ui': self._dev_tools.dev_tools_ui,
+        }  # noqa: E501
         if self._dev_tools.hot_reload:
             config['hot_reload'] = {
                 'interval': self._dev_tools.hot_reload_interval,
@@ -1226,6 +1228,8 @@ class Dash(object):
         env = _configs.env_configs()
         debug = debug or _configs.get_config('debug', None, env, debug,
                                              is_bool=True)
+
+        self._dev_tools.dev_tools_ui = debug
 
         self._dev_tools['serve_dev_bundles'] = _configs.get_config(
             'serve_dev_bundles', dev_tools_serve_dev_bundles, env,

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -329,7 +329,7 @@ class Dash(object):
     def _config(self):
         config = {
             'url_base_pathname': self.url_base_pathname,
-            'requests_pathname_prefix': self.config['requests_pathname_prefix'],  # noqa: E501
+            'requests_pathname_prefix': self.config.requests_pathname_prefix,
             'dev_tools_ui': self._dev_tools.dev_tools_ui,
         }
         if self._dev_tools.hot_reload:

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -329,9 +329,9 @@ class Dash(object):
     def _config(self):
         config = {
             'url_base_pathname': self.url_base_pathname,
-            'requests_pathname_prefix': self.config['requests_pathname_prefix'],
+            'requests_pathname_prefix': self.config['requests_pathname_prefix'],  # noqa: E501
             'dev_tools_ui': self._dev_tools.dev_tools_ui,
-        }  # noqa: E501
+        }
         if self._dev_tools.hot_reload:
             config['hot_reload'] = {
                 'interval': self._dev_tools.hot_reload_interval,


### PR DESCRIPTION
this fixes #674 

This PR introduces a new config `dev_tools_ui` to let FE know about if user has set debug=True. this implicitly enables the dev tools UI 

![image](https://user-images.githubusercontent.com/1394467/55358870-68b88580-549e-11e9-924d-eb6b6eebc9ca.png)
