### PR TITLE
Reduce test warnings

### DIFF
--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -64,7 +64,6 @@ class contains_text(object):
                 elem.get_attribute("value")
             )
         except WebDriverException:
-            logger.exception("contains_text encountered an exception")
             return False
 
 
@@ -82,7 +81,6 @@ class text_to_equal(object):
                 or str(elem.get_attribute("value")) == self.text
             )
         except WebDriverException:
-            logger.exception("text_to_equal encountered an exception")
             return False
 
 
@@ -99,5 +97,4 @@ class style_to_equal(object):
             logger.debug("style to equal {%s} => expected %s", val, self.val)
             return val == self.val
         except WebDriverException:
-            logger.exception("style_to_equal encountered an exception")
             return False


### PR DESCRIPTION
This is an attempt to reduce warnings printed during tests. Currently whenever an exception is raised during `text_to_equal()`, the stacktrace is printed. Since failures are expected fairly often (for example if the element being examined doesn't exist yet), the test output of even a successful run of the Dash Enterprise automated integration tests are filled with them.

This PR simply removes the exception logging since I doubt it's useful to anyone.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Test with the Dash Enterprise automated integrated tests
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR