### PR TITLE
Added send keys function to dash.testing

### DIFF
--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -301,6 +301,14 @@ class Browser(DashPageMixin):
             .send_keys(Keys.DELETE)
         ).perform()
 
+    def send_key_input(self, elem, key_input):
+        """send key input to an input"""
+        (
+            ActionChains(self.driver)
+            .click(elem)
+            .send_keys(key_input)
+        ).perform()
+
     def get_logs(self):
         """return a list of `SEVERE` level logs after last reset time stamps
         (default to 0, resettable by `reset_log_timestamp`. Chrome only

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -301,13 +301,9 @@ class Browser(DashPageMixin):
             .send_keys(Keys.DELETE)
         ).perform()
 
-    def send_key_input(self, elem, key_input):
-        """send key input to an input"""
-        (
-            ActionChains(self.driver)
-            .click(elem)
-            .send_keys(key_input)
-        ).perform()
+    def send_keys(self, selector, keys):
+        """send keys to an input"""
+        self.find_element(selector).send_keys(keys)
 
     def get_logs(self):
         """return a list of `SEVERE` level logs after last reset time stamps

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -46,7 +46,7 @@ def test_inin001_simple_callback(dash_duo):
 
     input1 = dash_duo.find_element('#input')
     dash_duo.clear_input(input1)
-    input1.send_keys('hello world')
+    dash_duo.send_keys('#input', 'hello world')
 
     dash_duo.wait_for_text_to_equal('#output-1', 'hello world')
     dash_duo.percy_snapshot(name='simple-callback-2')
@@ -139,8 +139,8 @@ def test_inin003_aborted_callback(dash_duo):
 
     dash_duo.start_server(app)
 
-    input_ = dash_duo.find_element('#input')
-    input_.send_keys('xyz')
+    dash_duo.find_element('#input')
+    dash_duo.send_keys('#input', 'xyz')
     dash_duo.wait_for_text_to_equal('#input', 'initial inputxyz')
 
     until(


### PR DESCRIPTION
**Problem**
Currently, dash.testing has [clear_input](https://github.com/plotly/dash/blob/149a8e853f7c94df55cd75c1735bec97717ae746/dash/testing/browser.py#L292) function which does
1. Click input box
2. Clear text

But, there's no function to input text to an input.
Adding such function would increase usability.

**Solution**

I have added a function to `dash/dash/testing/browser.py`

I know that we can do the same thing like...

```py
    input1 = dash_duo.find_element('#input')
    input1.send_keys('hello world')
```

And my way would be...

```py
    input1 = dash_duo.find_element('#input')
    dash_duo.send_key_input(input1, 'hello world')
```

I suppose, my way would make explanation and documenting easier.

# Tests
I haven't add tests as I could not figure out how. 
1. Deleting current way and replace them my new way.
2. Add my test code somewhere.

Which would be better?

*Start with a description of this PR. Then edit the list below to the items that make sense for your PR scope, and check off the boxes as you go!*

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Add code
   -  [ ] Add test
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
  - (I couldn't make tests run in locally as I got some errors, I would figure out later.)
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow
    -  [ ] this github [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in plotly dash community 
