### PR TITLE
Partial updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Support for "Clientside Callbacks" - an escape hatch to execute your callbacks in JavaScript instead of Python [#672](https://github.com/plotly/dash/pull/672)
 - Added `dev_tools_ui` config flag in `app.run_server` (serialized in `<script id="_dash-config" type="application/json">`)
   to display or hide the forthcoming Dev Tools UI in Dash's front-end (dash-renderer). [#676](https://github.com/plotly/dash/pull/676)
+- Partial updates: leave some multi-output updates unchanged while updating others [#680](https://github.com/plotly/dash/pull/680)
 
 ## [0.40.0] - 2019-03-25
 ### Changed

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -1,4 +1,4 @@
-from .dash import Dash  # noqa: F401
+from .dash import Dash, no_update  # noqa: F401
 from . import dependencies  # noqa: F401
 from . import development  # noqa: F401
 from . import exceptions  # noqa: F401

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -28,13 +28,11 @@ class IntegrationTests(unittest.TestCase):
         )
 
     def wait_for_text_to_equal(self, selector, assertion_text, timeout=TIMEOUT):
-        self.wait_for_element_by_css_selector(selector)
+        el = self.wait_for_element_by_css_selector(selector)
         WebDriverWait(self.driver, timeout).until(
             lambda *args: (
-                (str(self.wait_for_element_by_css_selector(selector).text)
-                 == assertion_text) or
-                 (str(self.wait_for_element_by_css_selector(selector).get_attribute('value'))
-                  == assertion_text)
+                (str(el.text) == assertion_text) or
+                (str(el.get_attribute('value')) == assertion_text)
             ),
             "Element '{}' text was supposed to equal '{}' but it didn't".format(
                 selector,

--- a/tests/IntegrationTests.py
+++ b/tests/IntegrationTests.py
@@ -21,15 +21,25 @@ class IntegrationTests(unittest.TestCase):
             name=snapshot_name
         )
 
-    def wait_for_element_by_css_selector(self, selector):
-        return WebDriverWait(self.driver, TIMEOUT).until(
-            EC.presence_of_element_located((By.CSS_SELECTOR, selector))
+    def wait_for_element_by_css_selector(self, selector, timeout=TIMEOUT):
+        return WebDriverWait(self.driver, timeout).until(
+            EC.presence_of_element_located((By.CSS_SELECTOR, selector)),
+            'Could not find element with selector "{}"'.format(selector)
         )
 
-    def wait_for_text_to_equal(self, selector, assertion_text):
-        return WebDriverWait(self.driver, TIMEOUT).until(
-            EC.text_to_be_present_in_element((By.CSS_SELECTOR, selector),
-                                             assertion_text)
+    def wait_for_text_to_equal(self, selector, assertion_text, timeout=TIMEOUT):
+        self.wait_for_element_by_css_selector(selector)
+        WebDriverWait(self.driver, timeout).until(
+            lambda *args: (
+                (str(self.wait_for_element_by_css_selector(selector).text)
+                 == assertion_text) or
+                 (str(self.wait_for_element_by_css_selector(selector).get_attribute('value'))
+                  == assertion_text)
+            ),
+            "Element '{}' text was supposed to equal '{}' but it didn't".format(
+                selector,
+                assertion_text
+            )
         )
 
     @classmethod

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -54,7 +54,7 @@ class Tests(IntegrationTests):
 
         @app.callback(Output('output-1', 'children'), [Input('input', 'value')])
         def update_output(value):
-            call_count.value = call_count.value + 1
+            call_count.value += 1
             return value
 
         self.startServer(app)
@@ -111,7 +111,7 @@ class Tests(IntegrationTests):
 
         @app.callback(Output('output-1', 'data-cb'), [Input('input', 'value')])
         def update_data(value):
-            input_call_count.value = input_call_count.value + 1
+            input_call_count.value += 1
             return value
 
         @app.callback(Output('output-1', 'children'),
@@ -167,13 +167,13 @@ class Tests(IntegrationTests):
 
         @app.callback(Output('output1', 'children'), [Input('input', 'value')])
         def callback1(value):
-            callback1_count.value = callback1_count.value + 1
+            callback1_count.value += 1
             raise PreventUpdate("testing callback does not update")
             return value
 
         @app.callback(Output('output2', 'children'), [Input('output1', 'children')])
         def callback2(value):
-            callback2_count.value = callback2_count.value + 1
+            callback2_count.value += 1
             return value
 
         self.startServer(app)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -184,8 +184,8 @@ class Tests(IntegrationTests):
         self.startServer(app)
 
         input_ = self.wait_for_element_by_id('input')
-        input_.clear()
         input_.send_keys('xyz')
+        self.wait_for_text_to_equal('#input', 'initial inputxyz')
         output1 = self.wait_for_element_by_id('output1')
         output2 = self.wait_for_element_by_id('output2')
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,7 @@ import dash_flow_example
 import dash_html_components as html
 import dash_core_components as dcc
 
-import dash
+from dash import Dash, callback_context
 
 from dash.dependencies import Input, Output, State
 from dash.exceptions import (
@@ -34,7 +34,7 @@ class Tests(IntegrationTests):
         self.wait_for_element_by_id = wait_for_element_by_id
 
     def test_simple_callback(self):
-        app = dash.Dash(__name__)
+        app = Dash(__name__)
         app.layout = html.Div([
             dcc.Input(
                 id='input',
@@ -90,7 +90,7 @@ class Tests(IntegrationTests):
         assert_clean_console(self)
 
     def test_wildcard_callback(self):
-        app = dash.Dash(__name__)
+        app = Dash(__name__)
         app.layout = html.Div([
             dcc.Input(
                 id='input',
@@ -155,7 +155,7 @@ class Tests(IntegrationTests):
         initial_input = 'initial input'
         initial_output = 'initial output'
 
-        app = dash.Dash(__name__)
+        app = Dash(__name__)
         app.layout = html.Div([
             dcc.Input(id='input', value=initial_input),
             html.Div(initial_output, id='output1'),
@@ -199,7 +199,7 @@ class Tests(IntegrationTests):
         self.percy_snapshot(name='aborted')
 
     def test_wildcard_data_attributes(self):
-        app = dash.Dash()
+        app = Dash()
         test_time = datetime.datetime(2012, 1, 10, 2, 3)
         test_date = datetime.date(test_time.year, test_time.month,
                                   test_time.day)
@@ -257,7 +257,7 @@ class Tests(IntegrationTests):
         assert_clean_console(self)
 
     def test_no_props_component(self):
-        app = dash.Dash()
+        app = Dash()
         app.layout = html.Div([
             dash_dangerously_set_inner_html.DangerouslySetInnerHTML('''
                 <h1>No Props Component</h1>
@@ -268,7 +268,7 @@ class Tests(IntegrationTests):
         self.percy_snapshot(name='no-props-component')
 
     def test_flow_component(self):
-        app = dash.Dash()
+        app = Dash()
 
         app.layout = html.Div([
             dash_flow_example.ExampleReactComponent(
@@ -309,7 +309,7 @@ class Tests(IntegrationTests):
             {'name': 'custom', 'content': 'customized'},
         ]
 
-        app = dash.Dash(meta_tags=metas)
+        app = Dash(meta_tags=metas)
 
         app.layout = html.Div(id='content')
 
@@ -329,7 +329,7 @@ class Tests(IntegrationTests):
             self.assertEqual(content, meta_info['content'])
 
     def test_index_customization(self):
-        app = dash.Dash()
+        app = Dash()
 
         app.index_string = '''
         <!DOCTYPE html>
@@ -384,8 +384,7 @@ class Tests(IntegrationTests):
         self.percy_snapshot('custom-index')
 
     def test_assets(self):
-        app = dash.Dash(__name__,
-                        assets_ignore='.*ignored.*')
+        app = Dash(__name__, assets_ignore='.*ignored.*')
         app.index_string = '''
         <!DOCTYPE html>
         <html>
@@ -437,7 +436,7 @@ class Tests(IntegrationTests):
         self.percy_snapshot('test assets includes')
 
     def test_invalid_index_string(self):
-        app = dash.Dash()
+        app = Dash()
 
         def will_raise():
             app.index_string = '''
@@ -496,9 +495,9 @@ class Tests(IntegrationTests):
             }
         ]
 
-        app = dash.Dash(__name__,
-                        external_scripts=js_files,
-                        external_stylesheets=css_files)
+        app = Dash(__name__,
+                   external_scripts=js_files,
+                   external_stylesheets=css_files)
 
         app.index_string = '''
         <!DOCTYPE html>
@@ -547,7 +546,7 @@ class Tests(IntegrationTests):
 
     def test_func_layout_accepted(self):
 
-        app = dash.Dash()
+        app = Dash()
 
         def create_layout():
             return html.Div('Hello World')
@@ -557,7 +556,7 @@ class Tests(IntegrationTests):
         time.sleep(0.5)
 
     def test_multi_output(self):
-        app = dash.Dash(__name__)
+        app = Dash(__name__)
         app.scripts.config.serve_locally = True
 
         app.layout = html.Div([
@@ -658,7 +657,7 @@ class Tests(IntegrationTests):
         self.assertGreater(int(output2.text), t)
 
     def test_with_custom_renderer(self):
-        app = dash.Dash(__name__)
+        app = Dash(__name__)
 
         app.index_string = '''
         <!DOCTYPE html>
@@ -758,7 +757,7 @@ class Tests(IntegrationTests):
             </script>
         '''
 
-        class CustomDash(dash.Dash):
+        class CustomDash(Dash):
 
             def interpolate_index(self, **kwargs):
                 return '''
@@ -824,7 +823,7 @@ class Tests(IntegrationTests):
         self.percy_snapshot(name='request-hooks interpolated')
 
     def test_modified_response(self):
-        app = dash.Dash(__name__)
+        app = Dash(__name__)
         app.layout = html.Div([
             dcc.Input(id='input', value='ab'),
             html.Div(id='output')
@@ -832,7 +831,7 @@ class Tests(IntegrationTests):
 
         @app.callback(Output('output', 'children'), [Input('input', 'value')])
         def update_output(value):
-            dash.callback_context.response.set_cookie(
+            callback_context.response.set_cookie(
                 'dash cookie', value + ' - cookie')
             return value + ' - output'
 
@@ -850,7 +849,7 @@ class Tests(IntegrationTests):
         assert_clean_console(self)
 
     def test_late_component_register(self):
-        app = dash.Dash()
+        app = Dash()
 
         app.layout = html.Div([
             html.Button('Click me to put a dcc ', id='btn-insert'),
@@ -874,7 +873,7 @@ class Tests(IntegrationTests):
         self.wait_for_element_by_css_selector('#inserted-input')
 
     def test_output_input_invalid_callback(self):
-        app = dash.Dash(__name__)
+        app = Dash(__name__)
         app.layout = html.Div([
             html.Div('child', id='input-output'),
             html.Div(id='out')
@@ -905,7 +904,7 @@ class Tests(IntegrationTests):
         )
 
     def test_callback_return_validation(self):
-        app = dash.Dash(__name__)
+        app = Dash(__name__)
         app.layout = html.Div([
             html.Div(id='a'),
             html.Div(id='b'),
@@ -942,7 +941,7 @@ class Tests(IntegrationTests):
             multi2('aaa')
 
     def test_callback_context(self):
-        app = dash.Dash(__name__)
+        app = Dash(__name__)
 
         btns = ['btn-{}'.format(x) for x in range(1, 6)]
 
@@ -956,9 +955,9 @@ class Tests(IntegrationTests):
         @app.callback(Output('output', 'children'),
                       [Input(x, 'n_clicks') for x in btns])
         def on_click(*args):
-            if not dash.callback_context.triggered:
+            if not callback_context.triggered:
                 raise PreventUpdate
-            trigger = dash.callback_context.triggered[0]
+            trigger = callback_context.triggered[0]
             return 'Just clicked {} for the {} time!'.format(
                 trigger['prop_id'].split('.')[0], trigger['value']
             )
@@ -982,4 +981,4 @@ class Tests(IntegrationTests):
     def test_no_callback_context(self):
         for attr in ['inputs', 'states', 'triggered', 'response']:
             with self.assertRaises(MissingCallbackContextException):
-                getattr(dash.callback_context, attr)
+                getattr(callback_context, attr)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -679,8 +679,8 @@ class Tests(IntegrationTests):
         def show_clicks(n):
             # partial or complete cancelation of updates via no_update
             return [
-                no_update if n > 4 else n,
-                no_update if n > 2 else n,
+                no_update if n and n > 4 else n,
+                no_update if n and n > 2 else n,
                 no_update
             ]
 


### PR DESCRIPTION
Fixes #668 

Provides a new `dash.no_update` - a singleton that you can use in a callback return to prevent a single output from updating. Two reasons you might want to do this:
1. Most importantly, for updating only *some* of a multi-output callback, leaving the rest unchanged
2. Even for a single-output callback, it might not be ideal to raise an exception. Maybe there's cleanup you want to do after determining the return value, or further logic that might reverse the decision to not update.

I'm not super excited about the name, any suggestions? `PreventUpdate` makes sense for an exception as it's based on a verb, this seems like it should be a noun but related to `PreventUpdate`, so I went with `no_update`.

Also its location: it's not an exception so doesn't seem to belong as `dash.exceptions.no_update`. For now I just put it at the top level as `dash.no_update`. OK?