### PR TITLE
dash-generate-components crashes on windows

### DIFF
--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -60,7 +60,7 @@ def generate_components(
     os.environ["NODE_PATH"] = "node_modules"
 
     cmd = shlex.split(
-        "node {} \"{}\" \"{}\" {}".format(
+        'node {} "{}" "{}" {}'.format(
             extract_path, ignore, reserved_patterns, components_source
         ),
         posix=not is_windows,

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -59,10 +59,8 @@ def generate_components(
 
     os.environ["NODE_PATH"] = "node_modules"
 
-    fmt = "node {} \"{}\" \"{}\" {}" if is_windows else "node {} {} {} {}"
-
     cmd = shlex.split(
-        fmt.format(
+        "node {} \"{}\" \"{}\" {}".format(
             extract_path, ignore, reserved_patterns, components_source
         ),
         posix=not is_windows,

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -58,8 +58,11 @@ def generate_components(
     reserved_patterns = "|".join("^{}$".format(p) for p in reserved_words)
 
     os.environ["NODE_PATH"] = "node_modules"
+
+    fmt = "node {} \"{}\" \"{}\" {}" if is_windows else "node {} {} {} {}"
+
     cmd = shlex.split(
-        "node {} {} {} {}".format(
+        fmt.format(
             extract_path, ignore, reserved_patterns, components_source
         ),
         posix=not is_windows,

--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -5,7 +5,7 @@ const path = require('path');
 const reactDocs = require('react-docgen');
 
 const componentPaths = process.argv.slice(4);
-const ignorePattern = new RegExp(process.argv[2]);
+const ignorePattern = new RegExp(process.argv[2].split('"').join(''));
 const reservedPatterns = process.argv[3].split('|').map(part => new RegExp(part));
 
 let failed = false;


### PR DESCRIPTION
dash-generate-components crashes on windows. This fix puts quotes around some of the offending command line arguments. This stops dash-generate-components crashing. The quotes placed around the `ignore` attribute need to be removed on entry to `extract-meta.js`

These problems have been reported here:

[Issue with executing dash-component-boilerplate on Windows](https://github.com/plotly/dash-component-boilerplate/issues/74)

and here:

[dash-generate-components ignore not working](https://github.com/plotly/dash/issues/913)