### PR TITLE
:wrench: remove map files from release tar

### DIFF
--- a/dash-renderer/MANIFEST.in
+++ b/dash-renderer/MANIFEST.in
@@ -1,4 +1,4 @@
 include package.json
 include digest.json
 include dash_renderer/*.js
-include dash_renderer/*.map
+exclude dash_renderer/*.map


### PR DESCRIPTION
This closes #810  

exclude the *.map file for release tar.gz file

the compressed file size is 1.1M 
