### PR TITLE
add stay_on_page to testing visit_and_snapshot method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
-- [#967](https://github.com/plotly/dash/pull/967) Adds support for defining
+- [#967](https://github.com/plotly/dash/pull/967) Add support for defining
 clientside JavaScript callbacks via inline strings.
+- [#1020](https://github.com/plotly/dash/pull/1020) Allow `visit_and_snapshot` method in `dash.testing` fixtures to stay on the page so you can run other checks.
 
 ### Fixed
 - [#1018](https://github.com/plotly/dash/pull/1006) Fix the `dash.testing` **stop** API with process application runner in Python2. Use `kill()` instead of `communicate()` to avoid hanging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - [#967](https://github.com/plotly/dash/pull/967) Add support for defining
 clientside JavaScript callbacks via inline strings.
-- [#1020](https://github.com/plotly/dash/pull/1020) Allow `visit_and_snapshot` method in `dash.testing` fixtures to stay on the page so you can run other checks.
+- [#1020](https://github.com/plotly/dash/pull/1020) Allow `visit_and_snapshot` API in `dash.testing.browser`  to stay on the page so you can run other checks.
 
 ### Fixed
 - [#1018](https://github.com/plotly/dash/pull/1006) Fix the `dash.testing` **stop** API with process application runner in Python2. Use `kill()` instead of `communicate()` to avoid hanging.

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -106,7 +106,12 @@ class Browser(DashPageMixin):
             logger.exception("percy runner failed to finalize properly")
 
     def visit_and_snapshot(
-        self, resource_path, hook_id, wait_for_callbacks=True, assert_check=True
+        self,
+        resource_path,
+        hook_id,
+        wait_for_callbacks=True,
+        assert_check=True,
+        stay_on_page=False
     ):
         try:
             path = resource_path.lstrip("/")
@@ -121,7 +126,8 @@ class Browser(DashPageMixin):
                 assert not self.driver.find_elements_by_css_selector(
                     "div.dash-debug-alert"
                 ), "devtools should not raise an error alert"
-            self.driver.back()
+            if not stay_on_page:
+                self.driver.back()
         except WebDriverException as e:
             logger.exception("snapshot at resource %s error", path)
             raise e


### PR DESCRIPTION
For https://github.com/plotly/dash-docs/pull/707 - I wanted to be able to run an additional test on pages we were visiting with `.visit_and_snapshot` - so this PR adds a `stay_on_page` kwarg, to skip the `driver.back()` that normally happens after taking the snapshot.

- [x] I have added entry in the `CHANGELOG.md`