### PR TITLE
Ci speedup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
             . venv/bin/activate
             cd packages && ls -la && pip install * && cd .. && pip list | grep dash
             TESTFILES=$(circleci tests glob "tests/integration/**/test_*.py" | circleci tests split --split-by=timings)
-            pytest --headless --durations=10 --junitxml=test-reports/junit_intg.xml ${TESTFILES}
+            pytest --headless --percyfinalize --junitxml=test-reports/junit_intg.xml ${TESTFILES}
       - store_artifacts:
           path: test-reports
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ jobs:
             . venv/bin/activate
             cd packages && ls -la && pip install * && cd .. && pip list | grep dash
             TESTFILES=$(circleci tests glob "tests/integration/**/test_*.py" | circleci tests split --split-by=timings)
-            pytest --headless --percyfinalize --junitxml=test-reports/junit_intg.xml ${TESTFILES}
+            pytest --headless --nopercyfinalize --junitxml=test-reports/junit_intg.xml ${TESTFILES}
       - store_artifacts:
           path: test-reports
       - store_test_results:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ $ pip install -r .circleci/requirements/dev-requirements.txt
 ```
 ## Git
 
-Use the [GitHub flow][] when proposing contributions to this repository (i.e. create a feature branch and submit a PR against the **dev** branch).
+Use the [GitHub flow][] when proposing contributions to this repository (i.e. create a feature branch and submit a PR against the default branch).
 
 ### Organize your commits
 
@@ -63,7 +63,7 @@ Emojis make the commit messages :cherry_blossom:. If you have no idea about what
 
 We use both `flake8` and `pylint` for basic linting check, please refer to the relevant steps in `.circleci/config.yml`.
 
-Note that we also start using [`black`](https://black.readthedocs.io/en/stable/) as formatter during the test code migration. 
+Note that we also start using [`black`](https://black.readthedocs.io/en/stable/) as formatter during the test code migration.
 
 ## Tests
 

--- a/dash/testing/plugin.py
+++ b/dash/testing/plugin.py
@@ -30,7 +30,15 @@ def pytest_addoption(parser):
     )
 
     dash.addoption(
-        "--headless", action="store_true", help="Run tests in headless mode"
+        "--headless",
+        action="store_true",
+        help="set this flag to run in headless mode",
+    )
+
+    dash.addoption(
+        "--percyfinalize",
+        action="store_false",
+        help="set this flag to control percy finalize at CI level",
     )
 
 
@@ -94,6 +102,7 @@ def dash_br(request, tmpdir):
         headless=request.config.getoption("headless"),
         options=request.config.hook.pytest_setup_options(),
         download_path=tmpdir.mkdir("download").strpath,
+        percy_finalize=request.config.getoption("percyfinalize"),
     ) as browser:
         yield browser
 
@@ -106,6 +115,7 @@ def dash_duo(request, dash_thread_server, tmpdir):
         headless=request.config.getoption("headless"),
         options=request.config.hook.pytest_setup_options(),
         download_path=tmpdir.mkdir("download").strpath,
+        percy_finalize=request.config.getoption("percyfinalize"),
     ) as dc:
         yield dc
 
@@ -118,5 +128,6 @@ def dashr(request, dashr_server, tmpdir):
         headless=request.config.getoption("headless"),
         options=request.config.hook.pytest_setup_options(),
         download_path=tmpdir.mkdir("download").strpath,
+        percy_finalize=request.config.getoption("percyfinalize"),
     ) as dc:
         yield dc

--- a/dash/testing/plugin.py
+++ b/dash/testing/plugin.py
@@ -36,7 +36,7 @@ def pytest_addoption(parser):
     )
 
     dash.addoption(
-        "--percyfinalize",
+        "--nopercyfinalize",
         action="store_false",
         help="set this flag to control percy finalize at CI level",
     )
@@ -102,7 +102,7 @@ def dash_br(request, tmpdir):
         headless=request.config.getoption("headless"),
         options=request.config.hook.pytest_setup_options(),
         download_path=tmpdir.mkdir("download").strpath,
-        percy_finalize=request.config.getoption("percyfinalize"),
+        percy_finalize=request.config.getoption("nopercyfinalize"),
     ) as browser:
         yield browser
 
@@ -115,7 +115,7 @@ def dash_duo(request, dash_thread_server, tmpdir):
         headless=request.config.getoption("headless"),
         options=request.config.hook.pytest_setup_options(),
         download_path=tmpdir.mkdir("download").strpath,
-        percy_finalize=request.config.getoption("percyfinalize"),
+        percy_finalize=request.config.getoption("nopercyfinalize"),
     ) as dc:
         yield dc
 
@@ -128,6 +128,6 @@ def dashr(request, dashr_server, tmpdir):
         headless=request.config.getoption("headless"),
         options=request.config.hook.pytest_setup_options(),
         download_path=tmpdir.mkdir("download").strpath,
-        percy_finalize=request.config.getoption("percyfinalize"),
+        percy_finalize=request.config.getoption("nopercyfinalize"),
     ) as dc:
         yield dc


### PR DESCRIPTION
this PR allows we control the percy snapshot finalize process by pytest flag, so we can do `pytest --percyfinalize` in case we need parallelism in the integration jobs. 