### PR TITLE
Add `inheritAsyncDecorator` for wrapper components

### DIFF
--- a/@plotly/dash-component-plugins/package.json
+++ b/@plotly/dash-component-plugins/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plotly/dash-component-plugins",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Plugins for Dash Components",
   "repository": {
     "type": "git",

--- a/@plotly/dash-component-plugins/src/dynamicImport.js
+++ b/@plotly/dash-component-plugins/src/dynamicImport.js
@@ -1,7 +1,5 @@
 import { lazy } from 'react';
 
-const isLazyProp = '_dashprivate_isLazyComponentReady';
-
 export const asyncDecorator = (target, promise) => {
     let resolve;
     const isReady = new Promise(r => {
@@ -22,7 +20,7 @@ export const asyncDecorator = (target, promise) => {
         }),
     };
 
-    Object.defineProperty(target, isLazyProp, {
+    Object.defineProperty(target, '_dashprivate_isLazyComponentReady', {
         get: () => state.isReady
     });
 
@@ -30,7 +28,7 @@ export const asyncDecorator = (target, promise) => {
 };
 
 export const setDecorator = (target, source) => {
-    Object.defineProperty(target, isLazyProp, {
+    Object.defineProperty(target, '_dashprivate_isLazyComponentReady', {
         get: () => isReady(source)
     });
 }

--- a/@plotly/dash-component-plugins/src/dynamicImport.js
+++ b/@plotly/dash-component-plugins/src/dynamicImport.js
@@ -1,5 +1,7 @@
 import { lazy } from 'react';
 
+const isLazyProp = '_dashprivate_isLazyComponentReady';
+
 export const asyncDecorator = (target, promise) => {
     let resolve;
     const isReady = new Promise(r => {
@@ -20,12 +22,18 @@ export const asyncDecorator = (target, promise) => {
         }),
     };
 
-    Object.defineProperty(target, '_dashprivate_isLazyComponentReady', {
+    Object.defineProperty(target, isLazyProp, {
         get: () => state.isReady
     });
 
     return state.get;
 };
+
+export const setDecorator = (target, source) => {
+    Object.defineProperty(target, isLazyProp, {
+        get: () => isReady(source)
+    });
+}
 
 export const isReady = target => target &&
     target._dashprivate_isLazyComponentReady;

--- a/@plotly/dash-component-plugins/src/dynamicImport.js
+++ b/@plotly/dash-component-plugins/src/dynamicImport.js
@@ -27,7 +27,7 @@ export const asyncDecorator = (target, promise) => {
     return state.get;
 };
 
-export const setDecorator = (target, source) => {
+export const inheritAsyncDecorator = (target, source) => {
     Object.defineProperty(target, '_dashprivate_isLazyComponentReady', {
         get: () => isReady(source)
     });

--- a/@plotly/dash-component-plugins/src/index.js
+++ b/@plotly/dash-component-plugins/src/index.js
@@ -1,5 +1,5 @@
-import { asyncDecorator, isReady, setDecorator } from './dynamicImport';
+import { asyncDecorator, inheritAsyncDecorator, isReady } from './dynamicImport';
 import History from './History';
 
-export { asyncDecorator, isReady, setDecorator };
+export { asyncDecorator, inheritAsyncDecorator, isReady };
 export { History };

--- a/@plotly/dash-component-plugins/src/index.js
+++ b/@plotly/dash-component-plugins/src/index.js
@@ -1,5 +1,5 @@
-import { asyncDecorator, isReady } from './dynamicImport';
+import { asyncDecorator, isReady, setDecorator } from './dynamicImport';
 import History from './History';
 
-export { asyncDecorator, isReady };
+export { asyncDecorator, isReady, setDecorator };
 export { History };


### PR DESCRIPTION
Wrapper components can use an async component but not be async themselves. `inheritAsyncDecorator` allows the wrapper to inherit the async-ness of the component it wraps.