### PR TITLE
Adding a smart `auto_callback` functions to populate callback information

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1042,8 +1042,10 @@ class Dash(object):
                 if prefix_name in in_name:
                     return in_name.find(prefix_name) + len(prefix_name)
 
-            raise ValueError('auto_callback requires callback name to start with {}'.format(
-                valid_prefix_names))
+            raise ValueError(
+                'auto_callback requires name to start with {}'.format(
+                valid_prefix_names)
+            )
 
         def process_output(callback_func):
             callback_name = getattr(callback_func, '__name__', '')
@@ -1057,7 +1059,8 @@ class Dash(object):
                 # assume children if no underscore
                 comp_name = comp_prop_name
                 prop_name = 'children'
-            return Output(component_id=comp_name, component_property=prop_name)
+            return Output(component_id=comp_name,
+                          component_property=prop_name)
 
         def process_input(callback_func):
             if sys.version_info[0] == 3:
@@ -1067,7 +1070,10 @@ class Dash(object):
                 # pylint: disable=maybe-no-member
                 spec_args = inspect.getargspec(callback_func).args
             else:
-                raise ValueError("Requires Python 2 or 3, {}".format(sys.version_info))
+                raise ValueError(
+                    "Requires Python 2 or 3, {}".format(
+                    sys.version_info)
+                )
 
             input_list = []
             for c_comp_prop_arg in spec_args:
@@ -1079,7 +1085,8 @@ class Dash(object):
                     # assume value if no underscore
                     comp_name = c_comp_prop_arg
                     prop_name = 'value'
-                input_list += [Input(component_id=comp_name, component_property=prop_name)]
+                input_list += [Input(component_id=comp_name,
+                                     component_property=prop_name)]
             return input_list
 
         def wrap_callback(callback_func):

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1044,7 +1044,7 @@ class Dash(object):
 
             raise ValueError(
                 'auto_callback requires name to start with {}'.format(
-                valid_prefix_names)
+                    valid_prefix_names)
             )
 
         def process_output(callback_func):
@@ -1072,7 +1072,7 @@ class Dash(object):
             else:
                 raise ValueError(
                     "Requires Python 2 or 3, {}".format(
-                    sys.version_info)
+                        sys.version_info)
                 )
 
             input_list = []

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1042,7 +1042,8 @@ class Dash(object):
                 if prefix_name in in_name:
                     return in_name.find(prefix_name) + len(prefix_name)
 
-            raise ValueError('EasyDash requires callback name to start with {}'.format(valid_prefix_names))
+            raise ValueError('auto_callback requires callback name to start with {}'.format(
+                valid_prefix_names))
 
         def process_output(callback_func):
             callback_name = getattr(callback_func, '__name__', '')
@@ -1060,8 +1061,10 @@ class Dash(object):
 
         def process_input(callback_func):
             if sys.version_info[0] == 3:
+                # pylint: disable=maybe-no-member
                 spec_args = inspect.getfullargspec(callback_func).args
             elif sys.version_info[0] == 2:
+                # pylint: disable=maybe-no-member
                 spec_args = inspect.getargspec(callback_func).args
             else:
                 raise ValueError("Requires Python 2 or 3, {}".format(sys.version_info))

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -13,6 +13,7 @@ import warnings
 import re
 import logging
 import pprint
+import inspect
 
 from functools import wraps
 
@@ -1030,6 +1031,66 @@ class Dash(object):
             return add_context
 
         return wrap_func
+
+    # Auto_callback uses inspect to populate input and output fields
+    def auto_callback(self, debug=False):
+
+        valid_prefix_names = ['update_', 'callback_']
+
+        def check_prefix(in_name):
+            for prefix_name in valid_prefix_names:
+                if prefix_name in in_name:
+                    return in_name.find(prefix_name) + len(prefix_name)
+
+            raise ValueError('EasyDash requires callback name to start with {}'.format(valid_prefix_names))
+
+        def process_output(callback_func):
+            callback_name = getattr(callback_func, '__name__', '')
+            comp_prop_start_idx = check_prefix(callback_name)
+            comp_prop_name = callback_name[comp_prop_start_idx:]
+            property_start = comp_prop_name.rfind('_')
+            if property_start >= 1:
+                prop_name = comp_prop_name[property_start + 1:]
+                comp_name = comp_prop_name[:property_start]
+            else:
+                # assume children if no underscore
+                comp_name = comp_prop_name
+                prop_name = 'children'
+            return Output(component_id=comp_name, component_property=prop_name)
+
+        def process_input(callback_func):
+            if sys.version_info[0] == 3:
+                spec_args = inspect.getfullargspec(callback_func).args
+            elif sys.version_info[0] == 2:
+                spec_args = inspect.getargspec(callback_func).args
+            else:
+                raise ValueError("Requires Python 2 or 3, {}".format(sys.version_info))
+
+            input_list = []
+            for c_comp_prop_arg in spec_args:
+                property_start = c_comp_prop_arg.rfind('_')
+                if property_start >= 1:
+                    comp_name = c_comp_prop_arg[:property_start]
+                    prop_name = c_comp_prop_arg[property_start + 1:]
+                else:
+                    # assume value if no underscore
+                    comp_name = c_comp_prop_arg
+                    prop_name = 'value'
+                input_list += [Input(component_id=comp_name, component_property=prop_name)]
+            return input_list
+
+        def wrap_callback(callback_func):
+            # process outputs
+            output = process_output(callback_func)
+            if debug:
+                print('Output:', output)
+            # process inputs
+            inputs = process_input(callback_func)
+            if debug:
+                print('Inputs:', inputs)
+            return self.callback(output, inputs=inputs)(callback_func)
+
+        return wrap_callback
 
     def dispatch(self):
         body = flask.request.get_json()

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1067,7 +1067,7 @@ class Dash(object):
                 # pylint: disable=maybe-no-member
                 spec_args = inspect.getfullargspec(callback_func).args
             elif sys.version_info[0] == 2:
-                # pylint: disable=maybe-no-member
+                # pylint: disable=maybe-no-member, deprecated-method
                 spec_args = inspect.getargspec(callback_func).args
             else:
                 raise ValueError(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -111,7 +111,7 @@ class Tests(IntegrationTests):
         @app.auto_callback()
         def update_output1_children(input_value):
             call_count.value = call_count.value + 1
-            return value
+            return input_value
 
         self.startServer(app)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -89,6 +89,62 @@ class Tests(IntegrationTests):
 
         assert_clean_console(self)
 
+    def test_auto_callback(self):
+        app = dash.Dash(__name__)
+        app.layout = html.Div([
+            dcc.Input(
+                id='input',
+                value='initial value'
+            ),
+            html.Div(
+                html.Div([
+                    1.5,
+                    None,
+                    'string',
+                    html.Div(id='output1')
+                ])
+            )
+        ])
+
+        call_count = Value('i', 0)
+
+        @app.auto_callback()
+        def update_output1_children(input_value):
+            call_count.value = call_count.value + 1
+            return value
+
+        self.startServer(app)
+
+        self.wait_for_text_to_equal('#output1', 'initial value')
+        self.percy_snapshot(name='auto-callback-1')
+
+        input1 = self.wait_for_element_by_id('input')
+
+        chain = (ActionChains(self.driver)
+                 .click(input1)
+                 .send_keys(Keys.HOME)
+                 .key_down(Keys.SHIFT)
+                 .send_keys(Keys.END)
+                 .key_up(Keys.SHIFT)
+                 .send_keys(Keys.DELETE))
+        chain.perform()
+
+        input1.send_keys('hello world')
+
+        self.wait_for_text_to_equal('#output1', 'hello world')
+        self.percy_snapshot(name='auto-callback-2')
+
+        self.assertEqual(
+            call_count.value,
+            # an initial call to retrieve the first value
+            # and one for clearing the input
+            2 +
+            # one for each hello world character
+            len('hello world')
+        )
+
+        assert_clean_console(self)
+
     def test_wildcard_callback(self):
         app = dash.Dash(__name__)
         app.layout = html.Div([


### PR DESCRIPTION
Basically a response for the issue #677 

makes a simple program like this possible by automatically determining inputs and outputs
```
app = dash.Dash()

app.layout = html.Div([
    html.H1([html.H2([])]),
    dcc.Input(id='simple_input', value='initial value', type="text"),
    html.Div(id='simple_output')
])

@app.auto_callback()
def update_simple_output_children(simple_input_value):
    return 'You\'ve entered "{}"'.format(simple_input_value)
```