### PR TITLE
[WIP / POC] Ability to prevent initial callback from firing

### DIFF
--- a/dash-renderer/src/actions/dependencies.js
+++ b/dash-renderer/src/actions/dependencies.js
@@ -785,18 +785,24 @@ export function getCallbacksInLayout(graphs, paths, layoutChunk, opts) {
                 // callbacks found in the layout by output should always run,
                 // ie this is the initial call of this callback even if it's
                 // not the page initialization but just a new layout chunk
+                // (unless the user explicitly didn't want them run)
                 cb.initialCall = true;
-                addCallback(cb);
+                if(!cb.callback.prevent_initial_call) {
+                    addCallback(cb);
+                }
             }
         }
         if (!outputsOnly && inIdCallbacks) {
             const idStr = removedArrayInputsOnly && stringifyId(id);
-            for (const property in inIdCallbacks) {
-                getCallbacksByInput(graphs, paths, id, property).forEach(
-                    removedArrayInputsOnly
-                        ? addCallbackIfArray(idStr)
-                        : addCallback
-                );
+            for (let property in inIdCallbacks) {
+                getCallbacksByInput(graphs, paths, id, property).forEach(function(...args) {
+                    if(args[0].callback.prevent_initial_call) {
+                        return;
+                    }
+                    return removedArrayInputsOnly
+                        ? addCallbackIfArray(idStr)(...args)
+                        : addCallback(...args)
+                });
             }
         }
     }

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -800,12 +800,13 @@ class Dash(object):
                     "inputs": v["inputs"],
                     "state": v["state"],
                     "clientside_function": v.get("clientside_function", None),
+                    "prevent_initial_call": v["prevent_initial_call"]
                 }
                 for k, v in self.callback_map.items()
             ]
         )
 
-    def _insert_callback(self, output, inputs, state):
+    def _insert_callback(self, output, inputs, state, prevent_initial_call):
         layout = self._cached_layout or self._layout_value()
         _validate.validate_callback(self, layout, output, inputs, state)
         callback_id = create_callback_id(output)
@@ -813,6 +814,7 @@ class Dash(object):
         self.callback_map[callback_id] = {
             "inputs": [c.to_dict() for c in inputs],
             "state": [c.to_dict() for c in state],
+            "prevent_initial_call": prevent_initial_call
         }
         self.used_outputs.extend(output if callback_id.startswith("..") else [output])
 
@@ -912,8 +914,8 @@ class Dash(object):
             "function_name": function_name,
         }
 
-    def callback(self, output, inputs, state=()):
-        callback_id = self._insert_callback(output, inputs, state)
+    def callback(self, output, inputs, state=(), prevent_initial_call=False):
+        callback_id = self._insert_callback(output, inputs, state, prevent_initial_call)
         multi = isinstance(output, (list, tuple))
 
         def wrap_func(func):


### PR DESCRIPTION
Via a new property in the `app.callback`, `prevent_initial_call=True`


```
@app.callback(Output('another-output', 'children'), [Input('another', 'value')], prevent_initial_call=True)
```

This will prevent it for both initial renders in `app.layout` as well as new component renders from a callback.

WIP / POC for now. Would need lots of tests.