### PR TITLE
Refactor <flavor> package generation

### DIFF
--- a/dash/development/_py_components_generation.py
+++ b/dash/development/_py_components_generation.py
@@ -110,7 +110,7 @@ def generate_class_string(typename, props, description, namespace):
     )
 
 
-def generate_class_file(typename, props, description, namespace):
+def generate_component_wrapper(typename, props, description, namespace):
     """
     Generate a python class file (.py) given a class string
 
@@ -129,49 +129,24 @@ def generate_class_file(typename, props, description, namespace):
         "# AUTO GENERATED FILE - DO NOT EDIT\n\n" + \
         "from dash.development.base_component import " + \
         "Component, _explicitize_args\n\n\n"
+
     class_string = generate_class_string(
         typename,
         props,
         description,
         namespace
     )
-    file_name = "{:s}.py".format(typename)
 
-    file_path = os.path.join(namespace, file_name)
-    with open(file_path, 'w') as f:
-        f.write(import_string)
-        f.write(class_string)
-
-    print('Generated {}'.format(file_name))
+    return import_string + class_string
 
 
 def generate_imports(project_shortname, components):
-    with open(os.path.join(project_shortname, '_imports_.py'), 'w') as f:
-        imports_string = '{}\n\n{}'.format(
-            '\n'.join(
-                'from .{0} import {0}'.format(x) for x in components),
-            '__all__ = [\n{}\n]'.format(
-                ',\n'.join('    "{}"'.format(x) for x in components))
-        )
-
-        f.write(imports_string)
-
-
-def generate_classes_files(project_shortname, metadata, *component_generators):
-    components = []
-    for component_path, component_data in metadata.items():
-        component_name = component_path.split('/')[-1].split('.')[0]
-        components.append(component_name)
-
-        for generator in component_generators:
-            generator(
-                component_name,
-                component_data['props'],
-                component_data['description'],
-                project_shortname
-            )
-
-    return components
+    return '{}\n\n{}'.format(
+        '\n'.join(
+            'from .{0} import {0}'.format(x) for x in components),
+        '__all__ = [\n{}\n]'.format(
+            ',\n'.join('    "{}"'.format(x) for x in components))
+    )
 
 
 def generate_class(typename, props, description, namespace):

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -1,109 +1,14 @@
-from __future__ import print_function
-from collections import OrderedDict
-
-import json
-import sys
-import subprocess
-import shlex
 import os
 import argparse
-import shutil
-import functools
 
-import pkg_resources
+from .plugins.helpers import extract_metadata
 
-from ._r_components_generation import write_class_file
-from ._r_components_generation import generate_exports
-from ._py_components_generation import generate_class_file
-from ._py_components_generation import generate_imports
-from ._py_components_generation import generate_classes_files
-
+from .plugins.R.generate import generate as r_generate
+from .plugins.python.generate import generate as py_generate
 
 class _CombinedFormatter(argparse.ArgumentDefaultsHelpFormatter,
                          argparse.RawDescriptionHelpFormatter):
     pass
-
-
-# pylint: disable=too-many-locals
-def generate_components(components_source, project_shortname,
-                        package_info_filename='package.json',
-                        ignore='^_',
-                        rprefix=None):
-
-    project_shortname = project_shortname.replace('-', '_').rstrip('/\\')
-
-    if rprefix:
-        prefix = rprefix
-
-    is_windows = sys.platform == 'win32'
-
-    extract_path = pkg_resources.resource_filename('dash', 'extract-meta.js')
-
-    os.environ['NODE_PATH'] = 'node_modules'
-    cmd = shlex.split(
-        'node {} {} {}'.format(extract_path, ignore, components_source),
-        posix=not is_windows
-    )
-
-    shutil.copyfile('package.json',
-                    os.path.join(project_shortname, package_info_filename))
-
-    proc = subprocess.Popen(cmd,
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            shell=is_windows)
-    out, err = proc.communicate()
-    status = proc.poll()
-
-    if err:
-        print(err.decode(), file=sys.stderr)
-
-    if not out:
-        print(
-            'Error generating metadata in {} (status={})'.format(
-                project_shortname, status),
-            file=sys.stderr)
-        sys.exit(1)
-
-    jsondata_unicode = json.loads(out.decode(), object_pairs_hook=OrderedDict)
-
-    if sys.version_info[0] >= 3:
-        metadata = jsondata_unicode
-    else:
-        metadata = byteify(jsondata_unicode)
-
-    generator_methods = [generate_class_file]
-
-    if rprefix:
-        if not os.path.exists('man'):
-            os.makedirs('man')
-        if not os.path.exists('R'):
-            os.makedirs('R')
-        generator_methods.append(
-            functools.partial(write_class_file, prefix=prefix))
-
-    components = generate_classes_files(
-        project_shortname,
-        metadata,
-        *generator_methods
-    )
-
-    with open(os.path.join(project_shortname, 'metadata.json'), 'w') as f:
-        json.dump(metadata, f, indent=2)
-
-    generate_imports(project_shortname, components)
-
-    if rprefix:
-        with open('package.json', 'r') as f:
-            jsondata_unicode = json.load(f, object_pairs_hook=OrderedDict)
-            if sys.version_info[0] >= 3:
-                pkg_data = jsondata_unicode
-            else:
-                pkg_data = byteify(jsondata_unicode)
-
-        generate_exports(
-            project_shortname, components, metadata, pkg_data, prefix
-        )
 
 
 def cli():
@@ -134,27 +39,40 @@ def cli():
         help='Experimental: specify a prefix for DashR component names, write'
              'DashR components to R dir, create R package.'
     )
+    parser.add_argument(
+        '-d', '--dist',
+        default=False,
+        action='store_true',
+        help='Generate into /dist folder'
+    )
 
     args = parser.parse_args()
     generate_components(
-        args.components_source, args.project_shortname,
-        package_info_filename=args.package_info_filename,
+        args.components_source,
+        args.project_shortname,
+        args.package_info_filename,
         ignore=args.ignore,
-        rprefix=args.r_prefix)
+        r_prefix=args.r_prefix,
+        use_dist=args.dist)
 
 
-# pylint: disable=undefined-variable
-def byteify(input_object):
-    if isinstance(input_object, dict):
-        return OrderedDict([
-            (byteify(key), byteify(value))
-            for key, value in input_object.iteritems()
-        ])
-    elif isinstance(input_object, list):
-        return [byteify(element) for element in input_object]
-    elif isinstance(input_object, unicode):  # noqa:F821
-        return input_object.encode('utf-8')
-    return input_object
+def generate_components(
+    components_source,
+    project_shortname,
+    package_info_filename,
+    ignore='^_',
+    r_prefix=None,
+    use_dist=False
+):
+
+    metadata = extract_metadata(components_source, ignore)
+    project_shortname = project_shortname.replace('-', '_').rstrip('/\\')
+
+    dist_python = os.path.join('dist', 'python') if use_dist else os.path.join('')
+    dist_r = os.path.join('dist', 'R') if use_dist else os.path.join('')
+
+    py_generate(project_shortname, package_info_filename, metadata, dist_python)
+    r_generate(project_shortname, metadata, r_prefix, dist_r)
 
 
 if __name__ == '__main__':

--- a/dash/development/component_loader.py
+++ b/dash/development/component_loader.py
@@ -2,12 +2,7 @@ import collections
 import json
 import os
 
-from ._py_components_generation import (
-    generate_class_file,
-    generate_imports,
-    generate_classes_files,
-    generate_class
-)
+from ._py_components_generation import generate_class
 from .base_component import ComponentRegistry
 
 
@@ -62,31 +57,3 @@ def load_components(metadata_path,
         components.append(component)
 
     return components
-
-
-def generate_classes(namespace, metadata_path='lib/metadata.json'):
-    """Load React component metadata into a format Dash can parse,
-    then create python class files.
-
-    Usage: generate_classes()
-
-    Keyword arguments:
-    namespace -- name of the generated python package (also output dir)
-
-    metadata_path -- a path to a JSON file created by
-    [`react-docgen`](https://github.com/reactjs/react-docgen).
-
-    Returns:
-    """
-
-    data = _get_metadata(metadata_path)
-    imports_path = os.path.join(namespace, '_imports_.py')
-
-    # Make sure the file doesn't exist, as we use append write
-    if os.path.exists(imports_path):
-        os.remove(imports_path)
-
-    components = generate_classes_files(namespace, data, generate_class_file)
-
-    # Add the __all__ value so we can import * from _imports_
-    generate_imports(namespace, components)

--- a/dash/development/plugins/R/generate.py
+++ b/dash/development/plugins/R/generate.py
@@ -1,0 +1,64 @@
+import os
+
+from ..helpers import (
+    compile,
+    get_package_data
+)
+
+from ..._r_components_generation import (
+    generate_description as description_and_help_generator,
+    generate_js_metadata as metadata_generator
+)
+
+from .generators import (
+    component_adapters,
+    component_help,
+    description,
+    global_help,
+    internal,
+    namespace,
+    js_artefacts,
+    license,
+
+    get_license
+)
+
+def compile_zip(project_shortname, metadata, compiler):
+    components, results = compile(project_shortname, metadata, compiler)
+
+    return zip(components, results)
+
+def generate(project_shortname, metadata, prefix, root):
+    if not prefix:
+        return
+
+    man_path = os.path.join(root, 'man')
+    r_path = os.path.join(root, 'R')
+    inst_deps_path = os.path.join(root, 'inst/deps')
+
+    if not os.path.exists(r_path):
+        os.makedirs(r_path)
+
+    if not os.path.exists(man_path):
+        os.makedirs(man_path)
+
+    if not os.path.exists(inst_deps_path):
+        os.makedirs(inst_deps_path)
+
+    package_data = get_package_data()
+    package_license = get_license(package_data, root)
+
+    bound_compile = lambda compiler: compile_zip(project_shortname, metadata, compiler)
+    get_description = lambda: description_and_help_generator(package_data, project_shortname, package_license)[0]
+    get_help = lambda: description_and_help_generator(package_data, project_shortname, package_license)[1]
+    get_internal = lambda: metadata_generator(package_data, project_shortname)
+    get_package_name = lambda: description_and_help_generator(package_data, project_shortname, package_license)[2]
+
+    component_adapters(bound_compile, prefix, r_path)
+    component_help(bound_compile, prefix, man_path)
+    description(get_description, root)
+    global_help(get_help, get_package_name, man_path)
+    internal(get_internal, root)
+    js_artefacts('dist/js', inst_deps_path)
+    license(package_data, root)
+    namespace(bound_compile, prefix, root)

--- a/dash/development/plugins/R/generate.py
+++ b/dash/development/plugins/R/generate.py
@@ -58,7 +58,7 @@ def generate(project_shortname, metadata, prefix, root):
     component_help(bound_compile, prefix, man_path)
     description(get_description, root)
     global_help(get_help, get_package_name, man_path)
-    internal(get_internal, root)
+    internal(get_internal, r_path)
     js_artefacts('dist/js', inst_deps_path)
     license(package_data, root)
     namespace(bound_compile, prefix, root)

--- a/dash/development/plugins/R/generators.py
+++ b/dash/development/plugins/R/generators.py
@@ -1,3 +1,4 @@
+import functools
 import os
 import shutil
 
@@ -12,13 +13,17 @@ from ..._r_components_generation import (
 from ..helpers import glob_js
 
 def component_adapters(compile, prefix, path):
-    for component, adapter in compile(adapter_compiler):
+    decorated_adapter_compiler = functools.partial(adapter_compiler, prefix=prefix)
+
+    for component, adapter in compile(decorated_adapter_compiler):
         component_path = os.path.join(path, '{}{}.R'.format(prefix, component))
         with open(component_path, 'w') as f:
             f.write(adapter)
 
 def component_help(compile, prefix, path):
-    for component, wrapper in compile(help_generator):
+    decorated_help_generator = functools.partial(help_generator, prefix=prefix)
+
+    for component, wrapper in compile(decorated_help_generator):
         component_path = os.path.join(path, '{}{}.Rd'.format(prefix, component))
         with open(component_path, 'w') as f:
             f.write(wrapper)
@@ -52,7 +57,7 @@ def js_artefacts(source, target):
 def license(package_data, path):
     license_path = get_license_path(path)
 
-    if has_license(path):
+    if has_license(path) and license_path != 'LICENSE':
         shutil.copyfile('LICENSE', license_path)
 
 def namespace(compile, prefix, path):

--- a/dash/development/plugins/R/generators.py
+++ b/dash/development/plugins/R/generators.py
@@ -1,0 +1,87 @@
+import os
+import shutil
+
+from ..._all_keywords import r_keywords
+
+from ..._r_components_generation import (
+    generate_component_wrapper as adapter_compiler,
+    generate_description as description_generator,
+    generate_help_file as help_generator
+)
+
+from ..helpers import glob_js
+
+def component_adapters(compile, prefix, path):
+    for component, adapter in compile(adapter_compiler):
+        component_path = os.path.join(path, '{}{}.R'.format(prefix, component))
+        with open(component_path, 'w') as f:
+            f.write(adapter)
+
+def component_help(compile, prefix, path):
+    for component, wrapper in compile(help_generator):
+        component_path = os.path.join(path, '{}{}.Rd'.format(prefix, component))
+        with open(component_path, 'w') as f:
+            f.write(wrapper)
+
+def description(get_description, path):
+    description = get_description()
+
+    desription_path = os.path.join(path, 'DESCRIPTION')
+    with open(desription_path, 'w') as f:
+        f.write(description)
+
+def global_help(get_help, get_package_name, path):
+    help = get_help()
+    package_name = get_package_name()
+
+    if help is not None:
+        package_help_path = os.path.join(path, '{}-package.Rd'.format(package_name))
+        with open(package_help_path, 'w') as f:
+            f.write(help)
+
+def internal(get_internal, path):
+    internal_path = os.path.join(path, 'internal.R')
+    internal = get_internal()
+
+    with open(internal_path, 'w') as f:
+        f.write(internal)
+
+def js_artefacts(source, target):
+    glob_js(source, target)
+
+def license(package_data, path):
+    license_path = get_license_path(path)
+
+    if has_license(path):
+        shutil.copyfile('LICENSE', license_path)
+
+def namespace(compile, prefix, path):
+    import_string = '# AUTO GENERATED FILE - DO NOT EDIT\n\n'
+    export_string = ''
+
+    for component, none in compile(None):
+        if not component.endswith('-*') and \
+                str(component) not in r_keywords and \
+                str(component) not in ['setProps', 'children', 'dashEvents']:
+            export_string += 'export({}{})\n'.format(prefix, component)
+
+    namespace_path = os.path.join(path, 'NAMESPACE')
+    with open(namespace_path, 'w') as f:
+        f.write(import_string)
+        f.write(export_string)
+
+def get_license_path(path):
+    return os.path.join(path, 'LICENSE')
+
+def get_license(package_data, path):
+    license_path = get_license_path(path)
+
+    result = package_data.get('license', '')
+    if has_license(path):
+        result = result + ' + file LICENSE'
+
+    return result
+
+def has_license(path):
+    license_path = get_license_path(path)
+    return os.path.isfile(license_path) or os.path.isfile('LICENSE')

--- a/dash/development/plugins/helpers.py
+++ b/dash/development/plugins/helpers.py
@@ -1,0 +1,92 @@
+from collections import OrderedDict
+import glob
+import json
+import os
+import pkg_resources
+import shlex
+import shutil
+import subprocess
+import sys
+
+# pylint: disable=undefined-variable
+def byteify(input_object):
+    if isinstance(input_object, dict):
+        return OrderedDict([
+            (byteify(key), byteify(value))
+            for key, value in input_object.iteritems()
+        ])
+    elif isinstance(input_object, list):
+        return [byteify(element) for element in input_object]
+    elif isinstance(input_object, unicode):  # noqa:F821
+        return input_object.encode('utf-8')
+    return input_object
+
+def compile(project_shortname, metadata, compiler):
+    components = []
+    results = []
+    for component_path, component_data in metadata.items():
+        component_name = component_path.split('/')[-1].split('.')[0]
+        components.append(component_name)
+
+        results.append(
+            compiler(
+                component_name,
+                component_data['props'],
+                component_data['description'],
+                project_shortname
+            ) if compiler is not None else None
+        )
+
+    return components, results
+
+def extract_metadata(components_source, ignore):
+    extract_path = pkg_resources.resource_filename('dash', 'extract-meta.js')
+    is_windows = sys.platform == 'win32'
+
+    os.environ['NODE_PATH'] = 'node_modules'
+    cmd = shlex.split(
+        'node {} {} {}'.format(extract_path, ignore, components_source),
+        posix=not is_windows
+    )
+
+    proc = subprocess.Popen(cmd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            shell=is_windows)
+    out, err = proc.communicate()
+    status = proc.poll()
+
+    if err:
+        print(err.decode(), file=sys.stderr)
+
+    if not out:
+        print(
+            'Error generating metadata in {} (status={})'.format(
+                project_shortname, status),
+            file=sys.stderr)
+        sys.exit(1)
+
+    jsondata_unicode = json.loads(out.decode(), object_pairs_hook=OrderedDict)
+
+    if sys.version_info[0] >= 3:
+        metadata = jsondata_unicode
+    else:
+        metadata = byteify(jsondata_unicode)
+
+    return metadata
+
+def get_package_data():
+    with open('package.json', 'r') as f:
+        jsondata_unicode = json.load(f, object_pairs_hook=OrderedDict)
+
+    return jsondata_unicode if sys.version_info[0] >= 3 else byteify(jsondata_unicode)
+
+def glob_js(source, target):
+    for javascript in glob.glob(source + '/*.js'):
+        shutil.copy(javascript, target)
+
+    for css in glob.glob(source + '{}/*.css'):
+        shutil.copy(css, target)
+
+    for sourcemap in glob.glob(source + '/*.map'):
+        shutil.copy(sourcemap, target)

--- a/dash/development/plugins/python/generate.py
+++ b/dash/development/plugins/python/generate.py
@@ -1,0 +1,62 @@
+import json
+import os
+import shutil
+
+from ..helpers import (
+    compile,
+    get_package_data,
+    glob_js
+)
+
+from ..._py_components_generation import (
+    generate_component_wrapper as adapter_compiler,
+    generate_imports as py_generate_imports
+)
+
+def generate(project_shortname, package_info_filename, metadata, root):
+    # Python Generation -- Version
+    module_path = os.path.join(root, project_shortname)
+    version_path = os.path.join(module_path, 'version.py')
+
+    package_data = get_package_data()
+    version = package_data['version'].replace(' ', '_').replace('-', '_')
+
+    with open(version_path, 'w') as f:
+        f.write('__version__ = \'{}\''.format(version))
+
+    package_target = os.path.join(root, package_info_filename)
+
+    if package_target != 'package.json':
+        shutil.copyfile(
+            'package.json',
+            package_target
+        )
+
+    # Python Generation -- Metadata
+    metadata_path = os.path.join(module_path, 'metadata.json')
+
+    with open(metadata_path, 'w') as f:
+        json.dump(metadata, f, indent=2)
+
+    if root != '':
+        shutil.copyfile('LICENSE', os.path.join(root, 'LICENSE'))
+        shutil.copyfile('README.md', os.path.join(root, 'README.md'))
+
+    # Python Generation -- Component Wrappers
+    bound_compile = lambda compiler: compile(project_shortname, metadata, compiler)
+
+    components, wrappers = bound_compile(adapter_compiler)
+
+    for component, wrapper in zip(components, wrappers):
+        component_path = os.path.join(module_path, '{}.py'.format(component))
+        with open(component_path, 'w') as f:
+            f.write(wrapper)
+
+    # Python Generation -- Imports
+    imports = py_generate_imports(project_shortname, components)
+    imports_path = os.path.join(module_path, '_imports_.py')
+
+    with open(imports_path, 'w') as f:
+        f.write(imports)
+
+    glob_js('dist/js', module_path)


### PR DESCRIPTION
Very much a work in progress. Not attempting to rewrite all the generation, just to provide some level of abstraction between the generation and the file structure through parametrization + isolating package building from the nitty-gritty of the generation of the various parts. So a good portion of what is happening here is moving `with open(...) as f:` higher up the stack.

- support building R and Python artefacts to arbitrary folder (dist/<flavor>) folders  (`--dist` flag)
- untie R and Python build implementations
- use `root` folder otherwise if `--dist` is not present

- [ ] meta file for js artefacts (will untie R from Python)
- [ ] meta file for name/description/etc. -- can default to package.json -- untie ourselves from the pacakge.json entirely at some point