### PR TITLE
[WIP] Add additional color-coding to callback graph in debug menu

### DIFF
--- a/dash-renderer/src/components/error/CallbackGraph/CallbackGraphContainer.react.js
+++ b/dash-renderer/src/components/error/CallbackGraph/CallbackGraphContainer.react.js
@@ -13,8 +13,13 @@ class CallbackGraphContainer extends Component {
         const {dependenciesRequest} = this.props;
         const elements = {};
         const callbacks = [];
-        const links = dependenciesRequest.content.map(({inputs, output}, i) => {
-            callbacks.push(`cb${i};`);
+        const clientside_callbacks = [];
+        const links = dependenciesRequest.content.map(({inputs, output, clientside_function}, i) => {
+            if (clientside_function) {
+                clientside_callbacks.push(`cb${i};`);
+            } else {
+                callbacks.push(`cb${i};`);
+            }
             function recordAndReturn([id, property]) {
                 elements[id] = elements[id] || {};
                 elements[id][property] = true;
@@ -40,6 +45,10 @@ class CallbackGraphContainer extends Component {
             subgraph callbacks {
                 node [shape=circle, width=0.3, label="", color="#00CC96"];
                 ${callbacks.join('\n')} }
+
+            subgraph clientside_callbacks {
+                node [shape=circle, width=0.3, label="", color="#EF553B"];
+                ${clientside_callbacks.join('\n')} }
 
             ${Object.entries(elements)
                 .map(


### PR DESCRIPTION
I've been using Dash for a while and would like to dip my toes into Dash development -- would this PR be welcome?

- [x] Previously, all callbacks were emerald (green), now clientside callbacks will be sienna (red).
- [ ] I would like to color code components that are not present in the layout differently -- this would be very useful for debugging if `suppress_callback_exceptions` is enabled. However, it's not clear to me what the cleanest way is to do this, would anyone have any suggestions here?

- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow
    -  [ ] this github [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in plotly dash community 
