### PR TITLE
Permit NAMESPACE exclusions when bundling user-authored R functions

### DIFF
--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -662,7 +662,7 @@ def generate_exports(
                 stripped_line = line.replace(" ", "").replace("\n", "")
                 if any(fndef in stripped_line for fndef in definitions):
                     fnlist += set([re.split("<-|=", stripped_line)[0]])
-        fnlist = list(filter(lambda x: x not in omitstrings, fnlist))
+        fnlist = [fn for fn in fnlist if fn not in omitstrings]
 
     export_string += "\n".join("export({})".format(function)
                                for function in fnlist)

--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -659,9 +659,9 @@ def generate_exports(
         with open(rfile, "r") as script:
             for line in script:
                 stripped_line = line.replace(" ", "").replace("\n", "")
-                if any(fndef in stripped_line and fndef not in omitstrings
-                       for fndef in definitions):
+                if any(fndef in stripped_line for fndef in definitions):
                     fnlist += set([re.split("<-|=", stripped_line)[0]])
+        fnlist = list(filter(lambda x: x not in omitstrings, fnlist))
 
     export_string += "\n".join("export({})".format(function)
                                for function in fnlist)

--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -639,8 +639,14 @@ def generate_exports(
     omitlist = ["utils.R", "internal.R"] + [
         "{}{}.R".format(prefix, component) for component in components
     ]
+    omitstrings = ["FUN"]
     stripped_line = ""
     fnlist = []
+
+    if os.path.exists(".ignorefns"):
+        with open(".ignorefns", "r") as f:
+            for line in f:
+                omitstrings.append(line.strip())
 
     for script in os.listdir("R"):
         if script.endswith(".R") and script not in omitlist:
@@ -653,7 +659,8 @@ def generate_exports(
         with open(rfile, "r") as script:
             for line in script:
                 stripped_line = line.replace(" ", "").replace("\n", "")
-                if any(fndef in stripped_line for fndef in definitions):
+                if any(fndef in stripped_line and fndef not in omitstrings
+                       for fndef in definitions):
                     fnlist += set([re.split("<-|=", stripped_line)[0]])
 
     export_string += "\n".join("export({})".format(function)

--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -131,6 +131,7 @@ test/
 LICENSE.txt
 ^.*\.Rproj$
 ^\.Rproj\.user$
+.ignorefns
 """
 
 pkghelp_stub = """% Auto-generated: do not edit by hand


### PR DESCRIPTION
This PR proposes to address #749 by disallowing `FUN` exports to the `NAMESPACE`, and optionally allowing other user-authored functions to remain "hidden" when packages are generated also.

The latter is accomplished by parsing an `.ignorefns` file, where function names may be listed one-per-line:

```
superSecretFunction
anotherSecretFunction
```

Closes #749.