### PR TITLE
Issue 995 - Correctly support `version-prerelease+metadata` in fingerprint

### DIFF
--- a/@plotly/webpack-dash-dynamic-import/src/index.js
+++ b/@plotly/webpack-dash-dynamic-import/src/index.js
@@ -5,7 +5,7 @@ function getFingerprint() {
     const packageJson = JSON.parse(package);
 
     const timestamp = Math.round(Date.now() / 1000);
-    const version = packageJson.version.replace(/[.]/g, '_');
+    const version = packageJson.version.replace(/[.]/g, '_').replace(/[+]/g, '__');
 
     return `"v${version}m${timestamp}"`;
 }

--- a/@plotly/webpack-dash-dynamic-import/src/index.js
+++ b/@plotly/webpack-dash-dynamic-import/src/index.js
@@ -5,7 +5,7 @@ function getFingerprint() {
     const packageJson = JSON.parse(package);
 
     const timestamp = Math.round(Date.now() / 1000);
-    const version = packageJson.version.replace(/[.]/g, '_').replace(/[+]/g, '__');
+    const version = packageJson.version.replace(/[^\w-]/g, '_');
 
     return `"v${version}m${timestamp}"`;
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
+- [#999](https://github.com/plotly/dash/pull/999) Fix fingerprint for component suites with `metadata` in version
 - [#983](https://github.com/plotly/dash/pull/983) Fix the assets loading issues when dashR application runner is handling with an app defined by string chunk.
 
 ## [1.5.1] - 2019-10-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Fixed
-- [#999](https://github.com/plotly/dash/pull/999) Fix fingerprint for component suites with `metadata` in version
+- [#999](https://github.com/plotly/dash/pull/999) Fix fingerprint for component suites with `metadata` in version.
 - [#983](https://github.com/plotly/dash/pull/983) Fix the assets loading issues when dashR application runner is handling with an app defined by string chunk.
 
 ## [1.5.1] - 2019-10-29

--- a/dash/fingerprint.py
+++ b/dash/fingerprint.py
@@ -1,7 +1,7 @@
 import re
 
 cache_regex = re.compile(r"^v[\w-]+m[0-9a-fA-F]+$")
-
+version_clean = re.compile(r"[^\w-]")
 
 def build_fingerprint(path, version, hash_value):
     path_parts = path.split("/")
@@ -9,7 +9,7 @@ def build_fingerprint(path, version, hash_value):
 
     return "{}.v{}m{}.{}".format(
         "/".join(path_parts[:-1] + [filename]),
-        str(version).replace(".", "_").replace("+", "__"),
+        re.sub(version_clean, "_", str(version)),
         hash_value,
         extension,
     )

--- a/dash/fingerprint.py
+++ b/dash/fingerprint.py
@@ -9,7 +9,7 @@ def build_fingerprint(path, version, hash_value):
 
     return "{}.v{}m{}.{}".format(
         "/".join(path_parts[:-1] + [filename]),
-        str(version).replace(".", "_"),
+        str(version).replace(".", "_").replace("+", "__"),
         hash_value,
         extension,
     )

--- a/tests/integration/devtools/test_props_check.py
+++ b/tests/integration/devtools/test_props_check.py
@@ -216,7 +216,7 @@ test_cases = {
 
 
 def test_dvpc001_prop_check_errors_with_path(dash_duo):
-    app = dash.Dash(__name__)
+    app = dash.Dash(__name__, eager_loading=True)
 
     app.layout = html.Div([html.Div(id="content"), dcc.Location(id="location")])
 

--- a/tests/unit/test_fingerprint.py
+++ b/tests/unit/test_fingerprint.py
@@ -19,7 +19,7 @@ valid_resources = [
     },
     {
         "path": "react@16.8.6.min.js",
-        "fingerprint": "react@16.v1_1_1-alpha_x_y_y_X_Y_Z_1_2_3__metadata_xx_yy_zz_XX_YY_ZZ_11_22_33_mmm1234567890abcdefABCDEF.8.6.min.js",
+        "fingerprint": "react@16.v1_1_1-alpha_x_y_y_X_Y_Z_1_2_3_metadata_xx_yy_zz_XX_YY_ZZ_11_22_33_mmm1234567890abcdefABCDEF.8.6.min.js",
         "version": "1.1.1-alpha.x.y.y.X.Y.Z.1.2.3+metadata.xx.yy.zz.XX.YY.ZZ.11.22.33.mm",
         "hash": "1234567890abcdefABCDEF",
     },

--- a/tests/unit/test_fingerprint.py
+++ b/tests/unit/test_fingerprint.py
@@ -116,8 +116,8 @@ def test_fingerprint():
         (original_path, has_fingerprint) = check_fingerprint(fingerprint)
         # The inverse operation returns that the fingerprint was valid
         # and the original path
-        assert has_fingerprint, original_path
-        assert original_path == resource.get("path"), original_path
+        assert has_fingerprint
+        assert original_path == resource.get("path")
 
     for resource in valid_fingerprints:
         (_, has_fingerprint) = check_fingerprint(resource)

--- a/tests/unit/test_fingerprint.py
+++ b/tests/unit/test_fingerprint.py
@@ -17,6 +17,12 @@ valid_resources = [
         "version": "1.1.1-alpha.1",
         "hash": "1234567890abcdef",
     },
+    {
+        "path": "react@16.8.6.min.js",
+        "fingerprint": "react@16.v1_1_1-alpha_x_y_y_X_Y_Z_1_2_3__metadata_xx_yy_zz_XX_YY_ZZ_11_22_33_mmm1234567890abcdefABCDEF.8.6.min.js",
+        "version": "1.1.1-alpha.x.y.y.X.Y.Z.1.2.3+metadata.xx.yy.zz.XX.YY.ZZ.11.22.33.mm",
+        "hash": "1234567890abcdefABCDEF",
+    },
     {"path": "dash.plotly.js", "fingerprint": "dash.v1m1.plotly.js"},
     {"path": "dash.plotly.j_s", "fingerprint": "dash.v1m1.plotly.j_s"},
     {"path": "dash.plotly.css", "fingerprint": "dash.v1m1.plotly.css"},
@@ -110,8 +116,8 @@ def test_fingerprint():
         (original_path, has_fingerprint) = check_fingerprint(fingerprint)
         # The inverse operation returns that the fingerprint was valid
         # and the original path
-        assert has_fingerprint
-        assert original_path == resource.get("path")
+        assert has_fingerprint, original_path
+        assert original_path == resource.get("path"), original_path
 
     for resource in valid_fingerprints:
         (_, has_fingerprint) = check_fingerprint(resource)


### PR DESCRIPTION
Fixes #995 

Manually tested against

1. Custom table build with version
```
  "version": "4.5.1-alpha1.2.3+metadata.1.2.3-abc",
```

2. The modified version of the `@plotly/webpack-dash-dynamic-import` plugin

3. App, with both `eager_loading` true / false to trigger async resources from both DashPy and the plugin
```
import json
import pandas as pd
from datetime import datetime

import dash
from dash.dependencies import Input, Output, State
from dash.exceptions import PreventUpdate

import dash_table
import dash_core_components as dcc
import dash_html_components as html

app = dash.Dash(__name__, eager_loading=False)

app.layout = html.Div([
    dcc.DatePickerRange(
        id="date-picker-range",
        start_date_id="startDate",
        end_date_id="endDate",
        start_date=datetime(1997, 5, 3),
        end_date_placeholder_text="Select a date!",
    ),
    dash_table.DataTable(
        columns=[],
        data=[]
    )
])

if __name__ == '__main__':
    app.run_server(debug=False)
```