### PR TITLE
move & fix manifest, and typo in setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include README.md
 include LICENSE
-include requires-ci.txt
-include requires-install.txt
+include requires-*.txt
 include dash/favicon.ico
 include dash/extract-meta.js

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,6 @@
 include README.md
 include LICENSE
+include requires-ci.txt
+include requires-install.txt
 include dash/favicon.ico
 include dash/extract-meta.js

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     install_requires=read_req_file("install"),
-    extra_require={"ci": read_req_file("ci")},
+    extras_require={"ci": read_req_file("ci")},
     entry_points={
         "console_scripts": [
             "dash-generate-components ="


### PR DESCRIPTION
To run `setup.py sdist` and get a tarball that's usable out of the box