### PR TITLE
Insert WC 'dots' into generated .Rd files

### DIFF
--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -185,6 +185,7 @@ def generate_class_string(name, props, project_shortname, prefix):
     props = reorder_props(props=props)
 
     prop_keys = list(props.keys())
+    prop_keys_wc = list(props.keys())
 
     wildcards = ""
     wildcard_declaration = ""
@@ -193,8 +194,8 @@ def generate_class_string(name, props, project_shortname, prefix):
     default_argtext = ""
     accepted_wildcards = ""
 
-    if any(key.endswith("-*") for key in prop_keys):
-        accepted_wildcards = get_wildcards_r(prop_keys)
+    if any(key.endswith("-*") for key in prop_keys_wc):
+        accepted_wildcards = get_wildcards_r(prop_keys_wc)
         wildcards = ", ..."
         wildcard_declaration = wildcard_template.format(
             accepted_wildcards.replace("-*", "")


### PR DESCRIPTION
This PR proposes the apply the same fix for detecting and inserting wildcards to `generate_class_string` as is already present in `write_help_file`. I should've made this change in both locations in my earlier PR, but missed the edit 🙈 .

Without the edit, the `...` are present in the component signature, but missing from the documentation. CRAN checks will fail at package build time otherwise; the updated artifacts are already in `master`.