### PR TITLE
CI branch conditional

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,12 +100,20 @@ jobs:
       - run:
           name: ️️🏗️ build core
           command: |
+              if [ $CIRCLE_BRANCH = "master" ]; then
+                echo "Clone from master branch"
+                git clone -b master --depth 1 git@github.com:plotly/dash.git dash-main
+                git clone -b master --depth 1 https://github.com/plotly/dash-renderer-test-components
+              else
+                echo "Clone from default branch"
+                git clone --depth 1 https://github.com/plotly/dash-core-components.git
+                git clone --depth 1 https://github.com/plotly/dash-renderer-test-components
+              fi
+
               . venv/bin/activate && pip install --upgrade -e . --quiet && mkdir packages
               python setup.py sdist && mv dist/* packages/
               cd dash-renderer && renderer build && python setup.py sdist && mv dist/* ../packages/ && cd ..
-              git clone --depth 1 https://github.com/plotly/dash-core-components.git
               cd dash-core-components && npm install --ignore-scripts && npm run build && python setup.py sdist && mv dist/* ../packages/  && cd ..
-              git clone --depth 1 https://github.com/plotly/dash-renderer-test-components
               cd dash-renderer-test-components && npm install --ignore-scripts && npm run build:all && python setup.py sdist && mv dist/* ../packages/ && cd ..
       - persist_to_workspace:
           root: ~/dash
@@ -151,10 +159,18 @@ jobs:
       - run:
           name: ️️🏗️ build misc
           command: |
+              if [ $CIRCLE_BRANCH = "master" ]; then
+                echo "Clone from master branch"
+                git clone -b master --depth 1 https://github.com/plotly/dash-table.git
+                git clone -b master --depth 1 https://github.com/plotly/dash-html-components.git
+              else
+                echo "Clone from default branch"
+                git clone --depth 1 https://github.com/plotly/dash-table.git
+                git clone --depth 1 https://github.com/plotly/dash-html-components.git
+              fi
+
               . venv/bin/activate && pip install --upgrade -e . --quiet && mkdir packages
-              git clone --depth 1 https://github.com/plotly/dash-table.git
               cd dash-table && npm install --ignore-scripts && npm run build && python setup.py sdist && mv dist/* ../packages/ && cd ..
-              git clone --depth 1 https://github.com/plotly/dash-html-components.git
               cd dash-html-components && npm install --ignore-scripts && npm run build && python setup.py sdist && mv dist/* ../packages/ && cd ..
       - persist_to_workspace:
           root: ~/dash


### PR DESCRIPTION
With our move from `master` to `dev` as the default branch for the repos, make sure to distinguish the `master` build to use `master` instead of the default branch - useful for final validation / release.