### PR TITLE
Add standard dash interface for location change

### DIFF
--- a/@plotly/dash-component-plugins/package.json
+++ b/@plotly/dash-component-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plotly/dash-component-plugins",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Plugins for Dash Components",
   "repository": {
     "type": "git",

--- a/@plotly/dash-component-plugins/src/History.js
+++ b/@plotly/dash-component-plugins/src/History.js
@@ -1,0 +1,13 @@
+const ON_CHANGE = '_dashprivate_onhistorychange';
+
+export default class History {
+    static dispatchChangeEvent() {
+        window.dispatchEvent(new CustomEvent(ON_CHANGE));
+    }
+
+    static onChange(listener) {
+        window.addEventListener(ON_CHANGE, listener);
+
+        return () => window.removeEventListener(ON_CHANGE, listener);
+    }
+}

--- a/@plotly/dash-component-plugins/src/History.js
+++ b/@plotly/dash-component-plugins/src/History.js
@@ -1,4 +1,4 @@
-const ON_CHANGE = '_dashprivate_onhistorychange';
+const ON_CHANGE = '_dashprivate_historychange';
 
 export default class History {
     static dispatchChangeEvent() {

--- a/@plotly/dash-component-plugins/src/index.js
+++ b/@plotly/dash-component-plugins/src/index.js
@@ -1,3 +1,5 @@
 import { asyncDecorator, isReady } from './dynamicImport';
+import History from './History';
 
 export { asyncDecorator, isReady };
+export { History };


### PR DESCRIPTION
Provide an official API to listen and trigger `location path` events.
This is currently handled with undocumented / hidden events in dcc.Link, dcc.Location and other component libraries depending on these hidden values.

`@plotly/dash-component-plugins` will be bumped to `1.1.0`.