### PR TITLE
Include newly minted `Dash` framework

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
+        "Framework :: Dash",
         "Framework :: Flask",
         "Intended Audience :: Developers",
         "Intended Audience :: Education",


### PR DESCRIPTION
`Framework :: Dash` is now an official PyPI trove classifier. See https://github.com/pypa/warehouse/issues/6273 for the great community-led effort to make this possible.

Published Dash-related packages that have this classifier can be found on PyPI at https://pypi.org/search/?q=&o=&c=Framework+%3A%3A+Dash.
- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow
    -  [ ] this github [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in plotly dash community 
