### PR TITLE
Fix test regressions related to dcc.Graph changes

### DIFF
--- a/tests/integration/callbacks/test_layout_paths_with_callbacks.py
+++ b/tests/integration/callbacks/test_layout_paths_with_callbacks.py
@@ -148,6 +148,10 @@ def test_cblp001_radio_buttons_callbacks_generating_children(dash_duo):
     dash_duo.start_server(app)
 
     def check_chapter(chapter):
+        dash_duo.wait_for_element(
+            '#{}-graph:not(.dash-graph--pending)'.format(chapter)
+        )
+
         for key in dash_duo.redux_state_paths:
             assert dash_duo.find_elements(
                 "#{}".format(key)
@@ -158,13 +162,17 @@ def test_cblp001_radio_buttons_callbacks_generating_children(dash_duo):
             if chapter == "chapter3"
             else chapters[chapter]["{}-controls".format(chapter)].value
         )
+
         # check the actual values
         dash_duo.wait_for_text_to_equal("#{}-label".format(chapter), value)
+
         wait.until(
             lambda: (
                 dash_duo.driver.execute_script(
                     "return document."
-                    'getElementById("{}-graph").'.format(chapter)
+                    'querySelector("#{}-graph:not(.dash-graph--pending) .js-plotly-plot").'.format(
+                        chapter
+                    )
                     + "layout.title.text"
                 )
                 == value

--- a/tests/integration/test_render.py
+++ b/tests/integration/test_render.py
@@ -965,10 +965,10 @@ class Tests(IntegrationTests):
 
         self.startServer(app)
 
-        self.wait_for_element_by_css_selector('#graph1')
+        self.wait_for_element_by_css_selector('#graph1:not(.dash-graph--pending)')
 
         self.driver.find_elements_by_css_selector(
-            '#graph1'
+            '#graph1:not(.dash-graph--pending)'
         )[0].click()
 
         graph_1_expected_clickdata = {
@@ -985,10 +985,10 @@ class Tests(IntegrationTests):
             '#tab2'
         )[0].click()
 
-        self.wait_for_element_by_css_selector('#graph2')
+        self.wait_for_element_by_css_selector('#graph2:not(.dash-graph--pending)')
 
         self.driver.find_elements_by_css_selector(
-            '#graph2'
+            '#graph2:not(.dash-graph--pending)'
         )[0].click()
 
         self.wait_for_text_to_equal('#graph2_info', json.dumps(graph_2_expected_clickdata))

--- a/tests/integration/test_scripts.py
+++ b/tests/integration/test_scripts.py
@@ -30,7 +30,7 @@ from selenium.webdriver.common.by import By
 
 def findSyncPlotlyJs(scripts):
     for script in scripts:
-        if "dash_core_components/plotly-" in script.get_attribute('src'):
+        if "dash_core_components/plotly" in script.get_attribute('src'):
             return script
 
 


### PR DESCRIPTION
Changes to dcc.Graph in https://github.com/plotly/dash-core-components/pull/706 are impacting tests only defined / run in the Dash repository. As the PR did not involve any changes outside of DCC, the test failures were only detected when the PR was merged and dash later modified.