### PR TITLE
Make component generator accept whitespace in paths

### DIFF
--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -51,8 +51,6 @@ def generate_components(
 
     project_shortname = project_shortname.replace("-", "_").rstrip("/\\")
 
-    is_windows = sys.platform == "win32"
-
     extract_path = pkg_resources.resource_filename("dash", "extract-meta.js")
 
     reserved_patterns = "|".join("^{}$".format(p) for p in reserved_words)
@@ -60,10 +58,9 @@ def generate_components(
     os.environ["NODE_PATH"] = "node_modules"
 
     cmd = shlex.split(
-        'node {} "{}" "{}" {}'.format(
+        'node "{}" "{}" "{}" {}'.format(
             extract_path, ignore, reserved_patterns, components_source
         ),
-        posix=not is_windows,
     )
 
     shutil.copyfile(
@@ -71,7 +68,7 @@ def generate_components(
     )
 
     proc = subprocess.Popen(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=is_windows
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
     out, err = proc.communicate()
     status = proc.poll()


### PR DESCRIPTION
Hello,

I've made some tweaks to the component generator in an attempt to make it more lenient with the paths that Dash boilerplate projects can be set up at. Specifically, paths with whitespace should now be acceptable.

Some remarks concerning the changes:

* Quoting the path to the `extract-meta.js` script helps avoid it being interpreted as multiple arguments (i.e. delimited by whitespace) when passed to Node
* Non-POSIX mode for `shlex.split()` appears to undesirably interfere with the script path, producing something incorrect on my Windows box, which I thought was odd.
* Also got rid of the `shell=True` because according to the [`subprocess.Popen` documentation][1], _"The only time you need to specify shell=True on Windows is when the command you wish to execute is built into the shell (e.g. dir or copy)."_

I also tested these changes on an Ubuntu box to see whether paths with whitespace could work, and they did.

Relevant issue reported previously: plotly/dash-component-boilerplate#71

[1]: https://docs.python.org/3.7/library/subprocess.html#subprocess.Popen