### PR TITLE
[WIP] Improve performance: What's the case for a revert on a boundary exception?

### DIFF
--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -111,7 +111,6 @@ function triggerDefaultState(dispatch, getState) {
 
 export const redo = moveHistory('REDO');
 export const undo = moveHistory('UNDO');
-export const revert = moveHistory('REVERT');
 
 function moveHistory(changeType) {
     return function(dispatch, getState) {

--- a/dash-renderer/src/components/error/ComponentErrorBoundary.react.js
+++ b/dash-renderer/src/components/error/ComponentErrorBoundary.react.js
@@ -2,7 +2,7 @@ import {connect} from 'react-redux';
 import {Component} from 'react';
 import PropTypes from 'prop-types';
 import Radium from 'radium';
-import {onError, revert} from '../../actions';
+import {onError} from '../../actions';
 
 class UnconnectedComponentErrorBoundary extends Component {
     constructor(props) {
@@ -28,7 +28,6 @@ class UnconnectedComponentErrorBoundary extends Component {
                 info,
             })
         );
-        dispatch(revert);
     }
 
     componentDidUpdate(prevProps, prevState) {

--- a/dash-renderer/src/reducers/history.js
+++ b/dash-renderer/src/reducers/history.js
@@ -28,17 +28,6 @@ function history(state = initialHistory, action) {
             };
         }
 
-        case 'REVERT': {
-            const {past, future} = state;
-            const previous = past[past.length - 1];
-            const newPast = past.slice(0, past.length - 1);
-            return {
-                past: newPast,
-                present: previous,
-                future: [...future],
-            };
-        }
-
         default: {
             return state;
         }


### PR DESCRIPTION
Running against dash-docs `/all`, seeing errors in the DashCanvas component being caught by the renderer's TreeContainer error boundary causing a history `revert` to be applied. In this specific case, the revert is done against a `setProps` call the dcc.Location component did to align its props with window.location. This brings about an interesting loop..

On render, dcc.Location identified correctly its `pathname` was misaligned with window.location (undefined vs `/all`), triggering a setProps for `pathname: '/all'`. This triggers a callback for the page content.

On render, DashCanvas fails, triggering a revert, causing the last know action to be cancelled. Namely, pathname is now `undefined`.

dcc.Location renders and identifies correctly, again, that its `pathname` is misaligned with window.location, triggering a setProps for `pathname: '/all'`. This triggers a callback for page content.

This goes on for a while...

This scenario causes ~95 additional callbacks to be triggered and many additional component renders.

---

I am uncertain as to the usefulness of reverting on an error and proposing here to remove the `revert` code entirely. The DevTools UI uses `undo` and `redo` so that feature would be unaffected.

---

It seems there's little more to be gained in terms of pure performance with the `/all` case that couldn't be investigated with a simpler use case or looking at optimizing `shouldComponentUpdate` for the larger components. In truth, a lot of the performance issues with this page have to do with components that are very expensive to render  (dcc.Graph, DashCanvas, various DashBio components). For example, there is a ~2 minutes "wall of silence" during rendering of the page, after the initial callback for the layout, where no additional ApiController render occurs, no callbacks are fired, and only a few components are re-rendered, as the expensive components described above get rendered - and deal with various DOM-related errors that somehow seem to be related to the weight of the page -- taking the example pages individually, these errors disappear.