### PR TITLE
Support referencing nested components

### DIFF
--- a/dash-renderer/src/registry.js
+++ b/dash-renderer/src/registry.js
@@ -1,3 +1,5 @@
+import { path } from 'ramda';
+
 export default {
     resolve: component => {
         const {type, namespace} = component;
@@ -5,8 +7,9 @@ export default {
         const ns = window[namespace];
 
         if (ns) {
-            if (ns[type]) {
-                return ns[type];
+            const c = path(type.split('.'), ns);
+            if (c) {
+                return c;
             }
 
             throw new Error(`Component ${type} not found in ${namespace}`);

--- a/dash-renderer/src/registry.js
+++ b/dash-renderer/src/registry.js
@@ -1,4 +1,4 @@
-import { path } from 'ramda';
+import {path} from 'ramda';
 
 export default {
     resolve: component => {

--- a/dash-renderer/tests/registry.test.js
+++ b/dash-renderer/tests/registry.test.js
@@ -1,0 +1,44 @@
+import registry from '../src/registry';
+
+describe('registry', () => {
+
+    afterEach(() => {
+        delete window.TestNamespace;
+    });
+
+    describe('resolving nested components', () => {
+        beforeEach(() => {
+            window.TestNamespace = {
+                TestComponent: {
+                    NestedComponent: 'test',
+                },
+            };
+        });
+
+        test('referencing nested components', () => {
+            const component = {
+                type: 'TestComponent.NestedComponent',
+                namespace: 'TestNamespace',
+            };
+            const actual = registry.resolve(component);
+            expect(actual).toEqual('test');
+        });
+    });
+
+    describe('resolving standard components', () => {
+        beforeEach(() => {
+            window.TestNamespace = {
+                TestComponent: 'test',
+            };
+        });
+
+        test('referencing nested components', () => {
+            const component = {
+                type: 'TestComponent',
+                namespace: 'TestNamespace',
+            };
+            const actual = registry.resolve(component);
+            expect(actual).toEqual('test');
+        });
+    });
+});


### PR DESCRIPTION
Our team is creating dash components for [bizcharts](https://bizcharts.net/products/bizCharts).  Some of the components are nested inside of other components (Ex: [Guide.Arc](https://github.com/alibaba/BizCharts/blob/master/src/addepter/Guide.tsx#L19-L26)).  In order to make it easier to map the python component classes to the react components, I'm adding the ability to supply dot notation strings to access nested components.

Ex: 
```python
Component._type = "TestComponent.NestedComponent"
```

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Update registry js file to use dot notation to reference components
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow
    -  [ ] this github [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in plotly dash community 
