### PR TITLE
fix for package generation with uninstalled new packages

### DIFF
--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -228,10 +228,10 @@ def generate_js_metadata(pkg_data, project_shortname):
     -------
     function_string = complete R function code to provide component features
     """
-    importlib.import_module(project_shortname)
-
-    # import component library module into sys
-    mod = sys.modules[project_shortname]
+    # make sure the module we're building is available to Python,
+    # even if it hasn't been installed yet
+    sys.path.insert(0, os.getcwd())
+    mod = importlib.import_module(project_shortname)
 
     alldist = getattr(mod, "_js_dist", []) + getattr(mod, "_css_dist", [])
 


### PR DESCRIPTION
Small fix needed to get dash-component-boilerplate working for totally fresh new packages. Also simplified `import_module` syntax. This branch is linked to https://github.com/plotly/dash-component-boilerplate/pull/75 - ideally we'll make a new release before we merge that.

Yet another reason to move `js_dist` and `css_dist` into the YAML file - then we can stop importing the package we're in the middle of creating 😅 