### PR TITLE
Include license in the sdist of dash-renderer

### DIFF
--- a/dash-renderer/MANIFEST.in
+++ b/dash-renderer/MANIFEST.in
@@ -2,3 +2,4 @@ include package.json
 include digest.json
 include dash_renderer/*.js
 include dash_renderer/*.map
+include LICENSE


### PR DESCRIPTION
This will ensure the pkg has a license shipped even if people fetch the package from pypi.