### PR TITLE
add show_undo_redo config option, default false

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Install dependencies (dash)
           command: |
-              git clone git@github.com:plotly/dash-renderer.git
+              git clone -b hide-undo-redo git@github.com:plotly/dash-renderer.git
               git clone git@github.com:plotly/dash-core-components.git
               git clone git@github.com:plotly/dash-html-components.git
               git clone git@github.com:plotly/dash-table.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [UNRELEASED]
+### Changed
+- Undo/redo toolbar is removed by default, you can enable it with `app=Dash(show_undo_redo=true)`. The CSS hack `._dash-undo-redo:{display:none;}` is no longer needed [#724](https://github.com/plotly/dash/pull/724)
+
 ## [0.43.0] - 2019-04-25
 ### Changed
 - Bumped dash-core-components version from 0.47.0 to [0.48.0](https://github.com/plotly/dash-core-components/blob/master/CHANGELOG.md#0480---2019-05-15)

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -106,6 +106,7 @@ class Dash(object):
             external_stylesheets=None,
             suppress_callback_exceptions=None,
             components_cache_max_age=None,
+            show_undo_redo=False,
             plugins=None,
             **kwargs):
 
@@ -149,7 +150,8 @@ class Dash(object):
             'components_cache_max_age': int(get_combined_config(
                 'components_cache_max_age',
                 components_cache_max_age,
-                2678400))
+                2678400)),
+            'show_undo_redo': show_undo_redo
         })
 
         assets_blueprint_name = '{}{}'.format(
@@ -342,6 +344,7 @@ class Dash(object):
             'requests_pathname_prefix': self.config.requests_pathname_prefix,
             'ui': self._dev_tools.ui,
             'props_check': self._dev_tools.props_check,
+            'show_undo_redo': self.config.show_undo_redo
         }
         if self._dev_tools.hot_reload:
             config['hot_reload'] = {


### PR DESCRIPTION
Closes #234

Disables the undo/redo toolbar by default - you can turn it back on with
`app = dash.Dash(show_undo_redo=True)`