### PR TITLE
:bug: fix #1098 : also persist 0, empty string etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [#1145](https://github.com/plotly/dash/pull/1145) Update from React 16.8.6 to 16.13.0
 
+### Fixed
+- [#1142](https://github.com/plotly/dash/pull/1142) [Persistence](https://dash.plot.ly/persistence): Also persist 0, empty string etc
+
 ## [1.9.1] - 2020-02-27
 ### Added
 - [#1133](github.com/plotly/dash/pull/1133) Allow the `compress` config variable to be set with an environment variable with DASH_COMPRESS=FALSE

--- a/dash-renderer/src/persistence.js
+++ b/dash-renderer/src/persistence.js
@@ -318,7 +318,7 @@ export function recordUiEdit(layout, newProps, dispatch) {
 
     forEach(persistedProp => {
         const [propName, propPart] = persistedProp.split('.');
-        if (newProps[propName]) {
+        if (newProps[propName] !== undefined) {
             const storage = getStore(persistence_type, dispatch);
             const {extract} = getTransform(element, propName, propPart);
 

--- a/tests/integration/renderer/test_persistence.py
+++ b/tests/integration/renderer/test_persistence.py
@@ -2,6 +2,8 @@ from multiprocessing import Value
 import pytest
 import time
 
+from selenium.webdriver.common.keys import Keys
+
 import dash
 from dash.dependencies import Input, Output
 
@@ -384,8 +386,8 @@ def test_rdps010_toggle_persistence(dash_duo):
 
     dash_duo.find_element("#persistence-val").send_keys("2")
     dash_duo.wait_for_text_to_equal("#out", "a")
-    dash_duo.find_element("#persisted").send_keys("ardvark")
-    dash_duo.wait_for_text_to_equal("#out", "aardvark")
+    dash_duo.find_element("#persisted").send_keys(Keys.BACK_SPACE)  # persist falsy value
+    dash_duo.wait_for_text_to_equal("#out", "")
 
     # alpaca not saved with falsy persistence
     dash_duo.clear_input("#persistence-val")
@@ -395,7 +397,7 @@ def test_rdps010_toggle_persistence(dash_duo):
     dash_duo.find_element("#persistence-val").send_keys("s")
     dash_duo.wait_for_text_to_equal("#out", "anchovies")
     dash_duo.find_element("#persistence-val").send_keys("2")
-    dash_duo.wait_for_text_to_equal("#out", "aardvark")
+    dash_duo.wait_for_text_to_equal('#out', "")
 
 
 def test_rdps011_toggle_persistence2(dash_duo):


### PR DESCRIPTION
fixes #1098 Persistence does not work for Input components when 0 is entered

## Contributor Checklist

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow
    -  [ ] this github [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in plotly dash community 
