### PR TITLE
Missing pattern-matching outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#1078](https://github.com/plotly/dash/pull/1078) Permit usage of arbitrary file extensions for assets within component libraries
 
 ### Fixed
+- [#1220](https://github.com/plotly/dash/pull/1220) Fixes [#1216](https://github.com/plotly/dash/issues/1216), a set of related issues about pattern-matching callbacks with `ALL` wildcards in their `Output` which would fail if no components matched the pattern.
 - [#1212](https://github.com/plotly/dash/pull/1212) Fixes [#1200](https://github.com/plotly/dash/issues/1200) - prior to Dash 1.11, if none of the inputs to a callback were on the page, it was not an error. This was, and is now again, treated as though the callback raised PreventUpdate. The one exception to this is with pattern-matching callbacks, when every Input uses a multi-value wildcard (ALL or ALLSMALLER), and every Output is on the page. In that case the callback fires as usual.
 - [#1201](https://github.com/plotly/dash/pull/1201) Fixes [#1193](https://github.com/plotly/dash/issues/1193) - prior to Dash 1.11, you could use `flask.has_request_context() == False` inside an `app.layout` function to provide a special layout containing all IDs for validation purposes in a multi-page app. Dash 1.11 broke this when we moved most of this validation into the renderer. This change makes it work again.
 

--- a/tests/integration/callbacks/test_missing_outputs.py
+++ b/tests/integration/callbacks/test_missing_outputs.py
@@ -1,0 +1,243 @@
+import pytest
+
+import dash_html_components as html
+# import dash_core_components as dcc
+import dash
+from dash.dependencies import Input, Output, ALL, MATCH
+
+debugging = dict(
+    debug=True, use_reloader=False, use_debugger=True, dev_tools_hot_reload=False
+)
+
+
+@pytest.mark.parametrize("with_simple", (False, True))
+def test_cbmo001_all_output(with_simple, dash_duo):
+    app = dash.Dash(__name__)
+
+    app.layout = html.Div(children=[
+        html.Button("items", id="items"),
+        html.Button("values", id="values"),
+        html.Div(id="content"),
+        html.Div("Output init", id="output"),
+    ])
+
+    @app.callback(Output("content", "children"), [Input("items", "n_clicks")])
+    def content(n1):
+        return [html.Div(id={"i": i}) for i in range((n1 or 0) % 4)]
+
+    # these two variants have identical results, but the internal behavior
+    # is different when you combine the callbacks.
+    if with_simple:
+        @app.callback(
+            [Output({"i": ALL}, "children"), Output("output", "children")],
+            [Input("values", "n_clicks"), Input({"i": ALL}, "id")]
+        )
+        def content_and_output(n2, content_ids):
+            # this variant *does* get called with empty ALL, because of the
+            # second Output
+            # TODO: however it doesn't get *triggered* by the ALL emptying,
+            # should it? for now, added content_ids to get proper triggering.
+            n1 = len(content_ids)
+            content = [n2 or 0] * n1
+            return content, sum(content)
+
+    else:
+        @app.callback(Output({"i": ALL}, "children"), [Input("values", "n_clicks")])
+        def content_inner(n2):
+            # this variant does NOT get called with empty ALL
+            # the second callback handles outputting 0 in that case.
+            # if it were to be called throw an error so we'll see it in get_logs
+            n1 = len(dash.callback_context.outputs_list)
+            if not n1:
+                raise ValueError("should not be called with no outputs!")
+            return [n2 or 0] * n1
+
+        @app.callback(Output("output", "children"), [Input({"i": ALL}, "children")])
+        def out2(contents):
+            return sum(contents)
+
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_text_to_equal("#content", "")
+    dash_duo.wait_for_text_to_equal("#output", "0")
+
+    actions = [
+        ["#values", "", "0"],
+        ["#items", "1", "1"],
+        ["#values", "2", "2"],
+        ["#items", "2\n2", "4"],
+        ["#values", "3\n3", "6"],
+        ["#items", "3\n3\n3", "9"],
+        ["#values", "4\n4\n4", "12"],
+        ["#items", "", "0"],
+        ["#values", "", "0"],
+        ["#items", "5", "5"]
+    ]
+    for selector, content, output in actions:
+        dash_duo.find_element(selector).click()
+        dash_duo.wait_for_text_to_equal("#content", content)
+        dash_duo.wait_for_text_to_equal("#output", output)
+
+    assert not dash_duo.get_logs()
+
+
+@pytest.mark.parametrize("with_simple", (False, True))
+def test_cbmo002_all_and_match_output(with_simple, dash_duo):
+    app = dash.Dash(__name__)
+
+    app.layout = html.Div(children=[
+        html.Button("items", id="items"),
+        html.Button("values", id="values"),
+        html.Div(id="content"),
+    ])
+
+    @app.callback(Output("content", "children"), [Input("items", "n_clicks")])
+    def content(n1):
+        return [
+            html.Div([
+                html.Div(
+                    [html.Div(id={"i": i, "j": j}) for i in range(((n1 or 0) + j) % 4)],
+                    className="content{}".format(j)
+                ),
+                html.Div(id={"j": j}, className="output{}".format(j)),
+                html.Hr(),
+            ])
+            for j in range(4)
+        ]
+
+    # these two variants have identical results, but the internal behavior
+    # is different when you combine the callbacks.
+    if with_simple:
+        @app.callback(
+            [Output({"i": ALL, "j": MATCH}, "children"), Output({"j": MATCH}, "children")],
+            [Input("values", "n_clicks"), Input({"i": ALL, "j": MATCH}, "id")]
+        )
+        def content_and_output(n2, content_ids):
+            # this variant *does* get called with empty ALL, because of the
+            # second Output
+            # TODO: however it doesn't get *triggered* by the ALL emptying,
+            # should it? for now, added content_ids to get proper triggering.
+            n1 = len(content_ids)
+            content = [n2 or 0] * n1
+            return content, sum(content)
+
+    else:
+        @app.callback(
+            Output({"i": ALL, "j": MATCH}, "children"),
+            [Input("values", "n_clicks")]
+        )
+        def content_inner(n2):
+            # this variant does NOT get called with empty ALL
+            # the second callback handles outputting 0 in that case.
+            # if it were to be called throw an error so we'll see it in get_logs
+            n1 = len(dash.callback_context.outputs_list)
+            if not n1:
+                raise ValueError("should not be called with no outputs!")
+            return [n2 or 0] * n1
+
+        @app.callback(
+            Output({"j": MATCH}, "children"),
+            [Input({"i": ALL, "j": MATCH}, "children")]
+        )
+        def out2(contents):
+            return sum(contents)
+
+    dash_duo.start_server(app, **debugging)
+
+    dash_duo.wait_for_text_to_equal(".content0", "")
+    dash_duo.wait_for_text_to_equal(".output0", "0")
+
+    actions = [
+        ["#values", [["", "0"], ["1", "1"], ["1\n1", "2"], ["1\n1\n1", "3"]]],
+        ["#items", [["1", "1"], ["1\n1", "2"], ["1\n1\n1", "3"], ["", "0"]]],
+        ["#values", [["2", "2"], ["2\n2", "4"], ["2\n2\n2", "6"], ["", "0"]]],
+        ["#items", [["2\n2", "4"], ["2\n2\n2", "6"], ["", "0"], ["2", "2"]]],
+        ["#values", [["3\n3", "6"], ["3\n3\n3", "9"], ["", "0"], ["3", "3"]]],
+        ["#items", [["3\n3\n3", "9"], ["", "0"], ["3", "3"], ["3\n3", "6"]]],
+        ["#values", [["4\n4\n4", "12"], ["", "0"], ["4", "4"], ["4\n4", "8"]]],
+        ["#items", [["", "0"], ["4", "4"], ["4\n4", "8"], ["4\n4\n4", "12"]]],
+        ["#values", [["", "0"], ["5", "5"], ["5\n5", "10"], ["5\n5\n5", "15"]]],
+        ["#items", [["5", "5"], ["5\n5", "10"], ["5\n5\n5", "15"], ["", "0"]]]
+    ]
+    for selector, output_spec in actions:
+        dash_duo.find_element(selector).click()
+        for j, (content, output) in enumerate(output_spec):
+            dash_duo.wait_for_text_to_equal(".content{}".format(j), content)
+            dash_duo.wait_for_text_to_equal(".output{}".format(j), output)
+
+    assert not dash_duo.get_logs()
+
+
+def test_cbmo003_multi_all(dash_duo):
+    app = dash.Dash(__name__)
+
+    app.layout = html.Div(children=[
+        html.Button("items", id="items"),
+        html.Button("values", id="values"),
+        html.Div(id="content1"),
+        html.Hr(),
+        html.Div(id="content2"),
+        html.Hr(),
+        html.Div("Output init", id="output"),
+    ])
+
+    @app.callback(
+        [Output("content1", "children"), Output("content2", "children")],
+        [Input("items", "n_clicks")]
+    )
+    def content(n1):
+        c1 = [html.Div(id={"i": i}) for i in range(((n1 or 0) + 2) % 4)]
+        c2 = [html.Div(id={"j": j}) for j in range((n1 or 0) % 3)]
+        return c1, c2
+
+    @app.callback(
+        [Output({"i": ALL}, "children"), Output({"j": ALL}, "children")],
+        [Input("values", "n_clicks")]
+    )
+    def content_inner(n2):
+        # this variant does NOT get called with empty ALL
+        # the second callback handles outputting 0 in that case.
+        # if it were to be called throw an error so we'll see it in get_logs
+        n1i = len(dash.callback_context.outputs_list[0])
+        n1j = len(dash.callback_context.outputs_list[1])
+        if not n1i + n1j:
+            raise ValueError("should not be called with no outputs!")
+        return [n2 or 0] * n1i, [(n2 or 0) + 2] * n1j
+
+    @app.callback(
+        Output("output", "children"),
+        [Input({"i": ALL}, "children"), Input({"j": ALL}, "children")]
+    )
+    def out2(ci, cj):
+        return sum(ci) + sum(cj)
+
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_text_to_equal("#content1", "0\n0")
+    dash_duo.wait_for_text_to_equal("#content2", "")
+    dash_duo.wait_for_text_to_equal("#output", "0")
+
+    actions = [
+        ["#values", "1\n1", "", "2"],
+        ["#items", "1\n1\n1", "3", "6"],
+        ["#values", "2\n2\n2", "4", "10"],
+        ["#items", "", "4\n4", "8"],
+        ["#values", "", "5\n5", "10"],
+        ["#items", "3", "", "3"],
+        ["#values", "4", "", "4"],
+        ["#items", "4\n4", "6", "14"],
+        ["#values", "5\n5", "7", "17"],
+        ["#items", "5\n5\n5", "7\n7", "29"],
+        ["#values", "6\n6\n6", "8\n8", "34"],
+        # all empty! we'll see an error logged if the callback was fired
+        ["#items", "", "", "0"],
+        ["#values", "", "", "0"],
+        ["#items", "7", "9", "16"]
+    ]
+    for selector, content1, content2, output in actions:
+        dash_duo.find_element(selector).click()
+        dash_duo.wait_for_text_to_equal("#content1", content1)
+        dash_duo.wait_for_text_to_equal("#content2", content2)
+        dash_duo.wait_for_text_to_equal("#output", output)
+
+    assert not dash_duo.get_logs()


### PR DESCRIPTION
Fixes #1216 

Pattern-matching callbacks had some issues with `ALL` wildcards in their `Output`, reported by user `@jaser` on the [forum](https://community.plotly.com/t/dash-v1-11-0-release-introducing-pattern-matching-callbacks/37592/27). Everything worked well as long as the `ALL` matched something, but if it didn't we would throw an error.

There are a number of additional cases to consider, involving various combinations of `ALL` and `MATCH` wildcards and multiple outputs, as enumerated in #1216 - I will comment on the tests which of these cases each covers. And as discussed in #1216, we will NOT trigger a callback simply because one or more output items was removed. If you want that to happen, include the output component set as inputs as well - our suggestion is to just change the prop to `'id'` to avoid circular dependencies, and as a side benefit you get a clean list of the IDs involved.

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
- [x] I have added entry in the `CHANGELOG.md`