### PR TITLE
Reword sentence in auto-generated docstrings.

### DIFF
--- a/dash/development/_py_components_generation.py
+++ b/dash/development/_py_components_generation.py
@@ -449,8 +449,8 @@ def create_prop_docstring(prop_name, type_object, required, description,
 
     if '\n' in py_type_name:
         return '{indent_spacing}- {name} (dict; {is_required}): ' \
-            '{description}{period}' \
-            '{name} has the following type: {type}'.format(
+            '{description}{period}\n' \
+            '{indent_spacing}{name} is a {type}'.format(
                 indent_spacing=indent_spacing,
                 name=prop_name,
                 type=py_type_name,
@@ -472,11 +472,7 @@ def map_js_to_py_types_prop_types(type_object):
     """Mapping from the PropTypes js type object to the Python type"""
 
     def shape_or_exact():
-        return 'dict containing keys {}.\n{}'.format(
-            ', '.join(
-                "'{}'".format(t) for t in list(type_object['value'].keys())
-            ),
-            'Those keys have the following types:\n{}'.format(
+        return 'dict with keys:\n{}'.format(
                 '\n'.join(
                     create_prop_docstring(
                         prop_name=prop_name,
@@ -487,7 +483,6 @@ def map_js_to_py_types_prop_types(type_object):
                         indent_num=1
                     ) for prop_name, prop in
                     list(type_object['value'].items())))
-            )
 
     return dict(
         array=lambda: 'list',

--- a/tests/unit/development/__init__.py
+++ b/tests/unit/development/__init__.py
@@ -28,31 +28,23 @@ expected_table_component_doc = [
     "- optionalObjectOf (dict with strings as keys and values "
     "of type number; optional)",
     "- optionalObjectWithExactAndNestedDescription (dict; optional): "
-    "optionalObjectWithExactAndNestedDescription has the "
-    "following type: dict containing keys "
-    "'color', 'fontSize', 'figure'.",
-    "Those keys have the following types:",
+    "optionalObjectWithExactAndNestedDescription.",
+    "  optionalObjectWithExactAndNestedDescription is a dict with keys:",
     "  - color (string; optional)",
     "  - fontSize (number; optional)",
-    "  - figure (dict; optional): Figure is a plotly graph object. "
-    "figure has the following type: dict containing "
-    "keys 'data', 'layout'.",
-    "Those keys have the following types:",
-    "  - data (list of dicts; optional): data is a collection of traces",
-    "  - layout (dict; optional): layout describes " "the rest of the figure",
+    "  - figure (dict; optional): Figure is a plotly graph object.",
+    "    figure is a dict with keys:",
+    "    - data (list of dicts; optional): data is a collection of traces",
+    "    - layout (dict; optional): layout describes " "the rest of the figure",
     "- optionalObjectWithShapeAndNestedDescription (dict; optional): "
-    "optionalObjectWithShapeAndNestedDescription has the "
-    "following type: dict containing keys "
-    "'color', 'fontSize', 'figure'.",
-    "Those keys have the following types:",
+    "optionalObjectWithShapeAndNestedDescription.",
+    "  optionalObjectWithShapeAndNestedDescription is a dict with keys:",
     "  - color (string; optional)",
     "  - fontSize (number; optional)",
-    "  - figure (dict; optional): Figure is a plotly graph object. "
-    "figure has the following type: dict containing "
-    "keys 'data', 'layout'.",
-    "Those keys have the following types:",
-    "  - data (list of dicts; optional): data is a collection of traces",
-    "  - layout (dict; optional): layout describes " "the rest of the figure",
+    "  - figure (dict; optional): Figure is a plotly graph object.",
+    "    figure is a dict with keys:",
+    "    - data (list of dicts; optional): data is a collection of traces",
+    "    - layout (dict; optional): layout describes " "the rest of the figure",
     "- optionalAny (boolean | number | string | dict | " "list; optional)",
     "- customProp (optional)",
     "- customArrayProp (list; optional)",

--- a/tests/unit/development/metadata_test.py
+++ b/tests/unit/development/metadata_test.py
@@ -21,22 +21,22 @@ Keyword arguments:
 - optionalUnion (string | number; optional)
 - optionalArrayOf (list of numbers; optional)
 - optionalObjectOf (dict with strings as keys and values of type number; optional)
-- optionalObjectWithExactAndNestedDescription (dict; optional): optionalObjectWithExactAndNestedDescription has the following type: dict containing keys 'color', 'fontSize', 'figure'.
-Those keys have the following types:
+- optionalObjectWithExactAndNestedDescription (dict; optional): optionalObjectWithExactAndNestedDescription.
+  optionalObjectWithExactAndNestedDescription is a dict with keys:
   - color (string; optional)
   - fontSize (number; optional)
-  - figure (dict; optional): Figure is a plotly graph object. figure has the following type: dict containing keys 'data', 'layout'.
-Those keys have the following types:
-  - data (list of dicts; optional): data is a collection of traces
-  - layout (dict; optional): layout describes the rest of the figure
-- optionalObjectWithShapeAndNestedDescription (dict; optional): optionalObjectWithShapeAndNestedDescription has the following type: dict containing keys 'color', 'fontSize', 'figure'.
-Those keys have the following types:
+  - figure (dict; optional): Figure is a plotly graph object.
+    figure is a dict with keys:
+    - data (list of dicts; optional): data is a collection of traces
+    - layout (dict; optional): layout describes the rest of the figure
+- optionalObjectWithShapeAndNestedDescription (dict; optional): optionalObjectWithShapeAndNestedDescription.
+  optionalObjectWithShapeAndNestedDescription is a dict with keys:
   - color (string; optional)
   - fontSize (number; optional)
-  - figure (dict; optional): Figure is a plotly graph object. figure has the following type: dict containing keys 'data', 'layout'.
-Those keys have the following types:
-  - data (list of dicts; optional): data is a collection of traces
-  - layout (dict; optional): layout describes the rest of the figure
+  - figure (dict; optional): Figure is a plotly graph object.
+    figure is a dict with keys:
+    - data (list of dicts; optional): data is a collection of traces
+    - layout (dict; optional): layout describes the rest of the figure
 - optionalAny (boolean | number | string | dict | list; optional)
 - customProp (optional)
 - customArrayProp (list; optional)

--- a/tests/unit/development/test_flow_metadata_conversions.py
+++ b/tests/unit/development/test_flow_metadata_conversions.py
@@ -47,8 +47,8 @@ expected_arg_strings = OrderedDict(
                 [
                     "dict containing keys 'customData', 'value'.",
                     "Those keys have the following types:",
-                    "- customData (dict; required): customData has the following type: dict containing keys 'checked', 'children', 'customData', 'disabled', 'label', 'primaryText', 'secondaryText', 'style', 'value'.",
-                    "  Those keys have the following types:",
+                    "- customData (dict; required): customData.",
+                    "  customData is a dict with keys:",
                     "  - checked (boolean; optional)",
                     "  - children (a list of or a singular dash component, string or number; optional)",
                     "  - customData (bool | number | str | dict | list; required)",
@@ -80,11 +80,8 @@ expected_doc = [
     "long description that covers several lines. It includes the newline character ",
     "and should span 3 lines in total.",
     "- requiredUnion (string | number; required)",
-    "- optionalSignature(shape) (dict; optional): This is a test of an object's shape. "
-    "optionalSignature(shape) has the following type: dict containing keys 'checked', "
-    "'children', 'customData', 'disabled', 'label', 'primaryText', 'secondaryText', "
-    "'style', 'value'.",
-    "  Those keys have the following types:",
+    "- optionalSignature(shape) (dict; optional): This is a test of an object's shape.",
+    "  optionalSignature(shape) is a dict with keys:",
     "  - checked (boolean; optional)",
     "  - children (a list of or a singular dash component, string or number; optional)",
     "  - customData (bool | number | str | dict | list; required): A test description",
@@ -94,13 +91,10 @@ expected_doc = [
     "  - secondaryText (string; optional)",
     "  - style (dict; optional)",
     "  - value (bool | number | str | dict | list; required)",
-    "- requiredNested (dict; required): requiredNested has the following type: dict containing "
-    "keys 'customData', 'value'.",
-    "  Those keys have the following types:",
-    "  - customData (dict; required): customData has the following type: dict containing "
-    "keys 'checked', 'children', 'customData', 'disabled', 'label', 'primaryText', "
-    "'secondaryText', 'style', 'value'.",
-    "    Those keys have the following types:",
+    "- requiredNested (dict; required): requiredNested.",
+    "  requiredNested is a dict with keys:",
+    "  - customData (dict; required): customData.",
+    "    customData is a dict with keys:",
     "    - checked (boolean; optional)",
     "    - children (a list of or a singular dash component, string or number; optional)",
     "    - customData (bool | number | str | dict | list; required)",

--- a/tests/unit/development/test_metadata_conversions.py
+++ b/tests/unit/development/test_metadata_conversions.py
@@ -33,9 +33,9 @@ expected_arg_strings = OrderedDict(
                     "Those keys have the following types:",
                     "  - color (string; optional)",
                     "  - fontSize (number; optional)",
-                    "  - figure (dict; optional): Figure is a plotly graph object. figure has the following type: dict containing keys 'data', 'layout'.",
+                    "  - figure (dict; optional): Figure is a plotly graph object.",
                     # noqa: E501
-                    "Those keys have the following types:",
+                    "  figure is a dict with keys:",
                     "  - data (list of dicts; optional): data is a collection of traces",
                     "  - layout (dict; optional): layout describes the rest of the figure",  # noqa: E501
                 ]
@@ -49,9 +49,9 @@ expected_arg_strings = OrderedDict(
                     "Those keys have the following types:",
                     "  - color (string; optional)",
                     "  - fontSize (number; optional)",
-                    "  - figure (dict; optional): Figure is a plotly graph object. figure has the following type: dict containing keys 'data', 'layout'.",
+                    "  - figure (dict; optional): Figure is a plotly graph object.",
                     # noqa: E501
-                    "Those keys have the following types:",
+                    "  figure is a dict with keys:",
                     "  - data (list of dicts; optional): data is a collection of traces",
                     "  - layout (dict; optional): layout describes the rest of the figure",  # noqa: E501
                 ]

--- a/tests/unit/development/test_metadata_conversions.py
+++ b/tests/unit/development/test_metadata_conversions.py
@@ -29,11 +29,10 @@ expected_arg_strings = OrderedDict(
             "optionalObjectWithExactAndNestedDescription",
             "\n".join(
                 [
-                    "dict containing keys 'color', 'fontSize', 'figure'.",
-                    "Those keys have the following types:",
+                    "dict with keys:",
                     "  - color (string; optional)",
                     "  - fontSize (number; optional)",
-                    "  - figure (dict; optional): Figure is a plotly graph object.",
+                    "  - figure (dict; optional): Figure is a plotly graph object. ",
                     # noqa: E501
                     "  figure is a dict with keys:",
                     "  - data (list of dicts; optional): data is a collection of traces",
@@ -45,11 +44,10 @@ expected_arg_strings = OrderedDict(
             "optionalObjectWithShapeAndNestedDescription",
             "\n".join(
                 [
-                    "dict containing keys 'color', 'fontSize', 'figure'.",
-                    "Those keys have the following types:",
+                    "dict with keys:",
                     "  - color (string; optional)",
                     "  - fontSize (number; optional)",
-                    "  - figure (dict; optional): Figure is a plotly graph object.",
+                    "  - figure (dict; optional): Figure is a plotly graph object. ",
                     # noqa: E501
                     "  figure is a dict with keys:",
                     "  - data (list of dicts; optional): data is a collection of traces",


### PR DESCRIPTION
This is a tiny PR inspired from my reviewing https://github.com/plotly/dash-bio/pull/411. Why the distance (expressed by "those")? I believe the meaning we want is that of "these."

## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow
    -  [ ] this github [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in plotly dash community 
