### PR TITLE
feat: disable cookie access under restricted sandboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - [#1080](https://github.com/plotly/dash/pull/1080) Handle case where dash fails to load when used inside an iframe with a sandbox attribute that only has allow-scripts
 
+
 ## [1.8.0] - 2020-01-14
 ### Added
 - [#1073](https://github.com/plotly/dash/pull/1073) Two new functions to simplify usage handling URLs and pathnames: `app.get_relative_path` & `app.trim_relative_path`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- [#1080](https://github.com/plotly/dash/pull/1080) Handle case where dash fails to load when used inside an iframe with a sandbox attribute that only has allow-scripts
+
 ## [1.8.0] - 2020-01-14
 ### Added
 - [#1073](https://github.com/plotly/dash/pull/1073) Two new functions to simplify usage handling URLs and pathnames: `app.get_relative_path` & `app.trim_relative_path`.

--- a/dash-renderer/src/AccessDenied.react.js
+++ b/dash-renderer/src/AccessDenied.react.js
@@ -1,9 +1,12 @@
 /* global window:true, document:true */
 import React from 'react';
-import {mergeRight} from 'ramda';
+import {mergeRight, once} from 'ramda';
 import PropTypes from 'prop-types';
 import * as styles from './styles/styles.js';
 import * as constants from './constants/constants.js';
+
+/* eslint-disable-next-line no-console */
+const logWarningOnce = once(console.warn);
 
 function AccessDenied(props) {
     const {config} = props;
@@ -34,8 +37,7 @@ function AccessDenied(props) {
                             `${constants.OAUTH_COOKIE_NAME}=; ` +
                             'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
                     } catch (e) {
-                        /* eslint-disable-next-line no-console */
-                        console.warn(e);
+                        logWarningOnce(e);
                     }
                     window.location.reload(true);
                 }}

--- a/dash-renderer/src/AccessDenied.react.js
+++ b/dash-renderer/src/AccessDenied.react.js
@@ -28,9 +28,15 @@ function AccessDenied(props) {
             <a
                 style={styles.base.a}
                 onClick={() => {
-                    document.cookie =
-                        `${constants.OAUTH_COOKIE_NAME}=; ` +
-                        'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+                    /* eslint no-empty: ["error", { "allowEmptyCatch": true }] */
+                    try {
+                        document.cookie =
+                            `${constants.OAUTH_COOKIE_NAME}=; ` +
+                            'expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+                    } catch (e) {
+                        /* eslint-disable-next-line no-console */
+                        console.warn(e);
+                    }
                     window.location.reload(true);
                 }}
             >

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -55,9 +55,15 @@ export function hydrateInitialOutputs() {
 }
 
 export function getCSRFHeader() {
-    return {
-        'X-CSRFToken': cookie.parse(document.cookie)._csrf_token,
-    };
+    try {
+        return {
+            'X-CSRFToken': cookie.parse(document.cookie)._csrf_token,
+        };
+    } catch (e) {
+        /* eslint-disable-next-line no-console */
+        console.warn(e);
+        return {};
+    }
 }
 
 function triggerDefaultState(dispatch, getState) {

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -16,6 +16,7 @@ import {
     lensPath,
     mergeLeft,
     mergeDeepRight,
+    once,
     path,
     pluck,
     propEq,
@@ -54,14 +55,16 @@ export function hydrateInitialOutputs() {
     };
 }
 
+/* eslint-disable-next-line no-console */
+const logWarningOnce = once(console.warn);
+
 export function getCSRFHeader() {
     try {
         return {
             'X-CSRFToken': cookie.parse(document.cookie)._csrf_token,
         };
     } catch (e) {
-        /* eslint-disable-next-line no-console */
-        console.warn(e);
+        logWarningOnce(e);
         return {};
     }
 }
@@ -77,7 +80,7 @@ function triggerDefaultState(dispatch, getState) {
     } catch (err) {
         dispatch(
             onError({
-                type: 'backEnd',
+                logWarningOncetype: 'backEnd',
                 error: {
                     message: 'Circular Dependencies',
                     html: err.toString(),

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -80,7 +80,7 @@ function triggerDefaultState(dispatch, getState) {
     } catch (err) {
         dispatch(
             onError({
-                logWarningOncetype: 'backEnd',
+                type: 'backEnd',
                 error: {
                     message: 'Circular Dependencies',
                     html: err.toString(),

--- a/tests/integration/renderer/test_iframe.py
+++ b/tests/integration/renderer/test_iframe.py
@@ -48,4 +48,4 @@ def test_rdif001_sandbox_allow_scripts(dash_duo):
 
     dash_duo.driver.get("data:text/html;charset=utf-8," + html_content)
 
-    assert not dash_duo.get_logs()
+    assert len(dash_duo.get_logs()) == 1

--- a/tests/integration/renderer/test_iframe.py
+++ b/tests/integration/renderer/test_iframe.py
@@ -54,4 +54,4 @@ def test_rdif001_sandbox_allow_scripts(dash_duo):
     dash_duo.wait_for_element_by_id('btn').click()
     dash_duo.wait_for_element('#output-0').text == '0=1'
 
-    assert len(dash_duo.get_logs()) == 2
+    assert len(dash_duo.get_logs()) != 0

--- a/tests/integration/renderer/test_iframe.py
+++ b/tests/integration/renderer/test_iframe.py
@@ -48,4 +48,10 @@ def test_rdif001_sandbox_allow_scripts(dash_duo):
 
     dash_duo.driver.get("data:text/html;charset=utf-8," + html_content)
 
+    dash_duo.driver.switch_to.frame(0)
+
+    dash_duo.wait_for_element('#output-0')
+    dash_duo.wait_for_element_by_id('btn').click()
+    dash_duo.wait_for_element('#output-0').text == '0=1'
+
     assert len(dash_duo.get_logs()) == 2

--- a/tests/integration/renderer/test_iframe.py
+++ b/tests/integration/renderer/test_iframe.py
@@ -1,0 +1,51 @@
+from multiprocessing import Value
+
+import dash
+from dash.dependencies import Input, Output
+from dash.exceptions import PreventUpdate
+
+import dash_html_components as html
+
+
+def test_rdif001_sandbox_allow_scripts(dash_duo):
+    app = dash.Dash(__name__)
+    call_count = Value("i")
+
+    N_OUTPUTS = 50
+
+    app.layout = html.Div([
+        html.Button("click me", id="btn"),
+    ] + [html.Div(id="output-{}".format(i)) for i in range(N_OUTPUTS)])
+
+    @app.callback(
+        [Output("output-{}".format(i), "children") for i in range(N_OUTPUTS)],
+        [Input("btn", "n_clicks")]
+    )
+    def update_output(n_clicks):
+        if n_clicks is None:
+            raise PreventUpdate
+
+        call_count.value += 1
+        return ["{}={}".format(i, i + n_clicks) for i in range(N_OUTPUTS)]
+
+    @app.server.after_request
+    def apply_cors(response):
+        response.headers["Access-Control-Allow-Origin"] = "*"
+        response.headers["Access-Control-Allow-Headers"] = "Origin, X-Requested-With, Content-Type, Accept, Authorization"
+        return response
+
+    dash_duo.start_server(app)
+
+    iframe = """
+        <!DOCTYPE html>
+    <html>
+    <iframe src="{0}" sandbox="allow-scripts">
+    </iframe>
+    </html>
+    """
+
+    html_content = iframe.format(dash_duo.server_url)
+
+    dash_duo.driver.get("data:text/html;charset=utf-8," + html_content)
+
+    assert not dash_duo.get_logs()

--- a/tests/integration/renderer/test_iframe.py
+++ b/tests/integration/renderer/test_iframe.py
@@ -48,4 +48,4 @@ def test_rdif001_sandbox_allow_scripts(dash_duo):
 
     dash_duo.driver.get("data:text/html;charset=utf-8," + html_content)
 
-    assert len(dash_duo.get_logs()) == 1
+    assert len(dash_duo.get_logs()) == 2


### PR DESCRIPTION
When dash is embedded into an iframe with a sandbox attribute that only has allow-scripts, cookie access is disabled and dash fails to load. As such, we need to restrict our cookie usage by disabling functionality.

This patch removes the disabled functionality in a graceful manner, allowing dash to load in very restricted iframes.

## Contributor Checklist

- [x] ~I have broken down my PR scope into the following TODO tasks~ not needed
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
