### PR TITLE
Update ramda

### DIFF
--- a/dash-renderer/package-lock.json
+++ b/dash-renderer/package-lock.json
@@ -11269,9 +11269,9 @@
       }
     },
     "ramda": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.23.0.tgz",
-      "integrity": "sha1-zNE//3NJepOXTj6GMnv9h71ujis="
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
+      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
     },
     "randomatic": {
       "version": "3.1.0",

--- a/dash-renderer/package.json
+++ b/dash-renderer/package.json
@@ -37,7 +37,7 @@
     "prop-types": "^15.6.2",
     "query-string": "^4.3.2",
     "radium": "^0.22.1",
-    "ramda": "^0.23.0",
+    "ramda": "^0.26.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-redux": "^4.4.5",

--- a/dash-renderer/src/AccessDenied.react.js
+++ b/dash-renderer/src/AccessDenied.react.js
@@ -1,6 +1,6 @@
 /* global window:true, document:true */
 import React from 'react';
-import {merge} from 'ramda';
+import {mergeRight} from 'ramda';
 import PropTypes from 'prop-types';
 import * as styles from './styles/styles.js';
 import * as constants from './constants/constants.js';
@@ -10,7 +10,7 @@ function AccessDenied(props) {
     const fid = config.fid;
     const owner_username = fid.split(':')[0];
     return (
-        <div style={merge(styles.base.html, styles.base.container)}>
+        <div style={mergeRight(styles.base.html, styles.base.container)}>
             <div style={styles.base.h2}>Access Denied</div>
 
             <div style={styles.base.h4}>

--- a/dash-renderer/src/TreeContainer.js
+++ b/dash-renderer/src/TreeContainer.js
@@ -15,7 +15,7 @@ import {
     isNil,
     keysIn,
     map,
-    mergeAll,
+    mergeRight,
     omit,
     pick,
     propOr,
@@ -76,7 +76,7 @@ function CheckedComponent(p) {
 
     return React.createElement(
         element,
-        mergeAll([props, extraProps]),
+        mergeRight(props, extraProps),
         ...(Array.isArray(children) ? children : [children])
     );
 }
@@ -140,7 +140,7 @@ class TreeContainer extends Component {
             >
                 {React.createElement(
                     element,
-                    mergeAll([props, { loading_state, setProps }]),
+                    mergeRight(props, { loading_state, setProps }),
                     ...(Array.isArray(children) ? children : [children])
                 )}
             </ComponentErrorBoundary>

--- a/dash-renderer/src/actions/api.js
+++ b/dash-renderer/src/actions/api.js
@@ -1,6 +1,6 @@
 /* global fetch: true, document: true */
 import cookie from 'cookie';
-import {merge} from 'ramda';
+import {mergeRight} from 'ramda';
 import {onError} from '../actions';
 import {urlBase} from '../utils';
 
@@ -20,7 +20,7 @@ function POST(path, body = {}, headers = {}) {
     return fetch(path, {
         method: 'POST',
         credentials: 'same-origin',
-        headers: merge(
+        headers: mergeRight(
             {
                 Accept: 'application/json',
                 'Content-Type': 'application/json',

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -1,6 +1,5 @@
 /* global fetch:true, Promise:true, document:true */
 import {
-    __,
     adjust,
     any,
     append,
@@ -15,14 +14,13 @@ import {
     isEmpty,
     keys,
     lensPath,
-    merge,
+    mergeLeft,
     pluck,
     propEq,
     reject,
     slice,
     sort,
     type,
-    //    values,
     view,
 } from 'ramda';
 import {createAction} from 'redux-actions';
@@ -414,7 +412,7 @@ function updateOutput(
         }
         const updatedQueue = adjust(
             thisRequestIndex,
-            merge(__, {
+            mergeLeft({
                 status: status,
                 responseTime: Date.now(),
                 rejected,

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -413,12 +413,12 @@ function updateOutput(
             return;
         }
         const updatedQueue = adjust(
+            thisRequestIndex,
             merge(__, {
                 status: status,
                 responseTime: Date.now(),
                 rejected,
             }),
-            thisRequestIndex,
             postRequestQueue
         );
         // We don't need to store any requests before this one

--- a/dash-renderer/src/components/core/Toolbar.react.js
+++ b/dash-renderer/src/components/core/Toolbar.react.js
@@ -1,7 +1,7 @@
 import {connect} from 'react-redux';
 import React from 'react';
 import PropTypes from 'prop-types';
-import {merge} from 'ramda';
+import {mergeRight} from 'ramda';
 import {redo, undo} from '../../actions/index.js';
 import Radium from 'radium';
 
@@ -26,7 +26,7 @@ function UnconnectedToolbar(props) {
     const undoLink = (
         <span
             key="undoLink"
-            style={merge(
+            style={mergeRight(
                 {
                     color: history.past.length ? '#0074D9' : 'grey',
                     cursor: history.past.length ? 'pointer' : 'default',
@@ -35,7 +35,12 @@ function UnconnectedToolbar(props) {
             )}
             onClick={() => dispatch(undo())}
         >
-            <div style={merge({transform: 'rotate(270deg)'}, styles.iconStyle)}>
+            <div
+                style={mergeRight(
+                    {transform: 'rotate(270deg)'},
+                    styles.iconStyle
+                )}
+            >
                 ↺
             </div>
             <div style={styles.labelStyle}>undo</div>
@@ -45,7 +50,7 @@ function UnconnectedToolbar(props) {
     const redoLink = (
         <span
             key="redoLink"
-            style={merge(
+            style={mergeRight(
                 {
                     color: history.future.length ? '#0074D9' : 'grey',
                     cursor: history.future.length ? 'pointer' : 'default',
@@ -55,7 +60,12 @@ function UnconnectedToolbar(props) {
             )}
             onClick={() => dispatch(redo())}
         >
-            <div style={merge({transform: 'rotate(90deg)'}, styles.iconStyle)}>
+            <div
+                style={mergeRight(
+                    {transform: 'rotate(90deg)'},
+                    styles.iconStyle
+                )}
+            >
                 ↻
             </div>
             <div style={styles.labelStyle}>redo</div>

--- a/dash-renderer/src/reducers/api.js
+++ b/dash-renderer/src/reducers/api.js
@@ -1,4 +1,4 @@
-import {assoc, assocPath, merge} from 'ramda';
+import {assoc, assocPath, mergeRight} from 'ramda';
 
 function createApiReducer(store) {
     return function ApiReducer(state = {}, action) {
@@ -24,7 +24,7 @@ function createApiReducer(store) {
                     state
                 );
             } else {
-                newState = merge(state, {
+                newState = mergeRight(state, {
                     status: payload.status,
                     content: payload.content,
                 });

--- a/dash-renderer/src/reducers/error.js
+++ b/dash-renderer/src/reducers/error.js
@@ -1,4 +1,4 @@
-import {findIndex, merge, propEq, remove} from 'ramda';
+import {findIndex, mergeRight, propEq, remove} from 'ramda';
 
 const initialError = {
     frontEnd: [],
@@ -11,7 +11,7 @@ function error(state = initialError, action) {
             if (action.payload.type === 'frontEnd') {
                 return {
                     frontEnd: [
-                        merge(action.payload, {timestamp: new Date()}),
+                        mergeRight(action.payload, {timestamp: new Date()}),
                         ...state.frontEnd,
                     ],
                     backEnd: state.backEnd,
@@ -20,7 +20,7 @@ function error(state = initialError, action) {
                 return {
                     frontEnd: state.frontEnd,
                     backEnd: [
-                        merge(action.payload, {timestamp: new Date()}),
+                        mergeRight(action.payload, {timestamp: new Date()}),
                         ...state.backEnd,
                     ],
                 };

--- a/dash-renderer/src/reducers/layout.js
+++ b/dash-renderer/src/reducers/layout.js
@@ -1,4 +1,4 @@
-import {append, assocPath, contains, lensPath, merge, view} from 'ramda';
+import {append, assocPath, contains, lensPath, mergeRight, view} from 'ramda';
 
 import {getAction} from '../actions/constants';
 
@@ -14,7 +14,7 @@ const layout = (state = {}, action) => {
     ) {
         const propPath = append('props', action.payload.itempath);
         const existingProps = view(lensPath(propPath), state);
-        const mergedProps = merge(existingProps, action.payload.props);
+        const mergedProps = mergeRight(existingProps, action.payload.props);
         return assocPath(propPath, mergedProps, state);
     }
 

--- a/dash-renderer/src/reducers/paths.js
+++ b/dash-renderer/src/reducers/paths.js
@@ -6,7 +6,7 @@ import {
     isEmpty,
     isNil,
     keys,
-    merge,
+    mergeRight,
     omit,
     slice,
 } from 'ramda';
@@ -36,7 +36,7 @@ const paths = (state = initialPaths, action) => {
                 );
                 newState = omit(removeKeys, oldState);
             } else {
-                newState = merge({}, oldState);
+                newState = mergeRight({}, oldState);
             }
 
             crawlLayout(subTree, function assignPath(child, itempath) {

--- a/dash-renderer/src/reducers/paths.js
+++ b/dash-renderer/src/reducers/paths.js
@@ -1,5 +1,15 @@
 import {crawlLayout, hasPropsId} from './utils';
-import R from 'ramda';
+import {
+    concat,
+    equals,
+    filter,
+    isEmpty,
+    isNil,
+    keys,
+    merge,
+    omit,
+    slice,
+} from 'ramda';
 import {getAction} from '../actions/constants';
 
 const initialPaths = null;
@@ -9,29 +19,29 @@ const paths = (state = initialPaths, action) => {
         case getAction('COMPUTE_PATHS'): {
             const {subTree, startingPath} = action.payload;
             let oldState = state;
-            if (R.isNil(state)) {
+            if (isNil(state)) {
                 oldState = {};
             }
             let newState;
 
             // if we're updating a subtree, clear out all of the existing items
-            if (!R.isEmpty(startingPath)) {
-                const removeKeys = R.filter(
+            if (!isEmpty(startingPath)) {
+                const removeKeys = filter(
                     k =>
-                        R.equals(
+                        equals(
                             startingPath,
-                            R.slice(0, startingPath.length, oldState[k])
+                            slice(0, startingPath.length, oldState[k])
                         ),
-                    R.keys(oldState)
+                    keys(oldState)
                 );
-                newState = R.omit(removeKeys, oldState);
+                newState = omit(removeKeys, oldState);
             } else {
-                newState = R.merge({}, oldState);
+                newState = merge({}, oldState);
             }
 
             crawlLayout(subTree, function assignPath(child, itempath) {
                 if (hasPropsId(child)) {
-                    newState[child.props.id] = R.concat(startingPath, itempath);
+                    newState[child.props.id] = concat(startingPath, itempath);
                 }
             });
 

--- a/dash-renderer/src/reducers/reducer.js
+++ b/dash-renderer/src/reducers/reducer.js
@@ -1,5 +1,5 @@
 'use strict';
-import R, {concat, lensPath, view} from 'ramda';
+import {concat, equals, filter, isEmpty, keys, lensPath, view} from 'ramda';
 import {combineReducers} from 'redux';
 import layout from './layout';
 import graphs from './dependencyGraph';
@@ -31,12 +31,12 @@ const reducer = combineReducers({
 function getInputHistoryState(itempath, props, state) {
     const {graphs, layout, paths} = state;
     const {InputGraph} = graphs;
-    const keyObj = R.filter(R.equals(itempath), paths);
+    const keyObj = filter(equals(itempath), paths);
     let historyEntry;
-    if (!R.isEmpty(keyObj)) {
-        const id = R.keys(keyObj)[0];
+    if (!isEmpty(keyObj)) {
+        const id = keys(keyObj)[0];
         historyEntry = {id, props: {}};
-        R.keys(props).forEach(propKey => {
+        keys(props).forEach(propKey => {
             const inputKey = `${id}.${propKey}`;
             if (
                 InputGraph.hasNode(inputKey) &&
@@ -58,7 +58,7 @@ function recordHistory(reducer) {
         if (action.type === 'ON_PROP_CHANGE') {
             const {itempath, props} = action.payload;
             const historyEntry = getInputHistoryState(itempath, props, state);
-            if (historyEntry && !R.isEmpty(historyEntry.props)) {
+            if (historyEntry && !isEmpty(historyEntry.props)) {
                 state.history.present = historyEntry;
             }
         }
@@ -79,7 +79,7 @@ function recordHistory(reducer) {
                 props,
                 nextState
             );
-            if (historyEntry && !R.isEmpty(historyEntry.props)) {
+            if (historyEntry && !isEmpty(historyEntry.props)) {
                 nextState.history = {
                     past: [...nextState.history.past, state.history.present],
                     present: historyEntry,

--- a/dash-renderer/src/reducers/utils.js
+++ b/dash-renderer/src/reducers/utils.js
@@ -1,22 +1,32 @@
-import R from 'ramda';
+import {
+    allPass,
+    append,
+    compose,
+    flip,
+    has,
+    is,
+    prop,
+    reduce,
+    type,
+} from 'ramda';
 
-const extend = R.reduce(R.flip(R.append));
+const extend = reduce(flip(append));
 
-const hasProps = R.allPass([R.is(Object), R.has('props')]);
+const hasProps = allPass([is(Object), has('props')]);
 
-export const hasPropsId = R.allPass([
+export const hasPropsId = allPass([
     hasProps,
-    R.compose(
-        R.has('id'),
-        R.prop('props')
+    compose(
+        has('id'),
+        prop('props')
     ),
 ]);
 
-export const hasPropsChildren = R.allPass([
+export const hasPropsChildren = allPass([
     hasProps,
-    R.compose(
-        R.has('children'),
-        R.prop('props')
+    compose(
+        has('children'),
+        prop('props')
     ),
 ]);
 
@@ -32,12 +42,12 @@ export const crawlLayout = (object, func, path = []) => {
         const newPath = extend(path, ['props', 'children']);
         if (Array.isArray(object.props.children)) {
             object.props.children.forEach((child, i) => {
-                crawlLayout(child, func, R.append(i, newPath));
+                crawlLayout(child, func, append(i, newPath));
             });
         } else {
             crawlLayout(object.props.children, func, newPath);
         }
-    } else if (R.is(Array, object)) {
+    } else if (is(Array, object)) {
         /*
          * Sometimes when we're updating a sub-tree
          * (like when we're responding to a callback)
@@ -47,15 +57,15 @@ export const crawlLayout = (object, func, path = []) => {
          */
 
         object.forEach((child, i) => {
-            crawlLayout(child, func, R.append(i, path));
+            crawlLayout(child, func, append(i, path));
         });
     }
 };
 
 export function hasId(child) {
     return (
-        R.type(child) === 'Object' &&
-        R.has('props', child) &&
-        R.has('id', child.props)
+        type(child) === 'Object' &&
+        has('props', child) &&
+        has('id', child.props)
     );
 }


### PR DESCRIPTION
First part of bringing over https://github.com/plotly/dash-renderer/pull/172

Per https://github.com/plotly/dash-renderer/pull/172/files#r283551202:

> I wanted `mergeDeepLeft` so I upgraded `ramda` - but there were two breaking changes there: changed order of args in `adjust`, and removed `import R from 'ramda'` - you can still do `import * as R` but seems like we're moving to explicit imports anyway.

Here I also converted `merge` - which is deprecated - to `mergeRight` - with a couple of exceptions that were simpler another way.