### PR TITLE
chore: unnecessary string

### DIFF
--- a/dash-renderer/src/APIController.react.js
+++ b/dash-renderer/src/APIController.react.js
@@ -102,7 +102,7 @@ class UnconnectedContainer extends Component {
             layoutRequest.status &&
             !contains(layoutRequest.status, [STATUS.OK, 'loading'])
         ) {
-            return <div className="_dash-error">{'Error loading layout'}</div>;
+            return <div className="_dash-error">Error loading layout</div>;
         } else if (
             errorLoading ||
             (dependenciesRequest.status &&


### PR DESCRIPTION
```js
            return <div className="_dash-error">Error loading layout</div>;
```

is better than 

```js
            return <div className="_dash-error">{'Error loading layout'}</div>;
```

*Start with a description of this PR. Then edit the list below to the items that make sense for your PR scope, and check off the boxes as you go!*

## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](../CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow
    -  [ ] this github [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in plotly dash community 
