### PR TITLE
eval eager_loading when ready

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- [#986](https://github.com/plotly/dash/pull/986) Fix bug with evaluation of `_force_eager_loading` when application is loaded with gunicorn
+
 ## [1.5.0] - 2019-10-29
 ### Added
 - [#964](https://github.com/plotly/dash/pull/964) Adds support for preventing updates in clientside functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Fixed
-- [#986](https://github.com/plotly/dash/pull/986) Fix bug with evaluation of `_force_eager_loading` when application is loaded with gunicorn
+- [#986](https://github.com/plotly/dash/pull/986) Fix a bug with evaluation of `_force_eager_loading` when application is loaded with gunicorn
 
 ## [1.5.0] - 2019-10-29
 ### Added

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -229,12 +229,6 @@ class Dash(object):
         plugins=None,
         **obsolete
     ):
-        # Apply _force_eager_loading overrides from modules
-        for module_name in ComponentRegistry.registry:
-            module = sys.modules[module_name]
-            eager = getattr(module, '_force_eager_loading', False)
-            eager_loading = eager_loading or eager
-
         for key in obsolete:
             if key in ["components_cache_max_age", "static_folder"]:
                 raise exceptions.ObsoleteKwargException(
@@ -272,6 +266,7 @@ class Dash(object):
             assets_external_path=get_combined_config(
                 "assets_external_path", assets_external_path, ""
             ),
+            eager_loading=eager_loading,
             include_assets_files=get_combined_config(
                 "include_assets_files", include_assets_files, True
             ),
@@ -1434,6 +1429,16 @@ class Dash(object):
             component_ids.add(component_id)
 
     def _setup_server(self):
+        # Apply _force_eager_loading overrides from modules
+        eager_loading = self.config.eager_loading
+        for module_name in ComponentRegistry.registry:
+            module = sys.modules[module_name]
+            eager = getattr(module, '_force_eager_loading', False)
+            eager_loading = eager_loading or eager
+
+        # Update eager_loading settings
+        self.scripts.config.eager_loading = eager_loading
+
         if self.config.include_assets_files:
             self._walk_assets_directory()
 


### PR DESCRIPTION
Fixes #984 - delays (reevaluates) Css and Scripts at the moment when the server is ready instead of doing so during initialization.

This should allow us to handle both (1) app.run_server and (2) gunicorn / multi-page apps correctly.