### PR TITLE
Props blacklist

### DIFF
--- a/dash/CHANGELOG.md
+++ b/dash/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 ### Changed
+- [#753](https://github.com/plotly/dash/pull/753) `Component` no longer inherits `MutableMapping`, so `values`, `keys`, and more are no longer methods. This fixed an issue reported in [dcc](https://github.com/plotly/dash-core-components/issues/440) where components with certain prop names defined but not provided would cause a failure to render. During component generation we now disallow all props with leading underscores or matching a few remaining reserved words: `UNDEFINED`, `REQUIRED`, `to_plotly_json`, `available_properties`, and `available_wildcard_properties`.
+
 - [#739](https://github.com/plotly/dash/pull/739) Allow the Flask app to be provided to Dash after object initialization. This allows users to define Dash layouts etc when using the app factory pattern, or any other pattern that inhibits access to the app object. This broadly complies with the flask extension API, allowing Dash to be considered as a Flask extension where it needs to be.
 
 - [#722](https://github.com/plotly/dash/pull/722) Assets are served locally by default. Both JS scripts and CSS files are affected. This improves robustness and flexibility in numerous situations, but in certain cases initial loading could be slowed. To restore the previous CDN serving, set `app.scripts.config.serve_locally = False` (and similarly with `app.css`, but this is generally less important).

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -914,6 +914,7 @@ class Dash(object):
         def _validate_value(val, index=None):
             # val is a Component
             if isinstance(val, Component):
+                # pylint: disable=protected-access
                 for p, j in val._traverse_with_paths():
                     # check each component value in the tree
                     if not _value_is_valid(j):
@@ -1194,6 +1195,7 @@ class Dash(object):
         layout_id = getattr(self.layout, 'id', None)
 
         component_ids = {layout_id} if layout_id else set()
+        # pylint: disable=protected-access
         for component in to_validate._traverse():
             component_id = getattr(component, 'id', None)
             if component_id and component_id in component_ids:

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -914,7 +914,7 @@ class Dash(object):
         def _validate_value(val, index=None):
             # val is a Component
             if isinstance(val, Component):
-                for p, j in val.traverse_with_paths():
+                for p, j in val._traverse_with_paths():
                     # check each component value in the tree
                     if not _value_is_valid(j):
                         _raise_invalid(
@@ -1194,7 +1194,7 @@ class Dash(object):
         layout_id = getattr(self.layout, 'id', None)
 
         component_ids = {layout_id} if layout_id else set()
-        for component in to_validate.traverse():
+        for component in to_validate._traverse():
             component_id = getattr(component, 'id', None)
             if component_id and component_id in component_ids:
                 raise exceptions.DuplicateIdError(

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -224,6 +224,7 @@ class Component(object):
         # children is just a component
         if isinstance(children, Component):
             yield "[*] " + children_string, children
+            # pylint: disable=protected-access
             for p, t in children._traverse_with_paths():
                 yield "\n".join(["[*] " + children_string, p]), t
 
@@ -238,6 +239,7 @@ class Component(object):
                 yield list_path, i
 
                 if isinstance(i, Component):
+                    # pylint: disable=protected-access
                     for p, t in i._traverse_with_paths():
                         yield "\n".join([list_path, p]), t
 

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -59,7 +59,7 @@ def _check_if_has_indexable_children(item):
 
 
 @six.add_metaclass(ComponentMeta)
-class Component(patch_collections_abc('MutableMapping')):
+class Component(object):
     class _UNDEFINED(object):
         def __repr__(self):
             return 'undefined'
@@ -184,7 +184,7 @@ class Component(patch_collections_abc('MutableMapping')):
         # If we were in a list, then this exception will get caught
         raise KeyError(id)
 
-    # Supply ABC methods for a MutableMapping:
+    # Magic methods for a mapping interface:
     # - __getitem__
     # - __setitem__
     # - __delitem__

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -208,12 +208,12 @@ class Component(object):
         """Delete items by ID in the tree of children."""
         return self._get_set_or_delete(id, 'delete')
 
-    def traverse(self):
+    def _traverse(self):
         """Yield each item in the tree."""
-        for t in self.traverse_with_paths():
+        for t in self._traverse_with_paths():
             yield t[1]
 
-    def traverse_with_paths(self):
+    def _traverse_with_paths(self):
         """Yield each item with its path in the tree."""
         children = getattr(self, 'children', None)
         children_type = type(children).__name__
@@ -224,7 +224,7 @@ class Component(object):
         # children is just a component
         if isinstance(children, Component):
             yield "[*] " + children_string, children
-            for p, t in children.traverse_with_paths():
+            for p, t in children._traverse_with_paths():
                 yield "\n".join(["[*] " + children_string, p]), t
 
         # children is a list of components
@@ -238,12 +238,12 @@ class Component(object):
                 yield list_path, i
 
                 if isinstance(i, Component):
-                    for p, t in i.traverse_with_paths():
+                    for p, t in i._traverse_with_paths():
                         yield "\n".join([list_path, p]), t
 
     def __iter__(self):
         """Yield IDs in the tree of children."""
-        for t in self.traverse():
+        for t in self._traverse():
             if (isinstance(t, Component) and
                     getattr(t, 'id', None) is not None):
 

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -19,12 +19,13 @@ from ._py_components_generation import generate_imports
 from ._py_components_generation import generate_classes_files
 
 
-forbidden_props = [
+reserved_words = [
     'UNDEFINED',
     'REQUIRED',
     'to_plotly_json',
     'available_properties',
-    'available_wildcard_properties'
+    'available_wildcard_properties',
+    '_.*'
 ]
 
 
@@ -56,14 +57,12 @@ def generate_components(
 
     extract_path = pkg_resources.resource_filename("dash", "extract-meta.js")
 
-    forbid_patterns = '|'.join(
-        '^{}$'.format(p) for p in forbidden_props + ['_.*']
-    )
+    reserved_patterns = '|'.join('^{}$'.format(p) for p in reserved_words)
 
     os.environ["NODE_PATH"] = "node_modules"
     cmd = shlex.split(
         "node {} {} {} {}".format(
-            extract_path, ignore, forbid_patterns, components_source
+            extract_path, ignore, reserved_patterns, components_source
         ),
         posix=not is_windows,
     )

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -19,6 +19,15 @@ from ._py_components_generation import generate_imports
 from ._py_components_generation import generate_classes_files
 
 
+forbidden_props = [
+    'UNDEFINED',
+    'REQUIRED',
+    'to_plotly_json',
+    'available_properties',
+    'available_wildcard_properties'
+]
+
+
 class _CombinedFormatter(
         argparse.ArgumentDefaultsHelpFormatter,
         argparse.RawDescriptionHelpFormatter
@@ -47,9 +56,15 @@ def generate_components(
 
     extract_path = pkg_resources.resource_filename("dash", "extract-meta.js")
 
+    forbid_patterns = '|'.join(
+        '^{}$'.format(p) for p in forbidden_props + ['_.*']
+    )
+
     os.environ["NODE_PATH"] = "node_modules"
     cmd = shlex.split(
-        "node {} {} {}".format(extract_path, ignore, components_source),
+        "node {} {} {} {}".format(
+            extract_path, ignore, forbid_patterns, components_source
+        ),
         posix=not is_windows,
     )
 
@@ -138,8 +153,8 @@ def cli():
         "-p",
         "--package-info-filename",
         default="package.json",
-        help="The filename of the copied `package.json` \
-to `project_shortname`",
+        help="The filename of the copied `package.json` "
+        "to `project_shortname`",
     )
     parser.add_argument(
         "-i",

--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -6,7 +6,7 @@ const reactDocs = require('react-docgen');
 
 const componentPaths = process.argv.slice(4);
 const ignorePattern = new RegExp(process.argv[2]);
-const forbiddenProps = process.argv[3].split('|').map(part => new RegExp(part));
+const reservedPatterns = process.argv[3].split('|').map(part => new RegExp(part));
 
 let failed = false;
 
@@ -65,11 +65,11 @@ function docstringWarning(doc) {
 
 function propError(doc) {
     for(const propName in doc.props) {
-        forbiddenProps.forEach(forbiddenPattern => {
-            if (forbiddenPattern.test(propName)) {
+        reservedPatterns.forEach(reservedPattern => {
+            if (reservedPattern.test(propName)) {
                 process.stderr.write(
-                    `\nERROR: "${propName}" matches forbidden prop name ` +
-                    `pattern: ${forbiddenPattern.toString()}\n`
+                    `\nERROR: "${propName}" matches reserved word ` +
+                    `pattern: ${reservedPattern.toString()}\n`
                 );
                 failed = true;
             }

--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -4,8 +4,11 @@ const fs = require('fs');
 const path = require('path');
 const reactDocs = require('react-docgen');
 
-const componentPaths = process.argv.slice(3);
+const componentPaths = process.argv.slice(4);
 const ignorePattern = new RegExp(process.argv[2]);
+const forbiddenProps = process.argv[3].split('|').map(part => new RegExp(part));
+
+let failed = false;
 
 const excludedDocProps = [
     'setProps', 'id', 'className', 'style'
@@ -20,13 +23,18 @@ const metadata = Object.create(null);
 componentPaths.forEach(componentPath =>
     collectMetadataRecursively(componentPath)
 );
-writeOut(metadata);
+if (failed) {
+    console.error('\nextract-meta failed.\n');
+}
+else {
+    writeOut(metadata);
+}
 
 function help() {
     console.error('usage: ');
     console.error(
-        'extract-meta path/to/component(s) ' +
-            ' [path/to/more/component(s), ...] > metadata.json'
+        'extract-meta ^fileIgnorePattern ^forbidden$|^props$|^patterns$' +
+        ' path/to/component(s) [path/to/more/component(s) ...] > metadata.json'
     );
 }
 
@@ -55,6 +63,20 @@ function docstringWarning(doc) {
     );
 }
 
+function propError(doc) {
+    for(const propName in doc.props) {
+        forbiddenProps.forEach(forbiddenPattern => {
+            if (forbiddenPattern.test(propName)) {
+                process.stderr.write(
+                    `\nERROR: "${propName}" matches forbidden prop name ` +
+                    `pattern: ${forbiddenPattern.toString()}\n`
+                );
+                failed = true;
+            }
+        });
+    }
+}
+
 
 function parseFile(filepath) {
     const urlpath = filepath.split(path.sep).join('/');
@@ -68,6 +90,7 @@ function parseFile(filepath) {
         src = fs.readFileSync(filepath);
         const doc = metadata[urlpath] = reactDocs.parse(src);
         docstringWarning(doc);
+        propError(doc);
     } catch (error) {
         writeError(error, filepath);
     }

--- a/tests/unit/dash/development/test_base_component.py
+++ b/tests/unit/dash/development/test_base_component.py
@@ -150,7 +150,7 @@ class TestComponent(unittest.TestCase):
 
     def test_traverse_with_nested_children_with_mixed_strings_and_without_lists(self):  # noqa: E501
         c, c1, c2, c3, c4, c5 = nested_tree()
-        elements = [i for i in c.traverse()]
+        elements = [i for i in c._traverse()]
         self.assertEqual(
             elements,
             c.children + [c3] + [c2] + c2.children
@@ -160,7 +160,7 @@ class TestComponent(unittest.TestCase):
         c, c1, c2, c3, c4, c5 = nested_tree()
         c2.children = tuple(c2.children)
         c.children = tuple(c.children)
-        elements = [i for i in c.traverse()]
+        elements = [i for i in c._traverse()]
         self.assertEqual(
             elements,
             list(c.children) + [c3] + [c2] + list(c2.children)

--- a/tests/unit/dash/development/test_base_component.py
+++ b/tests/unit/dash/development/test_base_component.py
@@ -16,6 +16,8 @@ from dash.development._py_components_generation import (
     js_to_py_type
 )
 
+_dir = os.path.dirname(os.path.abspath(__file__))
+
 Component._prop_names = ('id', 'a', 'children', 'style', )
 Component._type = 'TestComponent'
 Component._namespace = 'test_namespace'
@@ -487,8 +489,7 @@ class TestComponent(unittest.TestCase):
 
 class TestGenerateClassFile(unittest.TestCase):
     def setUp(self):
-        json_path = os.path.join(
-            'tests', 'unit', 'dash', 'development', 'metadata_test.json')
+        json_path = os.path.join(_dir, 'metadata_test.json')
         with open(json_path) as data_file:
             json_string = data_file.read()
             data = json\
@@ -527,9 +528,7 @@ class TestGenerateClassFile(unittest.TestCase):
             self.written_class_string = f.read()
 
         # The expected result for both class string and class file generation
-        expected_string_path = os.path.join(
-            'tests', 'unit', 'dash', 'development', 'metadata_test.py'
-        )
+        expected_string_path = os.path.join(_dir, 'metadata_test.py')
         with open(expected_string_path, 'r') as f:
             self.expected_class_string = f.read()
 
@@ -557,8 +556,7 @@ class TestGenerateClassFile(unittest.TestCase):
 
 class TestGenerateClass(unittest.TestCase):
     def setUp(self):
-        path = os.path.join(
-            'tests', 'unit', 'dash', 'development', 'metadata_test.json')
+        path = os.path.join(_dir, 'metadata_test.json')
         with open(path) as data_file:
             json_string = data_file.read()
             data = json\
@@ -573,10 +571,7 @@ class TestGenerateClass(unittest.TestCase):
             namespace='TableComponents'
         )
 
-        path = os.path.join(
-            'tests', 'unit', 'dash', 'development',
-            'metadata_required_test.json'
-        )
+        path = os.path.join(_dir, 'metadata_required_test.json')
         with open(path) as data_file:
             json_string = data_file.read()
             required_data = json\
@@ -746,8 +741,7 @@ class TestGenerateClass(unittest.TestCase):
 
 class TestMetaDataConversions(unittest.TestCase):
     def setUp(self):
-        path = os.path.join(
-            'tests', 'unit', 'dash', 'development', 'metadata_test.json')
+        path = os.path.join(_dir, 'metadata_test.json')
         with open(path) as data_file:
             json_string = data_file.read()
             data = json\
@@ -930,8 +924,7 @@ def assert_docstring(assertEqual, docstring):
 
 class TestFlowMetaDataConversions(unittest.TestCase):
     def setUp(self):
-        path = os.path.join(
-            'tests', 'unit', 'dash', 'development', 'flow_metadata_test.json')
+        path = os.path.join(_dir, 'flow_metadata_test.json')
         with open(path) as data_file:
             json_string = data_file.read()
             data = json\

--- a/tests/unit/dash/development/test_base_component.py
+++ b/tests/unit/dash/development/test_base_component.py
@@ -469,23 +469,23 @@ class TestComponent(unittest.TestCase):
                   'setdefault', 'update', 'values']
 
         for m in mixins:
-            self.assertFalse(hasattr(c, m), m)
+            assert not hasattr(c, m), 'should not have method ' + m
 
         keys = ['2', '3', '4', '5', '6', '7', '8']
 
         for k in keys:
             # test __contains__()
-            self.assertTrue(k in c)
+            assert k in c, 'should find key ' + k
             # test __getitem__()
-            self.assertEqual(c[k].id, k)
+            assert c[k].id == k, 'key {} points to the right item'.format(k)
 
         # test __iter__()
         keys2 = []
         for k in c:
             keys2.append(k)
-            self.assertIn(k, keys)
+            assert k in keys, 'iteration produces key ' + k
 
-        self.assertEqual(len(keys), len(keys2))
+        assert len(keys) == len(keys2), 'iteration produces no extra keys'
 
 
 class TestGenerateClassFile(unittest.TestCase):
@@ -745,16 +745,17 @@ class TestGenerateClass(unittest.TestCase):
         c = self.ComponentClass()
         base_attrs = dir(c)
         extra_attrs = [a for a in base_attrs if a[0] != '_']
-        self.assertEqual(set(extra_attrs), set(forbidden_props + ['children']))
+        assert set(extra_attrs) == set(forbidden_props + ['children']), \
+            'component has only underscored and reserved word attrs'
 
         # setting props causes them to show up as attrs
         c2 = self.ComponentClass('children', id='c2', optionalArray=[1])
         prop_attrs = dir(c2)
-        self.assertEqual(set(base_attrs) - set(prop_attrs), set([]))
-        self.assertEqual(
-            set(prop_attrs) - set(base_attrs),
-            set(['id', 'optionalArray'])
-        )
+        assert set(base_attrs) - set(prop_attrs) == set([]), \
+            'no attrs were removed'
+        assert (
+            set(prop_attrs) - set(base_attrs) == set(['id', 'optionalArray'])
+        ), 'explicit props were added as attrs'
 
 
 class TestMetaDataConversions(unittest.TestCase):

--- a/tests/unit/dash/development/test_base_component.py
+++ b/tests/unit/dash/development/test_base_component.py
@@ -7,6 +7,7 @@ import unittest
 import plotly
 
 from dash.development.base_component import Component
+from dash.development.component_generator import forbidden_props
 from dash.development._py_components_generation import (
     generate_class_string,
     generate_class_file,
@@ -737,6 +738,23 @@ class TestGenerateClass(unittest.TestCase):
             self.ComponentClassRequired(id='test', lahlah='test')
         with self.assertRaises(Exception):
             self.ComponentClassRequired(children='test')
+
+    def test_attrs_match_forbidden_props(self):
+        # props are not added as attrs unless explicitly provided
+        # except for children, which is always set if it's a prop at all.
+        c = self.ComponentClass()
+        base_attrs = dir(c)
+        extra_attrs = [a for a in base_attrs if a[0] != '_']
+        self.assertEqual(set(extra_attrs), set(forbidden_props + ['children']))
+
+        # setting props causes them to show up as attrs
+        c2 = self.ComponentClass('children', id='c2', optionalArray=[1])
+        prop_attrs = dir(c2)
+        self.assertEqual(set(base_attrs) - set(prop_attrs), set([]))
+        self.assertEqual(
+            set(prop_attrs) - set(base_attrs),
+            set(['id', 'optionalArray'])
+        )
 
 
 class TestMetaDataConversions(unittest.TestCase):


### PR DESCRIPTION
Fixes https://github.com/plotly/dash-core-components/issues/440

Pares down the attributes of dash component classes on the Python side by doing two things:
- Remove the `MutableMapping` inheritance - we weren't using any of the mixins from that class anyway, except in tests. This stops setting attributes: `clear`, `get`, `items`, `keys`, `pop`, `popitem`, `setdefault`, `update`, `values` - all of these are now allowable as prop names. We still set the magic methods of the mapping interface.
- Prefix a couple of other methods (`traverse` and `traverse_with_paths`) with underscores, so these are allowable as well.

Then what's left we blacklist: during `extract-meta`, if any prop has a leading underscore or matches one of the remaining disallowed names, we fail (not just print a warning) and refuse to generate the python file. The names we forbid are:
- `UNDEFINED`
- `REQUIRED`
- `to_plotly_json`
- `available_properties`
- `available_wildcard_properties`

These are all used within generated components, or (in the case of `to_plotly_json`) in other packages, so it would be difficult to allow these without forcing all packages to be rebuilt. Fortunately I don't see these as particularly valuable prop names (unlike, say, `values`, `items`, and some of the other `MutableMapping` methods)

Error messages look like:
```
ERROR: "_foo" matches forbidden prop name pattern: /^_.*$/

extract-meta failed.


Error generating metadata in dash_core_components (status=0)
npm ERR! code ELIFECYCLE
npm ERR! errno 1
...
```

- [X] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
- [x] I have added entry in the `CHANGELOG.md`