### PR TITLE
PropTypes.function isn't a thing

### DIFF
--- a/dash-renderer/src/components/error/menu/DebugAlertContainer.react.js
+++ b/dash-renderer/src/components/error/menu/DebugAlertContainer.react.js
@@ -32,7 +32,7 @@ class DebugAlertContainer extends Component {
 DebugAlertContainer.propTypes = {
     errors: PropTypes.object,
     alertsOpened: PropTypes.bool,
-    onClick: PropTypes.function,
+    onClick: PropTypes.func,
 };
 
 export {DebugAlertContainer};

--- a/dash-renderer/src/components/error/menu/DebugMenu.react.js
+++ b/dash-renderer/src/components/error/menu/DebugMenu.react.js
@@ -154,8 +154,8 @@ DebugMenu.propTypes = {
     children: PropTypes.object,
     error: PropTypes.object,
     dependenciesRequest: PropTypes.object,
-    resolveError: PropTypes.function,
-    dispatch: PropTypes.function,
+    resolveError: PropTypes.func,
+    dispatch: PropTypes.func,
 };
 
 export {DebugMenu};


### PR DESCRIPTION
Surprised that this hasn't bitten us in some way... but one of our clients reported a console warning:
```
Warning: Failed prop type: DebugMenu: prop type `resolveError` is invalid;
it must be a function, usually from the `prop-types` package, but received `undefined`
```
Dunno why *we* don't see that same warning... though I think we *would* see it in component code, at least I know I've made this exact mistake before and somehow knew to correct it.