### PR TITLE
Headless mode

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -398,7 +398,7 @@ valid-metaclass-classmethod-first-arg=mcs
 [DESIGN]
 
 # Maximum number of arguments for function / method
-max-args=5
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=20

--- a/.pylintrc37
+++ b/.pylintrc37
@@ -497,7 +497,7 @@ valid-metaclass-classmethod-first-arg=mcs
 [DESIGN]
 
 # Maximum number of arguments for function / method.
-max-args=5
+max-args=10
 
 # Maximum number of attributes for a class (see R0902).
 max-attributes=20

--- a/dash/CHANGELOG.md
+++ b/dash/CHANGELOG.md
@@ -1,3 +1,13 @@
+
+## [Unreleased]
+
+### Changed
+
+- 💥 [#808](https://github.com/plotly/dash/pull/808) Remove strong `dash.testing` dependencies per community feedbacks.
+Testing users should do `pip install dash[testing]` afterwards.
+
+- [#805](https://github.com/plotly/dash/pull/805) Add headless mode for dash.testing, add `pytest_setup_options` hook for full configuration of `WebDriver Options`.
+
 ## [1.0.0] - 2019-06-20
 ### Changed
 - 💥 [#761](https://github.com/plotly/dash/pull/761) Several breaking changes to the `dash.Dash` API:

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -296,7 +296,9 @@ class Browser(DashPageMixin):
         fp.set_preference("browser.download.folderList", 2)
         fp.set_preference("browser.download.manager.showWhenStarting", False)
 
-        return webdriver.Firefox(fp, options=options, capabilities=capabilities)
+        return webdriver.Firefox(
+            fp, options=options, capabilities=capabilities
+        )
 
     @staticmethod
     def _is_windows():

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -9,7 +9,6 @@ from selenium import webdriver
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
-from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.action_chains import ActionChains
@@ -25,8 +24,17 @@ logger = logging.getLogger(__name__)
 
 
 class Browser(DashPageMixin):
-    def __init__(self, browser, remote=None, wait_timeout=10):
+    def __init__(
+        self,
+        browser,
+        headless=False,
+        options=None,
+        remote=None,
+        wait_timeout=10,
+    ):
         self._browser = browser.lower()
+        self._headless = headless
+        self._options = options
         self._wait_timeout = wait_timeout
 
         self._driver = self.get_webdriver(remote)
@@ -244,10 +252,20 @@ class Browser(DashPageMixin):
             )
         )
 
-    @staticmethod
-    def _get_chrome():
-        options = Options()
-        options.add_argument("--no-sandbox")
+    def _get_wd_options(self):
+        options = (
+            self._options[0]
+            if self._options and isinstance(self._options, list)
+            else getattr(webdriver, self._browser).options.Options()
+        )
+
+        if self._headless:
+            options.headless = True
+
+        return options
+
+    def _get_chrome(self):
+        options = self._get_wd_options()
 
         capabilities = DesiredCapabilities.CHROME
         capabilities["loggingPrefs"] = {"browser": "SEVERE"}
@@ -261,8 +279,8 @@ class Browser(DashPageMixin):
         chrome.set_window_position(0, 0)
         return chrome
 
-    @staticmethod
-    def _get_firefox():
+    def _get_firefox(self):
+        options = self._get_wd_options()
 
         capabilities = DesiredCapabilities.FIREFOX
         capabilities["loggingPrefs"] = {"browser": "SEVERE"}
@@ -278,7 +296,7 @@ class Browser(DashPageMixin):
         fp.set_preference("browser.download.folderList", 2)
         fp.set_preference("browser.download.manager.showWhenStarting", False)
 
-        return webdriver.Firefox(fp, capabilities=capabilities)
+        return webdriver.Firefox(fp, options=options, capabilities=capabilities)
 
     @staticmethod
     def _is_windows():

--- a/dash/testing/composite.py
+++ b/dash/testing/composite.py
@@ -2,18 +2,8 @@ from dash.testing.browser import Browser
 
 
 class DashComposite(Browser):
-    def __init__(
-        self,
-        server,
-        browser,
-        headless=False,
-        options=None,
-        remote=None,
-        wait_timeout=10,
-    ):
-        super(DashComposite, self).__init__(
-            browser, headless, options, remote, wait_timeout
-        )
+    def __init__(self, server, **kwargs):
+        super(DashComposite, self).__init__(**kwargs)
         self.server = server
 
     def start_server(self, app, **kwargs):

--- a/dash/testing/composite.py
+++ b/dash/testing/composite.py
@@ -2,13 +2,22 @@ from dash.testing.browser import Browser
 
 
 class DashComposite(Browser):
-
-    def __init__(self, server, browser, remote=None, wait_timeout=10):
-        super(DashComposite, self).__init__(browser, remote, wait_timeout)
+    def __init__(
+        self,
+        server,
+        browser,
+        headless=False,
+        options=None,
+        remote=None,
+        wait_timeout=10,
+    ):
+        super(DashComposite, self).__init__(
+            browser, headless, options, remote, wait_timeout
+        )
         self.server = server
 
     def start_server(self, app, **kwargs):
-        '''start the local server with app'''
+        """start the local server with app"""
 
         # start server with app and pass Dash arguments
         self.server(app, **kwargs)

--- a/dash/testing/newhooks.py
+++ b/dash/testing/newhooks.py
@@ -1,0 +1,2 @@
+def pytest_setup_options():
+    """called before webdriver is initialized"""

--- a/dash/testing/plugin.py
+++ b/dash/testing/plugin.py
@@ -22,9 +22,29 @@ def pytest_addoption(parser):
     dash.addoption(
         "--webdriver",
         choices=tuple(WEBDRIVERS.keys()),
+        action="store",
         default="Chrome",
         help="Name of the selenium driver to use",
     )
+
+    dash.addoption(
+        "--headless",
+        action="store",
+        default=False,
+        help="Run tests in headless mode",
+    )
+
+
+@pytest.mark.tryfirst
+def pytest_addhooks(pluginmanager):
+    # https://github.com/pytest-dev/pytest-xdist/blob/974bd566c599dc6a9ea291838c6f226197208b46/xdist/plugin.py#L67
+    # avoid warnings with pytest-2.8
+    from dash.testing import newhooks
+
+    method = getattr(pluginmanager, "add_hookspecs", None)
+    if method is None:
+        method = pluginmanager.addhooks  # pragma: no cover
+    method(newhooks)
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
@@ -64,13 +84,20 @@ def dash_process_server():
 
 @pytest.fixture
 def dash_br(request):
-    with Browser(request.config.getoption("webdriver")) as browser:
+    with Browser(
+        browser=request.config.getoption("webdriver"),
+        headless=request.config.getoption("headless"),
+        options=request.config.hook.pytest_setup_options(),
+    ) as browser:
         yield browser
 
 
 @pytest.fixture
 def dash_duo(request, dash_thread_server):
     with DashComposite(
-        dash_thread_server, request.config.getoption("webdriver")
+        dash_thread_server,
+        browser=request.config.getoption("webdriver"),
+        headless=request.config.getoption("headless"),
+        options=request.config.hook.pytest_setup_options(),
     ) as dc:
         yield dc

--- a/requires-install.txt
+++ b/requires-install.txt
@@ -1,4 +1,4 @@
-Flask>=0.12
+Flask>=1.0.2
 flask-compress
 plotly
 dash_renderer==1.0.0
@@ -7,7 +7,7 @@ dash-html-components==1.0.0
 dash-table==4.0.0
 
 # dash.testing
-pytest
+pytest<5.0.0
 pytest-sugar
 pytest-mock
 lxml


### PR DESCRIPTION
this solves  #793 

- the headless mode option is added so you can do `pytest --headless True`, default is False
- it might be useful for advanced testers to further configure the selenium options via a hook. the current solution opens the options object, I feel it's a good compromise here.  But it might be good to know if users wanna full control on the webdriver construction. 

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] add headless mode
   -  [x] add hooks to configure webdriver options
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow
    -  [ ] this github [#PR number]() updates the dash docs

