### PR TITLE
Prevent initial call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 ### Added
+- [#1228](https://github.com/plotly/dash/pull/1228) Adds control over firing callbacks on page (or layout chunk) load. Individual callbacks can have their initial calls disabled in their definition `@app.callback(..., prevent_initial_call=True)` and similar for `app.clientside_callback`. The app-wide default can also be changed with `app=Dash(prevent_initial_callbacks=True)`, then individual callbacks may disable this behavior.
 - [#1201](https://github.com/plotly/dash/pull/1201) New attribute `app.validation_layout` allows you to create a multi-page app without `suppress_callback_exceptions=True` or layout function tricks. Set this to a component layout containing the superset of all IDs on all pages in your app.
 - [#1078](https://github.com/plotly/dash/pull/1078) Permit usage of arbitrary file extensions for assets within component libraries
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -211,6 +211,15 @@ class Dash(object):
         env: ``DASH_SUPPRESS_CALLBACK_EXCEPTIONS``
     :type suppress_callback_exceptions: boolean
 
+    :param prevent_initial_callbacks: Default ``False``: Sets the default value
+        of ``prevent_initial_call`` for all callbacks added to the app.
+        Normally all callbacks are fired when the associated outputs are first
+        added to the page. You can disable this for individual callbacks by
+        setting ``prevent_initial_call`` in their definitions, or set it
+        ``True`` here in which case you must explicitly set it ``False`` for
+        those callbacks you wish to have an initial call. This setting has no
+        effect on triggering callbacks when their inputs change later on.
+
     :param show_undo_redo: Default ``False``, set to ``True`` to enable undo
         and redo buttons for stepping through the history of the app state.
     :type show_undo_redo: boolean
@@ -241,6 +250,7 @@ class Dash(object):
         external_scripts=None,
         external_stylesheets=None,
         suppress_callback_exceptions=None,
+        prevent_initial_callbacks=False,
         show_undo_redo=False,
         plugins=None,
         **obsolete
@@ -288,6 +298,7 @@ class Dash(object):
             suppress_callback_exceptions=get_combined_config(
                 "suppress_callback_exceptions", suppress_callback_exceptions, False
             ),
+            prevent_initial_callbacks=prevent_initial_callbacks,
             show_undo_redo=show_undo_redo,
         )
         self.config.set_read_only(
@@ -814,6 +825,9 @@ class Dash(object):
         return flask.jsonify(self._callback_list)
 
     def _insert_callback(self, output, inputs, state, prevent_initial_call):
+        if prevent_initial_call is None:
+            prevent_initial_call = self.config.prevent_initial_callbacks
+
         _validate.validate_callback(output, inputs, state)
         callback_id = create_callback_id(output)
         callback_spec = {
@@ -832,7 +846,7 @@ class Dash(object):
         return callback_id
 
     def clientside_callback(
-        self, clientside_function, output, inputs, state=(), prevent_initial_call=False
+        self, clientside_function, output, inputs, state=(), prevent_initial_call=None
     ):
         """Create a callback that updates the output by calling a clientside
         (JavaScript) function instead of a Python function.
@@ -893,6 +907,10 @@ class Dash(object):
              Input('another-input', 'value')]
         )
         ```
+
+        The last, optional argument `prevent_initial_call` causes the callback
+        not to fire when its outputs are first added to the page. Defaults to
+        `False` unless `prevent_initial_callbacks=True` at the app level.
         """
         self._insert_callback(output, inputs, state, prevent_initial_call)
 
@@ -925,7 +943,18 @@ class Dash(object):
             "function_name": function_name,
         }
 
-    def callback(self, output, inputs, state=(), prevent_initial_call=False):
+    def callback(self, output, inputs, state=(), prevent_initial_call=None):
+        """
+        Normally used as a decorator, `@app.callback` provides a server-side
+        callback relating the values of one or more `output` items to one or
+        more `input` items which will trigger the callback when they change,
+        and optionally `state` items which provide additional information but
+        do not trigger the callback directly.
+
+        The last, optional argument `prevent_initial_call` causes the callback
+        not to fire when its outputs are first added to the page. Defaults to
+        `False` unless `prevent_initial_callbacks=True` at the app level.
+        """
         callback_id = self._insert_callback(output, inputs, state, prevent_initial_call)
         multi = isinstance(output, (list, tuple))
 

--- a/tests/integration/callbacks/test_prevent_initial.py
+++ b/tests/integration/callbacks/test_prevent_initial.py
@@ -1,0 +1,270 @@
+import json
+import pytest
+
+import dash_html_components as html
+import dash
+from dash.dependencies import Input, Output, MATCH
+from dash.exceptions import PreventUpdate
+
+
+def content_callback(app, content, layout):
+    if content:
+        app.layout = html.Div(id="content")
+
+        @app.callback(Output("content", "children"), [Input("content", "style")])
+        def set_content(_):
+            return layout
+
+    else:
+        app.layout = layout
+
+
+def const_callback(app, clientside, val, outputs, inputs, prevent_initial_call=None):
+    if clientside:
+        vstr = json.dumps(val)
+        app.clientside_callback(
+            "function() { return " + vstr + "; }",
+            outputs,
+            inputs,
+            prevent_initial_call=prevent_initial_call,
+        )
+    else:
+
+        @app.callback(outputs, inputs, prevent_initial_call=prevent_initial_call)
+        def f(*args):
+            return val
+
+
+def concat_callback(app, clientside, outputs, inputs, prevent_initial_call=None):
+    multi_out = isinstance(outputs, (list, tuple))
+    if clientside:
+        app.clientside_callback(
+            """
+            function() {
+                var out = '';
+                for(var i = 0; i < arguments.length; i++) {
+                    out += String(arguments[i]);
+                }
+                return X;
+            }
+            """.replace(
+                "X",
+                ("[" + ','.join(["out"] * len(outputs)) + "]") if multi_out else "out"
+            ),
+            outputs,
+            inputs,
+            prevent_initial_call=prevent_initial_call,
+        )
+    else:
+
+        @app.callback(outputs, inputs, prevent_initial_call=prevent_initial_call)
+        def f(*args):
+            out = "".join(str(arg) for arg in args)
+            return [out] * len(outputs) if multi_out else out
+
+
+@pytest.mark.parametrize("clientside", (False, True))
+@pytest.mark.parametrize("content", (False, True))
+def test_cbpi001_prevent_initial_call(clientside, content, dash_duo):
+    app = dash.Dash(__name__)
+    layout = html.Div(
+        [
+            html.Button("click", id="btn"),
+            html.Div("A", id="a"),
+            html.Div("B", id="b"),
+            html.Div("C", id="c"),
+            html.Div("D", id="d"),
+            html.Div("E", id="e"),
+            html.Div("F", id="f"),
+        ]
+    )
+    content_callback(app, content, layout)
+
+    # Prevented, so A will only change after the button is clicked
+    const_callback(
+        app,
+        clientside,
+        "Click",
+        Output("a", "children"),
+        [Input("btn", "n_clicks")],
+        prevent_initial_call=True,
+    )
+
+    # B depends on A - this *will* run, because prevent_initial_call is
+    # not equivalent to PreventUpdate within the callback, it's treated as if
+    # that callback was never in the initialization chain.
+    concat_callback(app, clientside, Output("b", "children"), [Input("a", "children")])
+
+    @app.callback(Output("d", "children"), [Input("d", "style")])
+    def d(_):
+        raise PreventUpdate
+
+    # E depends on A and D - one prevent_initial_call and one PreventUpdate
+    # the prevent_initial_call means it *will* run
+    concat_callback(
+        app,
+        clientside,
+        Output("e", "children"),
+        [Input("a", "children"), Input("d", "children")],
+    )
+
+    # F has prevent_initial_call but DOES fire during init, because one of its
+    # inputs (B) was changed by a callback
+    concat_callback(
+        app,
+        clientside,
+        Output("f", "children"),
+        [Input("a", "children"), Input("b", "children"), Input("d", "children")],
+        prevent_initial_call=True,
+    )
+
+    # C matches B except that it also has prevent_initial_call itself, not just
+    # its input A - so it will not run initially
+    concat_callback(app, clientside, Output("c", "children"), [Input("a", "children")], prevent_initial_call=True)
+
+    dash_duo.start_server(app)
+
+    # check from the end, to ensure the callbacks are all done
+    dash_duo.wait_for_text_to_equal("#f", "AAD")
+    dash_duo.wait_for_text_to_equal("#e", "AD"),
+    dash_duo.wait_for_text_to_equal("#d", "D")
+    dash_duo.wait_for_text_to_equal("#c", "C")
+    dash_duo.wait_for_text_to_equal("#b", "A")
+    dash_duo.wait_for_text_to_equal("#a", "A")
+
+    dash_duo.find_element("#btn").click()
+
+    dash_duo.wait_for_text_to_equal("#f", "ClickClickD")
+    dash_duo.wait_for_text_to_equal("#e", "ClickD"),
+    dash_duo.wait_for_text_to_equal("#d", "D")
+    dash_duo.wait_for_text_to_equal("#c", "Click")
+    dash_duo.wait_for_text_to_equal("#b", "Click")
+    dash_duo.wait_for_text_to_equal("#a", "Click")
+
+
+@pytest.mark.parametrize("clientside", (False, True))
+@pytest.mark.parametrize("content", (False, True))
+def test_cbpi002_pattern_matching(clientside, content, dash_duo):
+    # a clone of cbpi001 just throwing it through the pattern-matching machinery
+    app = dash.Dash(__name__)
+    layout = html.Div(
+        [
+            html.Button("click", id={"i": 0, "j": "btn"}, className="btn"),
+            html.Div("A", id={"i": 0, "j": "a"}, className="a"),
+            html.Div("B", id={"i": 0, "j": "b"}, className="b"),
+            html.Div("C", id={"i": 0, "j": "c"}, className="c"),
+            html.Div("D", id={"i": 0, "j": "d"}, className="d"),
+            html.Div("E", id={"i": 0, "j": "e"}, className="e"),
+            html.Div("F", id={"i": 0, "j": "f"}, className="f"),
+        ]
+    )
+    content_callback(app, content, layout)
+
+    # Prevented, so A will only change after the button is clicked
+    const_callback(
+        app,
+        clientside,
+        "Click",
+        Output({"i": MATCH, "j": "a"}, "children"),
+        [Input({"i": MATCH, "j": "btn"}, "n_clicks")],
+        prevent_initial_call=True,
+    )
+
+    # B depends on A - this *will* run, because prevent_initial_call is
+    # not equivalent to PreventUpdate within the callback, it's treated as if
+    # that callback was never in the initialization chain.
+    concat_callback(app, clientside, Output({"i": MATCH, "j": "b"}, "children"), [Input({"i": MATCH, "j": "a"}, "children")])
+
+    @app.callback(Output({"i": MATCH, "j": "d"}, "children"), [Input({"i": MATCH, "j": "d"}, "style")])
+    def d(_):
+        raise PreventUpdate
+
+    # E depends on A and D - one prevent_initial_call and one PreventUpdate
+    # the prevent_initial_call means it *will* run
+    concat_callback(
+        app,
+        clientside,
+        Output({"i": MATCH, "j": "e"}, "children"),
+        [Input({"i": MATCH, "j": "a"}, "children"), Input({"i": MATCH, "j": "d"}, "children")],
+    )
+
+    # F has prevent_initial_call but DOES fire during init, because one of its
+    # inputs (B) was changed by a callback
+    concat_callback(
+        app,
+        clientside,
+        Output({"i": MATCH, "j": "f"}, "children"),
+        [Input({"i": MATCH, "j": "a"}, "children"), Input({"i": MATCH, "j": "b"}, "children"), Input({"i": MATCH, "j": "d"}, "children")],
+        prevent_initial_call=True,
+    )
+
+    # C matches B except that it also has prevent_initial_call itself, not just
+    # its input A - so it will not run initially
+    concat_callback(app, clientside, Output({"i": MATCH, "j": "c"}, "children"), [Input({"i": MATCH, "j": "a"}, "children")], prevent_initial_call=True)
+
+    dash_duo.start_server(app)
+
+    # check from the end, to ensure the callbacks are all done
+    dash_duo.wait_for_text_to_equal(".f", "AAD")
+    dash_duo.wait_for_text_to_equal(".e", "AD"),
+    dash_duo.wait_for_text_to_equal(".d", "D")
+    dash_duo.wait_for_text_to_equal(".c", "C")
+    dash_duo.wait_for_text_to_equal(".b", "A")
+    dash_duo.wait_for_text_to_equal(".a", "A")
+
+    dash_duo.find_element(".btn").click()
+
+    dash_duo.wait_for_text_to_equal(".f", "ClickClickD")
+    dash_duo.wait_for_text_to_equal(".e", "ClickD"),
+    dash_duo.wait_for_text_to_equal(".d", "D")
+    dash_duo.wait_for_text_to_equal(".c", "Click")
+    dash_duo.wait_for_text_to_equal(".b", "Click")
+    dash_duo.wait_for_text_to_equal(".a", "Click")
+
+
+@pytest.mark.parametrize("clientside", (False, True))
+@pytest.mark.parametrize("content", (False, True))
+def test_cbpi003_multi_outputs(clientside, content, dash_duo):
+    app = dash.Dash(__name__)
+
+    layout = html.Div([
+        html.Button("click", id="btn"),
+        html.Div("A", id="a"),
+        html.Div("B", id="b"),
+        html.Div("C", id="c"),
+        html.Div("D", id="d"),
+        html.Div("E", id="e"),
+        html.Div("F", id="f"),
+        html.Div("G", id="g"),
+    ])
+
+    content_callback(app, content, layout)
+
+    const_callback(app, clientside, ["Blue", "Cheese"], [Output("a", "children"), Output("b", "children")], [Input("btn", "n_clicks")], prevent_initial_call=True)
+
+    concat_callback(app, clientside, [Output("c", "children"), Output("d", "children")], [Input("a", "children"), Input("b", "children")], prevent_initial_call=True)
+
+    concat_callback(app, clientside, [Output("e", "children"), Output("f", "children")], [Input("a", "children")], prevent_initial_call=True)
+
+    # this is the only one that should run initially
+    concat_callback(app, clientside, Output("g", "children"), [Input("f", "children")])
+
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_text_to_equal("#g", "F")
+    dash_duo.wait_for_text_to_equal("#f", "F")
+    dash_duo.wait_for_text_to_equal("#e", "E")
+    dash_duo.wait_for_text_to_equal("#d", "D")
+    dash_duo.wait_for_text_to_equal("#c", "C")
+    dash_duo.wait_for_text_to_equal("#b", "B")
+    dash_duo.wait_for_text_to_equal("#a", "A")
+
+    dash_duo.find_element("#btn").click()
+
+    dash_duo.wait_for_text_to_equal("#g", "Blue")
+    dash_duo.wait_for_text_to_equal("#f", "Blue")
+    dash_duo.wait_for_text_to_equal("#e", "Blue")
+    dash_duo.wait_for_text_to_equal("#d", "BlueCheese")
+    dash_duo.wait_for_text_to_equal("#c", "BlueCheese")
+    dash_duo.wait_for_text_to_equal("#b", "Cheese")
+    dash_duo.wait_for_text_to_equal("#a", "Blue")


### PR DESCRIPTION
Closes #1225 
Supersedes #1123 

Adds the ability to control whether or not callbacks fire when the page or layout chunk first loads. This can simplify a lot of code like `if n_clicks is None: raise PreventUpdate`, and it can improve loading performance, particularly for pattern-matching callbacks, where a page can easily generate hundreds of callback invocations, since there is no longer even a server call for these callbacks.

This option is off by default, but can either be turned on for each callback independently:
```py
@app.callback(outputs, inputs, prevent_initial_call=True)
def cb(...):
    ...

app.clientside_callback(func, outputs, inputs, prevent_initial_call=True)
```

or app-wide, in which case it can be turned _off_ for individual callbacks:
```py
app = dash.Dash(prevent_initial_callbacks=True)

@app.callback(outputs, inputs, prevent_initial_call=False)
def cb(...)
    ...
```

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
- [x] I have added entry in the `CHANGELOG.md`
- [x] Docs follow-up issue: https://github.com/plotly/dash-docs/issues/874
