### PR TITLE
remove strong testing dependencies.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,16 +25,16 @@ jobs:
             echo $CIRCLE_JOB > circlejob.txt
 
       - restore_cache:
-          key: v-{{ checksum "circlejob.txt" }}-{{ checksum "requires-ci.txt" }}-{{ checksum "requires-install.txt" }}
+          key: v-{{ checksum "circlejob.txt" }}-{{ checksum "requires-ci.txt" }}-{{ checksum "requires-install.txt" }}-{{ checksum "requires-testing.txt" }}
       - run:
           name: 🚧 pip dev requirements
           command: |
             sudo pip install --upgrade virtualenv
             python -m venv venv || virtualenv venv
             . venv/bin/activate
-            pip install -r requires-install.txt -r requires-ci.txt --quiet
+            pip install -r requires-install.txt -r requires-ci.txt -r requires-testing.txt --quiet
       - save_cache:
-          key: v-{{ checksum "circlejob.txt" }}-{{ checksum "requires-ci.txt" }}-{{ checksum "requires-install.txt" }}
+          key: v-{{ checksum "circlejob.txt" }}-{{ checksum "requires-ci.txt" }}-{{ checksum "requires-install.txt" }}-{{ checksum "requires-testing.txt" }}
           paths:
               - "venv"
 
@@ -42,7 +42,7 @@ jobs:
           name: 🌸 linting
           command: |
             . venv/bin/activate
-            pip install -e .[ci] --quiet
+            pip install -e .[ci,testing] --quiet
             pip list | grep dash
             flake8 dash setup.py
             flake8 --ignore=E123,E126,E501,E722,E731,F401,F841,W503,W504 --exclude=metadata_test.py tests

--- a/dash/CHANGELOG.md
+++ b/dash/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+## [Unreleased]
+
+### Changed
+
+- 💥 [#808](https://github.com/plotly/dash/pull/808) Remove strong `dash.testing` dependencies per community feedbacks.
+Testing users should do `pip install dash[testing]` afterwards.
+
 ## [1.0.0] - 2019-06-20
 ### Changed
 - 💥 [#761](https://github.com/plotly/dash/pull/761) Several breaking changes to the `dash.Dash` API:

--- a/dash/testing/plugin.py
+++ b/dash/testing/plugin.py
@@ -1,17 +1,16 @@
 # pylint: disable=missing-docstring,redefined-outer-name
-import pytest
+import warnings
 
-from selenium import webdriver
+try:
+    import pytest
 
-from dash.testing.application_runners import ThreadedRunner, ProcessRunner
-from dash.testing.browser import Browser
-from dash.testing.composite import DashComposite
+    from dash.testing.application_runners import ThreadedRunner, ProcessRunner
+    from dash.testing.browser import Browser
+    from dash.testing.composite import DashComposite
+except (ModuleNotFoundError, ImportError):
+    warnings.warn("run `pip install dash[testing]` if you need dash.testing")
 
-WEBDRIVERS = {
-    "Chrome": webdriver.Chrome,
-    "Firefox": webdriver.Firefox,
-    "Remote": webdriver.Remote,
-}
+WEBDRIVERS = {"Chrome", "Firefox", "Remote"}
 
 
 def pytest_addoption(parser):
@@ -21,7 +20,7 @@ def pytest_addoption(parser):
 
     dash.addoption(
         "--webdriver",
-        choices=tuple(WEBDRIVERS.keys()),
+        choices=tuple(WEBDRIVERS),
         default="Chrome",
         help="Name of the selenium driver to use",
     )

--- a/dash/testing/plugin.py
+++ b/dash/testing/plugin.py
@@ -7,7 +7,7 @@ try:
     from dash.testing.application_runners import ThreadedRunner, ProcessRunner
     from dash.testing.browser import Browser
     from dash.testing.composite import DashComposite
-except (ModuleNotFoundError, ImportError):
+except ImportError:
     warnings.warn("run `pip install dash[testing]` if you need dash.testing")
 
 WEBDRIVERS = {"Chrome", "Firefox", "Remote"}

--- a/requires-install.txt
+++ b/requires-install.txt
@@ -1,18 +1,7 @@
-Flask>=0.12
+Flask>=1.0.2
 flask-compress
 plotly
 dash_renderer==1.0.0
 dash-core-components==1.0.0
 dash-html-components==1.0.0
 dash-table==4.0.0
-
-# dash.testing
-pytest
-pytest-sugar
-pytest-mock
-lxml
-selenium
-percy
-requests[security]
-beautifulsoup4
-waitress

--- a/requires-testing.txt
+++ b/requires-testing.txt
@@ -1,0 +1,9 @@
+pytest<5.0.0
+pytest-sugar
+pytest-mock
+lxml
+selenium
+percy
+requests[security]
+beautifulsoup4
+waitress

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,10 @@ setup(
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     install_requires=read_req_file("install"),
-    extras_require={"ci": read_req_file("ci")},
+    extras_require={
+        "ci": read_req_file("ci"),
+        "testing": read_req_file("testing"),
+    },
     entry_points={
         "console_scripts": [
             "dash-generate-components ="


### PR DESCRIPTION
this solves the #804 

the separation could be easily handled by the extra_require. and the new `setup.py`. 

the only change might have an impact is for dash.testing users, they need to do `pip install dash[testing]` instead of `pip install dash`. 

