### PR TITLE
Delete contents of inst/deps when rebuilding R packages

### DIFF
--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -442,11 +442,10 @@ def write_js_metadata(pkg_data, project_shortname, has_wildcards):
     # now copy over all JS dependencies from the (Python) components dir
     # the inst/lib directory for the package won't exist on first call
     # create this directory if it is missing
-    if not os.path.exists("inst/deps"):
-        os.makedirs("inst/deps")
-    else:
+    if os.path.exists("inst/deps"):
         shutil.rmtree("inst/deps")
-        os.makedirs("inst/deps")
+
+    os.makedirs("inst/deps")
 
     for javascript in glob.glob("{}/*.js".format(project_shortname)):
         shutil.copy(javascript, "inst/deps/")

--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -444,6 +444,9 @@ def write_js_metadata(pkg_data, project_shortname, has_wildcards):
     # create this directory if it is missing
     if not os.path.exists("inst/deps"):
         os.makedirs("inst/deps")
+    else:
+        shutil.rmtree("inst/deps")
+        os.makedirs("inst/deps")
 
     for javascript in glob.glob("{}/*.js".format(project_shortname)):
         shutil.copy(javascript, "inst/deps/")


### PR DESCRIPTION
This PR proposes to modify the package generation code such that the `inst/deps` folder within generated R packages is emptied prior to copying over assets from the `project_shortname` directory:

https://github.com/plotly/dash/blob/4a689e01dcdbc0a2ad09871078c537d754ddbff6/dash/development/_r_components_generation.py#L447-L449

Closes #847.