### PR TITLE
Replace dashR with dash in R package generation code

### DIFF
--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -217,7 +217,8 @@ def generate_class_string(name, props, project_shortname, prefix):
 def generate_js_metadata(pkg_data, project_shortname):
     """
     Dynamically generate R function to supply JavaScript
-    and CSS dependency information required by dash package.
+    and CSS dependency information required by the dash
+    package for R.
 
     Parameters
     ----------

--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -30,7 +30,6 @@ r_component_string = """{funcname} <- function({default_argtext}{wildcards}) {{
 
     structure(component, class = c('dash_component', 'list'))
 }}
-
 """  # noqa:E501
 
 # the following strings represent all the elements in an object
@@ -56,7 +55,6 @@ all_files = FALSE), class = "html_dependency")"""  # noqa:E501
 frame_close_template = """)
 return(deps_metadata)
 }
-
 """
 
 help_string = """% Auto-generated: do not edit by hand
@@ -77,7 +75,6 @@ help_string = """% Auto-generated: do not edit by hand
 \\arguments{{
 {item_text}
 }}
-
 """
 
 description_template = """Package: {package_name}
@@ -146,7 +143,6 @@ Useful links:
 \\author{{
 \\strong{{Maintainer}}: {package_author}
 }}
-
 """
 
 

--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -86,7 +86,7 @@ Version: {package_version}
 Authors @R: as.person(c({package_author}))
 Description: {package_description}
 Depends: R (>= 3.0.2){package_depends}
-Imports: dashR{package_imports}
+Imports: dash{package_imports}
 Suggests: {package_suggests}
 License: {package_license}
 URL: {package_url}
@@ -221,7 +221,7 @@ def generate_class_string(name, props, project_shortname, prefix):
 def generate_js_metadata(pkg_data, project_shortname):
     """
     Dynamically generate R function to supply JavaScript
-    and CSS dependency information required by dashR package.
+    and CSS dependency information required by dash package.
 
     Parameters
     ----------
@@ -405,7 +405,7 @@ def write_class_file(name,
 def write_js_metadata(pkg_data, project_shortname):
     """
     Write an internal (not exported) R function to return all JS
-    dependencies as required by dashR.
+    dependencies as required by dash.
 
     Parameters
     ----------
@@ -530,7 +530,7 @@ def generate_rpkg(
     pkghelp_stub_path = os.path.join("man", package_name + "-package.Rd")
 
     # generate the internal (not exported to the user) functions which
-    # supply the JavaScript dependencies to the dashR package.
+    # supply the JavaScript dependencies to the dash package.
     # this avoids having to generate an RData file from within Python.
     write_js_metadata(pkg_data=pkg_data, project_shortname=project_shortname)
 

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -165,8 +165,8 @@ def cli():
     )
     parser.add_argument(
         "--r-prefix",
-        help="Specify a prefix for DashR component names, write "
-        "DashR components to R dir, create R package.",
+        help="Specify a prefix for Dash for R component names, write "
+        "components to R dir, create R package.",
     )
     parser.add_argument(
         "--r-depends",


### PR DESCRIPTION
This PR proposes minor changes to the R package generation code, which will use the R package name `dash` in lieu of `dashR` going forward.