### PR TITLE
R: Exclude nested and private functions from generated NAMESPACE

### DIFF
--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -672,8 +672,13 @@ def make_namespace_exports(components, prefix):
 
     for rfile in rfilelist:
         with open(rfile, "r") as script:
+            s = script.read()
+
+            # remove comments
+            s = re.sub('#.*$', '', s, flags=re.M)
+
             # put the whole file on one line
-            s = script.read().replace("\n", " ").replace("\r", " ")
+            s = s.replace("\n", " ").replace("\r", " ")
 
             # empty out strings, in case of unmatched block terminators
             s = re.sub(r"'([^'\\]|\\'|\\[^'])*'", "''", s)
@@ -691,7 +696,7 @@ def make_namespace_exports(components, prefix):
             # now, in whatever is left, look for functions
             matches = re.findall(
                 # in R, either = or <- may be used to create and assign objects
-                r"([^A-Za-z._]|^)([A-Za-z._]+)\s*(=|<-)\s*function", s
+                r"([^A-Za-z0-9._]|^)([A-Za-z0-9._]+)\s*(=|<-)\s*function", s
             )
             for match in matches:
                 fn = match[1]

--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -622,6 +622,31 @@ def generate_exports(
         package_suggests,
         **kwargs
 ):
+    export_string = make_namespace_exports(components, prefix)
+
+    # Look for wildcards in the metadata
+    has_wildcards = False
+    for component_data in metadata.values():
+        if any(key.endswith('-*') for key in component_data['props']):
+            has_wildcards = True
+            break
+
+    # now, bundle up the package information and create all the requisite
+    # elements of an R package, so that the end result is installable either
+    # locally or directly from GitHub
+    generate_rpkg(
+        pkg_data,
+        rpkg_data,
+        project_shortname,
+        export_string,
+        package_depends,
+        package_imports,
+        package_suggests,
+        has_wildcards,
+    )
+
+
+def make_namespace_exports(components, prefix):
     export_string = ""
     for component in components:
         if (
@@ -676,27 +701,7 @@ def generate_exports(
 
     export_string += "\n".join("export({})".format(function)
                                for function in fnlist)
-
-    # Look for wildcards in the metadata
-    has_wildcards = False
-    for component_data in metadata.values():
-        if any(key.endswith('-*') for key in component_data['props']):
-            has_wildcards = True
-            break
-
-    # now, bundle up the package information and create all the requisite
-    # elements of an R package, so that the end result is installable either
-    # locally or directly from GitHub
-    generate_rpkg(
-        pkg_data,
-        rpkg_data,
-        project_shortname,
-        export_string,
-        package_depends,
-        package_imports,
-        package_suggests,
-        has_wildcards,
-    )
+    return export_string
 
 
 def get_r_prop_types(type_object):

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -89,7 +89,7 @@ def generate_components(
         )
         sys.exit(1)
 
-    metadata = safe_json_loads(out.decode())
+    metadata = safe_json_loads(out.decode("utf-8"))
 
     generator_methods = [generate_class_file]
 

--- a/tests/unit/development/test_r_component_gen.py
+++ b/tests/unit/development/test_r_component_gen.py
@@ -1,0 +1,85 @@
+import os
+import shutil
+import re
+from textwrap import dedent
+
+import pytest
+
+from dash.development._r_components_generation import (
+    make_namespace_exports
+)
+
+
+@pytest.fixture
+def make_r_dir():
+    os.makedirs("R")
+
+    yield
+
+    shutil.rmtree("R")
+
+
+def test_r_exports(make_r_dir):
+    extra_file = dedent("""
+        # normal function syntax
+        my_func <- function(a, b) {
+            c <- a + b
+            nested_func <- function() { stop("no!") }
+            another_to_exclude = function(d) { d * d }
+            another_to_exclude(c)
+        }
+
+        # indented (no reason but we should allow) and using = instead of <-
+        # also braces in comments enclosing it {
+            my_func2 = function() {
+                s <- "unmatched closing brace }"
+                ignore_please <- function() { 1 }
+            }
+        # }
+
+        # real example from dash-table that should exclude FUN
+        df_to_list <- function(df) {
+          if(!(is.data.frame(df)))
+            stop("!")
+          setNames(lapply(split(df, seq(nrow(df))),
+                          FUN = function (x) {
+                            as.list(x)
+                          }), NULL)
+        }
+
+        # single-line compressed
+        util<-function(x){x+1}
+
+        # prefix with . to tell us to ignore
+        .secret <- function() { stop("You can't see me") }
+
+        # . in the middle is OK though
+        not.secret <- function() { 42 }
+    """)
+
+    components = ["Component1", "Component2"]
+    prefix = 'pre'
+
+    expected_exports = [prefix + c for c in components] + [
+        "my_func",
+        "my_func2",
+        "df_to_list",
+        "util",
+        "not.secret"
+    ]
+
+    mock_component_file = dedent("""
+        nope <- function() { stop("we don't look in component files") }
+    """)
+
+    with open(os.path.join("R", "preComponent1.R"), "w") as f:
+        f.write(mock_component_file)
+
+    with open(os.path.join("R", "extras.R"), "w") as f:
+        f.write(extra_file)
+
+    exports = make_namespace_exports(components, prefix)
+    print(exports)
+    matches = re.findall(r"export\(([^()]+)\)", exports.replace('\n', ' '))
+
+    assert matches == expected_exports


### PR DESCRIPTION
Fixes #749 
Supersedes #824 

Two changes to the code generating NAMESPACE for R:
- Don't consider functions that are arguments to other function calls or nested inside other functions.
- Omit functions that start with `.` - which seems to be a relatively standard way to mark functions private in R. As @rpkyle points out, there may be other functions we want to exclude, such as S3/S4 methods; we can cross that bridge when we get there. For now I wanted to avoid a user-provided list of functions to exclude as in #824, as that seems likely to be forgotten.

Also fixes a unicode issue reading metadata.json, uncovered by building current master `dash-table` in py27. (cc @Marc-Andre-Rivet)