### PR TITLE
Attempt to standardize Python Docstrings to PEP 257.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -272,7 +272,7 @@ ignore-docstrings=yes
 ignore-imports=no
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=10
 
 
 [SPELLING]

--- a/.pylintrc37
+++ b/.pylintrc37
@@ -367,7 +367,7 @@ ignore-docstrings=yes
 ignore-imports=no
 
 # Minimum lines number of a similarity.
-min-similarity-lines=4
+min-similarity-lines=10
 
 
 [SPELLING]

--- a/dash/_configs.py
+++ b/dash/_configs.py
@@ -38,9 +38,9 @@ DASH_ENV_VARS = load_dash_env_vars()
 
 
 def get_combined_config(name, val, default=None):
-    '''consolidate the config with priority from high to low
-    provided init value > OS environ > default
-    '''
+    """Consolidate the config with priority from high to low provided init
+    value > OS environ > default."""
+
     if val is not None:
         return val
 

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -60,8 +60,7 @@ def patch_collections_abc(member):
 
 
 class AttributeDict(dict):
-    """
-    Dictionary subclass enabling attribute lookup/assignment of keys/values.
+    """Dictionary subclass enabling attribute lookup/assignment of keys/values.
 
     For example::
         >>> m = AttributeDict({'foo': 'bar'})
@@ -95,7 +94,7 @@ class AttributeDict(dict):
         object.__setattr__(self, "_read_only_msg", msg)
 
     def finalize(self, msg="Object is final: No new keys may be added."):
-        """Prevent any new keys being set"""
+        """Prevent any new keys being set."""
         object.__setattr__(self, "_final", msg)
 
     def __setitem__(self, key, val):

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -87,8 +87,7 @@ no_update = _NoUpdate()
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-arguments, too-many-locals
 class Dash(object):
-    """
-    Dash is a framework for building analytical web applications.
+    """Dash is a framework for building analytical web applications.
     No JavaScript required.
 
     If a parameter can be set by an environment variable, that is listed as:
@@ -347,9 +346,7 @@ class Dash(object):
             self.init_app()
 
     def init_app(self, app=None):
-        """
-        Initialize the parts of Dash that require a flask app
-        """
+        """Initialize the parts of Dash that require a flask app."""
         config = self.config
 
         if app is not None:
@@ -377,7 +374,7 @@ class Dash(object):
 
         @self.server.errorhandler(exceptions.PreventUpdate)
         def _handle_error(_):
-            """Handle a halted callback and return an empty 204 response"""
+            """Handle a halted callback and return an empty 204 response."""
             return "", 204
 
         prefix = config.routes_pathname_prefix
@@ -774,16 +771,14 @@ class Dash(object):
         favicon="",
         renderer="",
     ):
-        """
-        Called to create the initial HTML string that is loaded on page.
+        """Called to create the initial HTML string that is loaded on page.
         Override this method to provide you own custom HTML.
 
         :Example:
 
             class MyDash(dash.Dash):
                 def interpolate_index(self, **kwargs):
-                    return '''
-                    <!DOCTYPE html>
+                    return '''<!DOCTYPE html>
                     <html>
                         <head>
                             <title>My App</title>
@@ -796,12 +791,10 @@ class Dash(object):
                             {renderer}
                             <div id="custom-footer">My custom footer</div>
                         </body>
-                    </html>
-                    '''.format(
-                        app_entry=kwargs.get('app_entry'),
-                        config=kwargs.get('config'),
-                        scripts=kwargs.get('scripts'),
-                        renderer=kwargs.get('renderer'))
+                    </html>'''.format(app_entry=kwargs.get('app_entry'),
+                                      config=kwargs.get('config'),
+                                      scripts=kwargs.get('scripts'),
+                                      renderer=kwargs.get('renderer'))
 
         :param metas: Collected & formatted meta tags.
         :param title: The title of the app.
@@ -1164,8 +1157,7 @@ class Dash(object):
     def clientside_callback(
         self, clientside_function, output, inputs=[], state=[]
     ):
-        """
-        Create a callback that updates the output by calling a clientside
+        """Create a callback that updates the output by calling a clientside
         (JavaScript) function instead of a Python function.
 
         Unlike `@app.calllback`, `clientside_callback` is not a decorator:
@@ -1518,9 +1510,8 @@ class Dash(object):
         dev_tools_silence_routes_logging=None,
         dev_tools_prune_errors=None,
     ):
-        """
-        Activate the dev tools, called by `run_server`. If your application is
-        served by wsgi and you want to activate the dev tools, you can call
+        """Activate the dev tools, called by `run_server`. If your application
+        is served by wsgi and you want to activate the dev tools, you can call
         this method out of `__main__`.
 
         All parameters can be set by environment variables as listed.
@@ -1734,8 +1725,7 @@ class Dash(object):
         dev_tools_prune_errors=None,
         **flask_run_options
     ):
-        """
-        Start the flask server in local mode, you should not run this on a
+        """Start the flask server in local mode, you should not run this on a
         production server, use gunicorn/waitress instead.
 
         If a parameter can be set by an environment variable, that is listed

--- a/dash/development/_py_components_generation.py
+++ b/dash/development/_py_components_generation.py
@@ -10,9 +10,8 @@ from .base_component import Component
 
 # pylint: disable=unused-argument
 def generate_class_string(typename, props, description, namespace):
-    """
-    Dynamically generate class strings to have nicely formatted docstrings,
-    keyword arguments, and repr
+    """Dynamically generate class strings to have nicely formatted docstrings,
+    keyword arguments, and repr.
 
     Inspired by http://jameso.be/2013/08/06/namedtuple.html
 
@@ -26,7 +25,6 @@ def generate_class_string(typename, props, description, namespace):
     Returns
     -------
     string
-
     """
     # TODO _prop_names, _type, _namespace, and available_properties
     # can be modified by a Dash JS developer via setattr
@@ -111,8 +109,7 @@ def generate_class_string(typename, props, description, namespace):
 
 
 def generate_class_file(typename, props, description, namespace):
-    """
-    Generate a python class file (.py) given a class string
+    """Generate a python class file (.py) given a class string.
 
     Parameters
     ----------
@@ -123,7 +120,6 @@ def generate_class_file(typename, props, description, namespace):
 
     Returns
     -------
-
     """
     import_string =\
         "# AUTO GENERATED FILE - DO NOT EDIT\n\n" + \
@@ -175,8 +171,7 @@ def generate_classes_files(project_shortname, metadata, *component_generators):
 
 
 def generate_class(typename, props, description, namespace):
-    """
-    Generate a python class object given a class string
+    """Generate a python class object given a class string.
 
     Parameters
     ----------
@@ -187,7 +182,6 @@ def generate_class(typename, props, description, namespace):
 
     Returns
     -------
-
     """
     string = generate_class_string(typename, props, description, namespace)
     scope = {'Component': Component, '_explicitize_args': _explicitize_args}
@@ -198,8 +192,7 @@ def generate_class(typename, props, description, namespace):
 
 
 def required_props(props):
-    """
-    Pull names of required props from the props object
+    """Pull names of required props from the props object.
 
     Parameters
     ----------
@@ -215,8 +208,7 @@ def required_props(props):
 
 
 def create_docstring(component_name, props, description):
-    """
-    Create the Dash component docstring
+    """Create the Dash component docstring.
 
     Parameters
     ----------
@@ -258,8 +250,8 @@ Keyword arguments:\n{args}"""
 
 
 def prohibit_events(props):
-    """
-    Events have been removed. Raise an error if we see dashEvents or fireEvents
+    """Events have been removed. Raise an error if we see dashEvents or
+    fireEvents.
 
     Parameters
     ----------
@@ -277,8 +269,7 @@ def prohibit_events(props):
 
 
 def parse_wildcards(props):
-    """
-    Pull out the wildcard attributes from the Component props
+    """Pull out the wildcard attributes from the Component props.
 
     Parameters
     ----------
@@ -298,9 +289,8 @@ def parse_wildcards(props):
 
 
 def reorder_props(props):
-    """
-    If "children" is in props, then move it to the
-    front to respect dash convention
+    """If "children" is in props, then move it to the front to respect dash
+    convention.
 
     Parameters
     ----------
@@ -322,8 +312,8 @@ def reorder_props(props):
 
 
 def filter_props(props):
-    """
-    Filter props from the Component arguments to exclude:
+    """Filter props from the Component arguments to exclude:
+
         - Those without a "type" or a "flowType" field
         - Those with arg.type.name in {'func', 'symbol', 'instanceOf'}
 
@@ -397,8 +387,7 @@ def filter_props(props):
 # pylint: disable=too-many-arguments
 def create_prop_docstring(prop_name, type_object, required, description,
                           default, indent_num, is_flow_type=False):
-    """
-    Create the Dash component prop docstring
+    """Create the Dash component prop docstring.
 
     Parameters
     ----------
@@ -469,7 +458,7 @@ def create_prop_docstring(prop_name, type_object, required, description,
 
 
 def map_js_to_py_types_prop_types(type_object):
-    """Mapping from the PropTypes js type object to the Python type"""
+    """Mapping from the PropTypes js type object to the Python type."""
 
     def shape_or_exact():
         return 'dict containing keys {}.\n{}'.format(
@@ -515,7 +504,7 @@ def map_js_to_py_types_prop_types(type_object):
 
         # React's PropTypes.arrayOf
         arrayOf=lambda: (
-            "list" + ((" of {}").format(
+            "list" + (" of {}".format(
                 js_to_py_type(type_object["value"]) + 's'
                 if js_to_py_type(type_object["value"]).split(' ')[0] != 'dict'
                 else js_to_py_type(type_object["value"]).replace(
@@ -540,7 +529,7 @@ def map_js_to_py_types_prop_types(type_object):
 
 
 def map_js_to_py_types_flow_types(type_object):
-    """Mapping from the Flow js types to the Python type"""
+    """Mapping from the Flow js types to the Python type."""
 
     return dict(
         array=lambda: 'list',
@@ -587,8 +576,7 @@ def map_js_to_py_types_flow_types(type_object):
 
 
 def js_to_py_type(type_object, is_flow_type=False, indent_num=0):
-    """
-    Convert JS types to Python types for the component definition
+    """Convert JS types to Python types for the component definition.
 
     Parameters
     ----------

--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -241,10 +241,8 @@ def generate_class_string(name, props, project_shortname, prefix):
 
 # pylint: disable=R0914
 def generate_js_metadata(pkg_data, project_shortname):
-    """
-    Dynamically generate R function to supply JavaScript
-    and CSS dependency information required by the dash
-    package for R.
+    """Dynamically generate R function to supply JavaScript and CSS dependency
+    information required by the dash package for R.
 
     Parameters
     ----------
@@ -333,8 +331,7 @@ def wrap(tag, code):
 
 
 def write_help_file(name, props, description, prefix, rpkg_data):
-    """
-    Write R documentation file (.Rd) given component name and properties
+    """Write R documentation file (.Rd) given component name and properties.
 
     Parameters
     ----------
@@ -347,7 +344,6 @@ def write_help_file(name, props, description, prefix, rpkg_data):
     Returns
     -------
     writes an R help file to the man directory for the generated R package
-
     """
     funcname = format_fn_name(prefix, name)
     file_name = funcname + ".Rd"
@@ -436,8 +432,7 @@ def write_class_file(name,
 
 
 def write_js_metadata(pkg_data, project_shortname, has_wildcards):
-    """
-    Write an internal (not exported) R function to return all JS
+    """Write an internal (not exported) R function to return all JS
     dependencies as required by dash.
 
     Parameters
@@ -446,7 +441,6 @@ def write_js_metadata(pkg_data, project_shortname, has_wildcards):
 
     Returns
     -------
-
     """
     function_string = generate_js_metadata(
         pkg_data=pkg_data, project_shortname=project_shortname
@@ -493,8 +487,7 @@ def generate_rpkg(
         package_suggests,
         has_wildcards,
 ):
-    """
-    Generate documents for R package creation
+    """Generate documents for R package creation.
 
     Parameters
     ----------
@@ -505,10 +498,10 @@ def generate_rpkg(
     package_depends
     package_imports
     package_suggests
+    has_wildcards
 
     Returns
     -------
-
     """
     # Leverage package.json to import specifics which are also applicable
     # to R package that we're generating here, use .get in case the key
@@ -737,7 +730,7 @@ def make_namespace_exports(components, prefix):
 
 
 def get_r_prop_types(type_object):
-    """Mapping from the PropTypes js type object to the R type"""
+    """Mapping from the PropTypes js type object to the R type."""
 
     def shape_or_exact():
         return 'lists containing elements {}.\n{}'.format(
@@ -782,7 +775,7 @@ def get_r_prop_types(type_object):
         ),
         # React's PropTypes.arrayOf
         arrayOf=lambda: (
-            "list" + ((" of {}s").format(
+            "list" + (" of {}s".format(
                 get_r_type(type_object["value"]))
                       if get_r_type(type_object["value"]) != ""
                       else "")
@@ -808,7 +801,7 @@ def get_r_type(type_object, is_flow_type=False, indent_num=0):
     ----------
     type_object: dict
         react-docgen-generated prop type dictionary
-
+    is_flow_type: bool
     indent_num: int
         Number of indents to use for the docstring for the prop
     Returns

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -196,9 +196,8 @@ class Component(with_metaclass(ComponentMeta, object)):
     # - __len__
 
     def __getitem__(self, id):  # pylint: disable=redefined-builtin
-        """Recursively find the element with the given ID through the tree
-        of children.
-        """
+        """Recursively find the element with the given ID through the tree of
+        children."""
 
         # A component's children can be undefined, a string, another component,
         # or a list of components.

--- a/dash/development/build_process.py
+++ b/dash/development/build_process.py
@@ -66,7 +66,7 @@ class BuildProcess(object):
 
     @job("run `npm i --ignore-scripts`")
     def npm(self):
-        """job to install npm packages"""
+        """Job to install npm packages."""
         os.chdir(self.main)
         self._clean_path(self.package_lock)
         run_command_with_process("npm i --ignore-scripts")
@@ -157,7 +157,7 @@ class BuildProcess(object):
 
 class Renderer(BuildProcess):
     def __init__(self):
-        # dash-renderer's path is binding with the dash folder hierarchy
+        """dash-renderer's path is binding with the dash folder hierarchy."""
         super(Renderer, self).__init__(
             self._concat(
                 os.path.dirname(__file__),

--- a/dash/development/component_loader.py
+++ b/dash/development/component_loader.py
@@ -64,8 +64,8 @@ def load_components(metadata_path, namespace="default_namespace"):
 
 
 def generate_classes(namespace, metadata_path="lib/metadata.json"):
-    """Load React component metadata into a format Dash can parse,
-    then create python class files.
+    """Load React component metadata into a format Dash can parse, then create
+    python class files.
 
     Usage: generate_classes()
 

--- a/dash/testing/application_runners.py
+++ b/dash/testing/application_runners.py
@@ -25,10 +25,8 @@ logger = logging.getLogger(__name__)
 
 
 def import_app(app_file, application_name="app"):
-    """
-    Import a dash application from a module.
-    The import path is in dot notation to the module.
-    The variable named app will be returned.
+    """Import a dash application from a module. The import path is in dot
+    notation to the module. The variable named app will be returned.
 
     :Example:
 
@@ -97,7 +95,7 @@ class BaseDashRunner(object):
 
     @property
     def url(self):
-        """the default server url"""
+        """The default server url."""
         return "http://localhost:{}".format(self.port)
 
     @property
@@ -106,9 +104,9 @@ class BaseDashRunner(object):
 
 
 class ThreadedRunner(BaseDashRunner):
-    """Runs a dash application in a thread
+    """Runs a dash application in a thread.
 
-    this is the default flavor to use in dash integration tests
+    This is the default flavor to use in dash integration tests.
     """
 
     def __init__(self, keep_open=False, stop_timeout=3):
@@ -129,7 +127,7 @@ class ThreadedRunner(BaseDashRunner):
 
     # pylint: disable=arguments-differ,C0330
     def start(self, app, **kwargs):
-        """Start the app server in threading flavor"""
+        """Start the app server in threading flavor."""
         app.server.add_url_rule(
             self.stop_route, self.stop_route, self._stop_server
         )
@@ -167,9 +165,9 @@ class ThreadedRunner(BaseDashRunner):
 
 
 class ProcessRunner(BaseDashRunner):
-    """Runs a dash application in a waitress-serve subprocess
+    """Runs a dash application in a waitress-serve subprocess.
 
-    this flavor is closer to production environment but slower
+    This flavor is closer to production environment but slower.
     """
 
     def __init__(self, keep_open=False, stop_timeout=3):
@@ -187,7 +185,7 @@ class ProcessRunner(BaseDashRunner):
         port=8050,
         start_timeout=3,
     ):
-        """Start the server with waitress-serve in process flavor """
+        """Start the server with waitress-serve in process flavor."""
         if not (app_module or raw_command):  # need to set a least one
             logging.error(
                 "the process runner needs to start with"
@@ -251,7 +249,7 @@ class RRunner(ProcessRunner):
 
     # pylint: disable=arguments-differ
     def start(self, app, start_timeout=2):
-        """Start the server with waitress-serve in process flavor """
+        """Start the server with waitress-serve in process flavor."""
 
         # app is a R string chunk
         if not (os.path.isfile(app) and os.path.exists(app)):

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -101,8 +101,8 @@ class Browser(DashPageMixin):
             logger.exception("percy runner failed to finalize properly")
 
     def percy_snapshot(self, name=""):
-        """percy_snapshot - visual test api shortcut to `percy_runner.snapshot`
-        it also combines the snapshot `name` with the python version
+        """percy_snapshot - visual test api shortcut to `percy_runner.snapshot`.
+        It also combines the snapshot `name` with the python version.
         """
         snapshot_name = "{} - py{}.{}".format(
             name, sys.version_info.major, sys.version_info.minor
@@ -111,8 +111,9 @@ class Browser(DashPageMixin):
         self.percy_runner.snapshot(name=snapshot_name)
 
     def take_snapshot(self, name):
-        """hook method to take snapshot when a selenium test fails
-        The snapshot is placed under
+        """Hook method to take snapshot when a selenium test fails. The
+        snapshot is placed under.
+
             - `/tmp/dash_artifacts` in linux
             - `%TEMP` in windows
         with a filename combining test case name and the
@@ -135,13 +136,14 @@ class Browser(DashPageMixin):
 
     def find_element(self, selector):
         """find_element returns the first found element by the css `selector`
-        shortcut to `driver.find_element_by_css_selector`
-        """
+        shortcut to `driver.find_element_by_css_selector`."""
         return self.driver.find_element_by_css_selector(selector)
 
     def find_elements(self, selector):
         """find_elements returns a list of all elements matching the css
-        `selector`. shortcut to `driver.find_elements_by_css_selector`
+        `selector`.
+
+        shortcut to `driver.find_elements_by_css_selector`.
         """
         return self.driver.find_elements_by_css_selector(selector)
 
@@ -151,7 +153,7 @@ class Browser(DashPageMixin):
         return elem_or_selector
 
     def _wait_for(self, method, args, timeout, msg):
-        """abstract generic pattern for explicit WebDriverWait"""
+        """Abstract generic pattern for explicit WebDriverWait."""
         _wait = (
             self._wd_wait
             if timeout is None
@@ -168,15 +170,13 @@ class Browser(DashPageMixin):
 
     def wait_for_element(self, selector, timeout=None):
         """wait_for_element is shortcut to `wait_for_element_by_css_selector`
-        timeout if not set, equals to the fixture's `wait_timeout`
-        """
+        timeout if not set, equals to the fixture's `wait_timeout`."""
         return self.wait_for_element_by_css_selector(selector, timeout)
 
     def wait_for_element_by_css_selector(self, selector, timeout=None):
-        """explicit wait until the element is present,
-        timeout if not set, equals to the fixture's `wait_timeout`
-        shortcut to `WebDriverWait` with `EC.presence_of_element_located`
-        """
+        """Explicit wait until the element is present, timeout if not set,
+        equals to the fixture's `wait_timeout` shortcut to `WebDriverWait` with
+        `EC.presence_of_element_located`."""
         return self._wait_for(
             EC.presence_of_element_located,
             ((By.CSS_SELECTOR, selector),),
@@ -187,10 +187,9 @@ class Browser(DashPageMixin):
         )
 
     def wait_for_element_by_id(self, element_id, timeout=None):
-        """explicit wait until the element is present,
-        timeout if not set, equals to the fixture's `wait_timeout`
-        shortcut to `WebDriverWait` with `EC.presence_of_element_located`
-        """
+        """Explicit wait until the element is present, timeout if not set,
+        equals to the fixture's `wait_timeout` shortcut to `WebDriverWait` with
+        `EC.presence_of_element_located`."""
         return self._wait_for(
             EC.presence_of_element_located,
             ((By.ID, element_id),),
@@ -201,10 +200,9 @@ class Browser(DashPageMixin):
         )
 
     def wait_for_style_to_equal(self, selector, style, val, timeout=None):
-        """explicit wait until the element's style has expected `value`
-        timeout if not set, equals to the fixture's `wait_timeout`
-        shortcut to `WebDriverWait` with customized `style_to_equal` condition
-        """
+        """Explicit wait until the element's style has expected `value` timeout
+        if not set, equals to the fixture's `wait_timeout` shortcut to
+        `WebDriverWait` with customized `style_to_equal` condition."""
         return self._wait_for(
             method=style_to_equal,
             args=(selector, style, val),
@@ -215,9 +213,11 @@ class Browser(DashPageMixin):
         )
 
     def wait_for_text_to_equal(self, selector, text, timeout=None):
-        """explicit wait until the element's text equals the expected `text`.
+        """Explicit wait until the element's text equals the expected `text`.
+
         timeout if not set, equals to the fixture's `wait_timeout`
-        shortcut to `WebDriverWait` with customized `text_to_equal` condition
+        shortcut to `WebDriverWait` with customized `text_to_equal`
+        condition.
         """
         return self._wait_for(
             method=text_to_equal,
@@ -229,9 +229,11 @@ class Browser(DashPageMixin):
         )
 
     def wait_for_contains_text(self, selector, text, timeout=None):
-        """explicit wait until the element's text contains the expected `text`.
+        """Explicit wait until the element's text contains the expected `text`.
+
         timeout if not set, equals to the fixture's `wait_timeout`
-        shortcut to `WebDriverWait` with customized `contains_text` condition
+        shortcut to `WebDriverWait` with customized `contains_text`
+        condition.
         """
         return self._wait_for(
             method=contains_text,
@@ -243,9 +245,10 @@ class Browser(DashPageMixin):
         )
 
     def wait_for_page(self, url=None, timeout=10):
-        """wait_for_page navigates to the url in webdriver
-        wait until the renderer is loaded in browser. use the `server_url`
-        if url is not provided.
+        """wait_for_page navigates to the url in webdriver wait until the
+        renderer is loaded in browser.
+
+        use the `server_url` if url is not provided.
         """
         self.driver.get(self.server_url if url is None else url)
         try:
@@ -296,24 +299,21 @@ class Browser(DashPageMixin):
         )
 
     def toggle_window(self):
-        """switch between the current working window and the new opened one"""
+        """Switch between the current working window and the new opened one."""
         idx = (self._window_idx + 1) % 2
         self.switch_window(idx=idx)
         self._window_idx += 1
 
     def switch_window(self, idx=0):
-        """switch to window by window index
-        shortcut to `driver.switch_to.window`
-        """
+        """Switch to window by window index shortcut to
+        `driver.switch_to.window`."""
         if len(self.driver.window_handles) <= idx:
             raise BrowserError("there is no second window in Browser")
 
         self.driver.switch_to.window(self.driver.window_handles[idx])
 
     def open_new_tab(self, url=None):
-        """open a new tab in browser
-        url is not set, equals to `server_url`
-        """
+        """Open a new tab in browser url is not set, equals to `server_url`."""
         self.driver.execute_script(
             'window.open("{}", "new window")'.format(
                 self.server_url if url is None else url
@@ -422,12 +422,12 @@ class Browser(DashPageMixin):
         return sys.platform == "win32"
 
     def multiple_click(self, elem_or_selector, clicks):
-        """multiple_click click the element with number of `clicks`"""
+        """multiple_click click the element with number of `clicks`."""
         for _ in range(clicks):
             self._get_element(elem_or_selector).click()
 
     def clear_input(self, elem_or_selector):
-        """simulate key press to clear the input"""
+        """Simulate key press to clear the input."""
         elem = self._get_element(elem_or_selector)
 
         (
@@ -447,10 +447,9 @@ class Browser(DashPageMixin):
         zoom_box_fraction=0.2,
         compare=True
     ):
-        """zoom out a graph with a zoom box fraction of component dimension
-        default start at middle with a rectangle of 1/5 of the dimension
-        use `compare` to control if we check the svg get changed
-        """
+        """Zoom out a graph with a zoom box fraction of component dimension
+        default start at middle with a rectangle of 1/5 of the dimension use
+        `compare` to control if we check the svg get changed."""
         elem = self._get_element(elem_or_selector)
 
         prev = elem.get_attribute("innerHTML")
@@ -476,8 +475,10 @@ class Browser(DashPageMixin):
         ).click().perform()
 
     def get_logs(self):
-        """return a list of `SEVERE` level logs after last reset time stamps
-        (default to 0, resettable by `reset_log_timestamp`. Chrome only
+        """Return a list of `SEVERE` level logs after last reset time stamps
+        (default to 0, resettable by `reset_log_timestamp`.
+
+        Chrome only
         """
         if self.driver.name.lower() == "chrome":
             return [
@@ -491,7 +492,7 @@ class Browser(DashPageMixin):
         return None
 
     def reset_log_timestamp(self):
-        """reset_log_timestamp only work with chrome webdrier"""
+        """reset_log_timestamp only work with chrome webdrier."""
         if self.driver.name.lower() == "chrome":
             entries = self.driver.get_log("browser")
             if entries:
@@ -516,7 +517,7 @@ class Browser(DashPageMixin):
 
     @property
     def driver(self):
-        """expose the selenium webdriver as fixture property"""
+        """Expose the selenium webdriver as fixture property."""
         return self._driver
 
     @property
@@ -529,8 +530,10 @@ class Browser(DashPageMixin):
 
     @server_url.setter
     def server_url(self, value):
-        """set the server url so the selenium is aware of the local server port
-        it also implicitly calls `wait_for_page`
+        """Set the server url so the selenium is aware of the local server
+        port.
+
+        It also implicitly calls `wait_for_page`.
         """
         self._url = value
         self.wait_for_page()

--- a/dash/testing/composite.py
+++ b/dash/testing/composite.py
@@ -7,7 +7,7 @@ class DashComposite(Browser):
         self.server = server
 
     def start_server(self, app, **kwargs):
-        """start the local server with app"""
+        """Start the local server with app."""
 
         # start server with app and pass Dash arguments
         self.server(app, **kwargs)

--- a/dash/testing/errors.py
+++ b/dash/testing/errors.py
@@ -11,16 +11,16 @@ class NoAppFoundError(DashTestingError):
 
 
 class DashAppLoadingError(DashTestingError):
-    """The dash app failed to load"""
+    """The dash app failed to load."""
 
 
 class ServerCloseError(DashTestingError):
-    """The server cannot be closed"""
+    """The server cannot be closed."""
 
 
 class TestingTimeoutError(DashTestingError):
-    """all timeout error about dash testing"""
+    """All timeout error about dash testing."""
 
 
 class BrowserError(DashTestingError):
-    """all browser relevant errors"""
+    """All browser relevant errors."""

--- a/dash/testing/newhooks.py
+++ b/dash/testing/newhooks.py
@@ -1,2 +1,2 @@
 def pytest_setup_options():
-    """called before webdriver is initialized"""
+    """Called before webdriver is initialized."""

--- a/dash/testing/plugin.py
+++ b/dash/testing/plugin.py
@@ -97,14 +97,14 @@ def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
 
 @pytest.fixture
 def dash_thread_server():
-    """Start a local dash server in a new thread"""
+    """Start a local dash server in a new thread."""
     with ThreadedRunner() as starter:
         yield starter
 
 
 @pytest.fixture
 def dash_process_server():
-    """Start a Dash server with subprocess.Popen and waitress-serve"""
+    """Start a Dash server with subprocess.Popen and waitress-serve."""
     with ProcessRunner() as starter:
         yield starter
 

--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-few-public-methods
-"""Utils methods for pytest-dash such wait_for wrappers"""
+"""Utils methods for pytest-dash such wait_for wrappers."""
 import time
 import logging
 from selenium.common.exceptions import WebDriverException

--- a/tests/integration/callbacks/test_basic_callback.py
+++ b/tests/integration/callbacks/test_basic_callback.py
@@ -47,7 +47,7 @@ def test_cbsc001_simple_callback(dash_duo):
 
 
 def test_cbsc002_callbacks_generating_children(dash_duo):
-    """Modify the DOM tree by adding new components in the callbacks"""
+    """Modify the DOM tree by adding new components in the callbacks."""
 
     # some components don't exist in the initial render
     app = dash.Dash(__name__, suppress_callback_exceptions=True)

--- a/tests/integration/dash_assets/test_dash_assets.py
+++ b/tests/integration/dash_assets/test_dash_assets.py
@@ -10,8 +10,7 @@ from dash import Dash
 
 def test_dada001_assets(dash_duo):
     app = Dash(__name__, assets_ignore=".*ignored.*")
-    app.index_string = """
-    <!DOCTYPE html>
+    app.index_string = """<!DOCTYPE html>
     <html>
         <head>
             {%metas%}
@@ -27,8 +26,7 @@ def test_dada001_assets(dash_duo):
                 {%renderer%}
             </footer>
         </body>
-    </html>
-    """
+    </html>"""
 
     app.layout = html.Div(
         [html.Div("Content", id="content"), dcc.Input(id="test")], id="layout"
@@ -92,8 +90,7 @@ def test_dada002_external_files_init(dash_duo):
         __name__, external_scripts=js_files, external_stylesheets=css_files
     )
 
-    app.index_string = """
-    <!DOCTYPE html>
+    app.index_string = """<!DOCTYPE html>
     <html>
         <head>
             {%metas%}
@@ -111,8 +108,7 @@ def test_dada002_external_files_init(dash_duo):
                 {%renderer%}
             </footer>
         </body>
-    </html>
-    """
+    </html>"""
 
     app.layout = html.Div()
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -118,10 +118,8 @@ def test_inin002_wildcard_callback(dash_duo):
 
 
 def test_inin003_aborted_callback(dash_duo):
-    """
-    Raising PreventUpdate OR returning no_update
-    prevents update and triggering dependencies
-    """
+    """Raising PreventUpdate OR returning no_update prevents update and
+    triggering dependencies."""
 
     initial_input = "initial input"
     initial_output = "initial output"
@@ -296,8 +294,7 @@ def test_inin007_meta_tags(dash_duo):
 def test_inin008_index_customization(dash_duo):
     app = Dash()
 
-    app.index_string = """
-    <!DOCTYPE html>
+    app.index_string = """<!DOCTYPE html>
     <html>
         <head>
             {%metas%}
@@ -327,8 +324,7 @@ def test_inin008_index_customization(dash_duo):
                 .then(r => config = r).catch(err => ({config}));
             </script>
         </body>
-    </html>
-    """
+    </html>"""
 
     app.layout = html.Div("Dash app", id="app")
 
@@ -345,8 +341,7 @@ def test_inin009_invalid_index_string(dash_duo):
     app = Dash()
 
     def will_raise():
-        app.index_string = """
-        <!DOCTYPE html>
+        app.index_string = """<!DOCTYPE html>
         <html>
             <head>
                 {%metas%}
@@ -360,8 +355,7 @@ def test_inin009_invalid_index_string(dash_duo):
                 <footer>
                 </footer>
             </body>
-        </html>
-        """
+        </html>"""
 
     with pytest.raises(Exception) as err:
         will_raise()
@@ -564,7 +558,7 @@ def test_inin013_no_update_chains(dash_duo):
         [Input("a_in", "value")],
     )
     def a_out(a):
-        return (a, a if len(a) < 3 else no_update)
+        return a, a if len(a) < 3 else no_update
 
     @app.callback(Output("b_out", "children"), [Input("b_in", "value")])
     def b_out(b):
@@ -612,8 +606,7 @@ def test_inin013_no_update_chains(dash_duo):
 def test_inin014_with_custom_renderer(dash_duo):
     app = Dash(__name__)
 
-    app.index_string = """
-    <!DOCTYPE html>
+    app.index_string = """<!DOCTYPE html>
     <html>
         <head>
             {%metas%}
@@ -647,8 +640,7 @@ def test_inin014_with_custom_renderer(dash_duo):
             </footer>
             <div>With request hooks</div>
         </body>
-    </html>
-    """
+    </html>"""
 
     app.layout = html.Div(
         [
@@ -707,8 +699,7 @@ def test_inin015_with_custom_renderer_interpolated(dash_duo):
 
     class CustomDash(Dash):
         def interpolate_index(self, **kwargs):
-            return """
-            <!DOCTYPE html>
+            return """<!DOCTYPE html>
             <html>
                 <head>
                     <title>My App</title>
@@ -722,13 +713,10 @@ def test_inin015_with_custom_renderer_interpolated(dash_duo):
                     {renderer}
                     <div id="custom-footer">My custom footer</div>
                 </body>
-            </html>
-            """.format(
-                app_entry=kwargs["app_entry"],
-                config=kwargs["config"],
-                scripts=kwargs["scripts"],
-                renderer=renderer,
-            )
+            </html>""".format(app_entry=kwargs["app_entry"],
+                              config=kwargs["config"],
+                              scripts=kwargs["scripts"],
+                              renderer=renderer)
 
     app = CustomDash()
 

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -175,7 +175,7 @@ class Tests(IntegrationTests):
         @app.callback(Output('output', 'children'),
                       [Input('button', 'n_clicks')])
         def update_output(n_clicks):
-            if(not n_clicks):
+            if not n_clicks:
                 raise PreventUpdate
             call_count.value += 1
             return 'Click'
@@ -811,8 +811,7 @@ class Tests(IntegrationTests):
     def test_request_hooks(self):
         app = Dash(__name__)
 
-        app.index_string = '''
-        <!DOCTYPE html>
+        app.index_string = '''<!DOCTYPE html>
         <html>
             <head>
                 {%metas%}
@@ -857,8 +856,7 @@ class Tests(IntegrationTests):
                 </footer>
                 <div>With request hooks</div>
             </body>
-        </html>
-        '''
+        </html>'''
 
         app.layout = html.Div([
             dcc.Input(

--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -18,9 +18,10 @@ class WaitForTimeout(Exception):
 
 
 def wait_for(condition_function, get_message=lambda: '', *args, **kwargs):
-    """
-    Waits for condition_function to return True or raises WaitForTimeout.
+    """Waits for condition_function to return True or raises WaitForTimeout.
+
     :param (function) condition_function: Should return True on success.
+    :param (function) get_message:
     :param args: Optional args to pass to condition_function.
     :param kwargs: Optional kwargs to pass to condition_function.
         if `timeout` is in kwargs, it will be used to override TIMEOUT

--- a/tests/unit/development/test_base_component.py
+++ b/tests/unit/development/test_base_component.py
@@ -13,6 +13,7 @@ Component._valid_wildcard_attributes = ["data-", "aria-"]
 
 def nested_tree():
     """This tree has a few unique properties:
+
     - children is mixed strings and components (as in c2)
     - children is just components (as in c)
     - children is just strings (as in c1)


### PR DESCRIPTION
Remove whitespace.  Full stop at end of first sentence. Use triple double quotes.  Capital letter to start Docstring. Add missing docstring params.

https://www.python.org/dev/peps/pep-0257/

Found this great Docstring autoformater called `docformatter`.

https://pypi.org/project/docformatter/ 

`docformatter --in-place --recursive tests` is an example run 👍 

Minor fix to remove unneeded parens.

Another minor fix to remove the first and last blank lines from HTML in view source mode.