### PR TITLE
improve error message for components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Fixed
+- [#1045](https://github.com/plotly/dash/pull/1045) Error messages when providing an incorrect property to a component have been improved: they now specify the component type, library, version, and ID (if available).
+
 ## [1.7.0] - 2019-11-27
 ### Added
 - [#967](https://github.com/plotly/dash/pull/967) Add support for defining

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -90,7 +90,7 @@ class Component(with_metaclass(ComponentMeta, object)):
             error_string_prefix = "The `{}.{}` component (version {}){}'.format(
                 self._namespace,
                 self._type,
-                __import__(self._namespace).__version__,                
+                getattr(__import__(self._namespace), '__version__', 'unknown'),                
                 ' with the ID "{}"'.format(getattr(self, 'id') if hasattr(self, 'id') else ''
             )
             if not k_in_propnames and not k_in_wildcards:

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -86,9 +86,12 @@ class Component(with_metaclass(ComponentMeta, object)):
             k_in_wildcards = any(
                 [k.startswith(w) for w in self._valid_wildcard_attributes]
             )
-            error_string_prefix = "The `{}` component{} '.format(
+            # e.g. "The dash_core_components.Dropdown component (version 1.6.0) with the ID "my-dropdown"
+            error_string_prefix = "The `{}.{}` component (version {}){}'.format(
+                self._namespace,
                 self._type,
-                'with the ID "{}"'.format(getattr(self, 'id') if hasattr(self, 'id') else ''
+                __import__(self._namespace).__version__,                
+                ' with the ID "{}"'.format(getattr(self, 'id') if hasattr(self, 'id') else ''
             )
             if not k_in_propnames and not k_in_wildcards:
                 raise TypeError(

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -86,17 +86,20 @@ class Component(with_metaclass(ComponentMeta, object)):
             k_in_wildcards = any(
                 [k.startswith(w) for w in self._valid_wildcard_attributes]
             )
-            # e.g. "The dash_core_components.Dropdown component (version 1.6.0) with the ID "my-dropdown"
+            # e.g. "The dash_core_components.Dropdown component (version 1.6.0)
+            # with the ID "my-dropdown"
             error_string_prefix = "The `{}.{}` component (version {}){}'.format(
                 self._namespace,
                 self._type,
-                getattr(__import__(self._namespace), '__version__', 'unknown'),                
-                ' with the ID "{}"'.format(getattr(self, 'id') if hasattr(self, 'id') else ''
+                getattr(__import__(self._namespace), '__version__', 'unknown'),
+                ' with the ID "{}"'.format(getattr(self, 'id'))
+                if hasattr(self, 'id') else ''
             )
             if not k_in_propnames and not k_in_wildcards:
                 raise TypeError(
-                    "{} received an unexpected keyword argument: `{}`".format(error_string_prefix, k)
-                    + "\nAllowed arguments: {}".format(
+                    "{} received an unexpected keyword argument: `{}`".format(
+                        error_string_prefix, k
+                    ) + "\nAllowed arguments: {}".format(
                         # pylint: disable=no-member
                         ", ".join(sorted(self._prop_names))
                     )

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -88,13 +88,23 @@ class Component(with_metaclass(ComponentMeta, object)):
             )
             # e.g. "The dash_core_components.Dropdown component (version 1.6.0)
             # with the ID "my-dropdown"
-            error_string_prefix = "The `{}.{}` component (version {}){}'.format(
-                self._namespace,
-                self._type,
-                getattr(__import__(self._namespace), '__version__', 'unknown'),
-                ' with the ID "{}"'.format(getattr(self, 'id'))
-                if hasattr(self, 'id') else ''
-            )
+            try:
+                error_string_prefix = 'The `{}.{}` component (version {}){}'.format(
+                    self._namespace,
+                    self._type,
+                    getattr(__import__(self._namespace), '__version__', 'unknown'),
+                    ' with the ID "{}"'.format(getattr(self, 'id'))
+                    if hasattr(self, 'id') else ''
+                )
+            except ImportError:
+                # Our tests create mock components with libraries that
+                # aren't importable
+                error_string_prefix = 'The `{}` component{}'.format(
+                    self._type,
+                    ' with the ID "{}"'.format(getattr(self, 'id'))
+                    if hasattr(self, 'id') else ''
+                )
+
             if not k_in_propnames and not k_in_wildcards:
                 raise TypeError(
                     "{} received an unexpected keyword argument: `{}`".format(

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -93,16 +93,16 @@ class Component(with_metaclass(ComponentMeta, object)):
                     self._namespace,
                     self._type,
                     getattr(__import__(self._namespace), '__version__', 'unknown'),
-                    ' with the ID "{}"'.format(getattr(self, 'id'))
-                    if hasattr(self, 'id') else ''
+                    ' with the ID "{}"'.format(kwargs['id'])
+                    if 'id' in kwargs else ''
                 )
             except ImportError:
                 # Our tests create mock components with libraries that
                 # aren't importable
                 error_string_prefix = 'The `{}` component{}'.format(
                     self._type,
-                    ' with the ID "{}"'.format(getattr(self, 'id'))
-                    if hasattr(self, 'id') else ''
+                    ' with the ID "{}"'.format(kwargs['id'])
+                    if 'id' in kwargs else ''
                 )
 
             if not k_in_propnames and not k_in_wildcards:

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -86,9 +86,13 @@ class Component(with_metaclass(ComponentMeta, object)):
             k_in_wildcards = any(
                 [k.startswith(w) for w in self._valid_wildcard_attributes]
             )
+            error_string_prefix = "The `{}` component{} '.format(
+                self._type,
+                'with the ID "{}"'.format(getattr(self, 'id') if hasattr(self, 'id') else ''
+            )
             if not k_in_propnames and not k_in_wildcards:
                 raise TypeError(
-                    "Unexpected keyword argument `{}`".format(k)
+                    "{} received an unexpected keyword argument: `{}`".format(error_string_prefix, k)
                     + "\nAllowed arguments: {}".format(
                         # pylint: disable=no-member
                         ", ".join(sorted(self._prop_names))
@@ -97,7 +101,8 @@ class Component(with_metaclass(ComponentMeta, object)):
 
             if k != "children" and isinstance(v, Component):
                 raise TypeError(
-                    "Component detected as a prop other than `children`\n" +
+                    error_string_prefix +
+                    " detected a Component for a prop other than `children`\n" +
                     "Did you forget to wrap multiple `children` in an array?\n" +
                     "Prop {} has value {}\n".format(k, repr(v))
                 )

--- a/tests/unit/development/test_base_component.py
+++ b/tests/unit/development/test_base_component.py
@@ -435,3 +435,36 @@ def test_debc026_component_not_children():
         with pytest.raises(TypeError):
             # If you forget the `[]` around children you get this:
             html.Div(children[0], children[1], children[2], children[3])
+
+
+def test_debc027_component_error_message():
+    with pytest.raises(TypeError) as e:
+        Component(asdf=True)
+
+    assert str(e.value) == (
+        "The `TestComponent` component received an unexpected " +
+        "keyword argument: `asdf`\nAllowed arguments: a, children, " +
+        "id, style"
+    )
+
+    with pytest.raises(TypeError) as e:
+        Component(asdf=True, id='my-component')
+    assert str(e.value) == (
+        "The `TestComponent` component " +
+        "with the ID \"my-component\" received an unexpected " +
+        "keyword argument: `asdf`\nAllowed arguments: a, children, " +
+        "id, style"
+    )
+
+
+    with pytest.raises(TypeError) as e:
+        html.Div(asdf=True, id='my-component')
+    assert str(e.value) == (
+        "The `dash_html_components.Div` component " +
+        "(version {}) ".format(html.__version__) +
+        "with the ID \"my-component\" received an unexpected " +
+        "keyword argument: `asdf`\n" +
+        "Allowed arguments: {}".format(
+            ', '.join(sorted(html.Div()._prop_names))
+        )
+    )

--- a/tests/unit/development/test_base_component.py
+++ b/tests/unit/development/test_base_component.py
@@ -455,6 +455,17 @@ def test_debc027_component_error_message():
         "id, style"
     )
 
+    with pytest.raises(TypeError) as e:
+        html.Div(asdf=True)
+    assert str(e.value) == (
+        "The `dash_html_components.Div` component " +
+        "(version {}) ".format(html.__version__) +
+        "received an unexpected " +
+        "keyword argument: `asdf`\n" +
+        "Allowed arguments: {}".format(
+            ', '.join(sorted(html.Div()._prop_names))
+        )
+    )
 
     with pytest.raises(TypeError) as e:
         html.Div(asdf=True, id='my-component')

--- a/tests/unit/development/test_base_component.py
+++ b/tests/unit/development/test_base_component.py
@@ -440,7 +440,6 @@ def test_debc026_component_not_children():
 def test_debc027_component_error_message():
     with pytest.raises(TypeError) as e:
         Component(asdf=True)
-
     assert str(e.value) == (
         "The `TestComponent` component received an unexpected " +
         "keyword argument: `asdf`\nAllowed arguments: a, children, " +


### PR DESCRIPTION
These error messages are hard to parse in large projects especially after upgrading. For example, I'm working on a project right now that has the following error message:
```
  File "/Users/chriddyp/Repos/dash-stuff/dash-enterprise-docs/vv/lib/python3.6/site-packages/dash_docs/tutorial/__init__.py", line 11, in <module>
    from .import daq_component_examples as daq_examples
  File "/Users/chriddyp/Repos/dash-stuff/dash-enterprise-docs/vv/lib/python3.6/site-packages/dash_docs/tutorial/daq_component_examples.py", line 969, in <module>
    ''', style=styles.code_container),
  File "/Users/chriddyp/Repos/dash-stuff/dash-enterprise-docs/vv/lib/python3.6/site-packages/dash_docs/tutorial/utils/component_block.py", line 27, in ComponentBlock
    raise e
  File "/Users/chriddyp/Repos/dash-stuff/dash-enterprise-docs/vv/lib/python3.6/site-packages/dash_docs/tutorial/utils/component_block.py", line 19, in ComponentBlock
    exec(converted_string, scope)
  File "<string>", line 6, in <module>
  File "/Users/chriddyp/Repos/dash-stuff/dash-enterprise-docs/vv/lib/python3.6/site-packages/dash/development/base_component.py", line 324, in wrapper
    return func(*args, **kwargs)
  File "<string>", line 66, in __init__
  File "/Users/chriddyp/Repos/dash-stuff/dash-enterprise-docs/vv/lib/python3.6/site-packages/dash/development/base_component.py", line 94, in __init__
    ", ".join(sorted(self._prop_names))
TypeError: Unexpected keyword argument `height`
Allowed arguments: base, className, color, id, label, labelPosition, logarithmic, max, min, scale, showCurrentValue, size, style, units, value
```

I'm not even sure _which component library_ let alone _component_ is failing!

- [x] I have added entry in the `CHANGELOG.md`
- [ ] ~If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow~
    -  [ ] ~this github [#PR number]() updates the dash docs~
    -  [ ] ~here is the show and tell thread in plotly dash community~

