### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
 * @alexcjohnson @byronz @Marc-Andre-Rivet
+
+_r_*     @alexcjohnson @byronz @Marc-Andre-Rivet @rpkyle

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-* @alexcjohnson @byronz @Marc-Andre-Rivet 
-
-tests/*  @byronz
-
-*.js     @Marc-Andre-Rivet  @alexcjohnson
-
-_r_*     @rpkyle
-
-*.md     @alexcjohnson
-
-*.py     @alexcjohnson @byronz
-
-
-
+* @alexcjohnson @byronz @Marc-Andre-Rivet


### PR DESCRIPTION
Loosening up the code ownership to match the more general ownership in [dcc](https://github.com/plotly/dash-core-components/blob/dev/.github/CODEOWNERS).

Keeping the `R` special cases but including the maintainer instead of requiring his review.

If this turns out to cause problems we can adjust.