### PR TITLE
Issue-1213 clientside callback_context Initial Commit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [UNRELEASED]
 ### Added
 - [#1240](https://github.com/plotly/dash/pull/1240) Adds `callback_context` to clientside callbacks (e.g. `dash_clientside.callback_context.triggered`). Supports `triggered`, `inputs`, `inputs_list`, `states`, and `states_list`, all of which closely resemble their serverside cousins.
+
+## [1.12.0] - 2020-05-05
+### Added
 - [#1228](https://github.com/plotly/dash/pull/1228) Adds control over firing callbacks on page (or layout chunk) load. Individual callbacks can have their initial calls disabled in their definition `@app.callback(..., prevent_initial_call=True)` and similar for `app.clientside_callback`. The app-wide default can also be changed with `app=Dash(prevent_initial_callbacks=True)`, then individual callbacks may disable this behavior.
 - [#1201](https://github.com/plotly/dash/pull/1201) New attribute `app.validation_layout` allows you to create a multi-page app without `suppress_callback_exceptions=True` or layout function tricks. Set this to a component layout containing the superset of all IDs on all pages in your app.
 - [#1078](https://github.com/plotly/dash/pull/1078) Permit usage of arbitrary file extensions for assets within component libraries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [1.12.0] - 2020-05-05
+## [UNRELEASED]
 ### Added
+- [#1240](https://github.com/plotly/dash/pull/1240) Adds `callback_context` to clientside callbacks (e.g. `dash_clientside.callback_context.triggered`). Supports `triggered`, `inputs`, `inputs_list`, `states`, and `states_list`, all of which closely resemble their serverside cousins.
 - [#1228](https://github.com/plotly/dash/pull/1228) Adds control over firing callbacks on page (or layout chunk) load. Individual callbacks can have their initial calls disabled in their definition `@app.callback(..., prevent_initial_call=True)` and similar for `app.clientside_callback`. The app-wide default can also be changed with `app=Dash(prevent_initial_callbacks=True)`, then individual callbacks may disable this behavior.
 - [#1201](https://github.com/plotly/dash/pull/1201) New attribute `app.validation_layout` allows you to create a multi-page app without `suppress_callback_exceptions=True` or layout function tricks. Set this to a component layout containing the superset of all IDs on all pages in your app.
 - [#1078](https://github.com/plotly/dash/pull/1078) Permit usage of arbitrary file extensions for assets within component libraries

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -531,6 +531,9 @@ function inputsToDict(inputs_list) {
     // returns an Object (map):
     //  keys of the form `id.property` or `{"id": 0}.property`
     //  values contain the property value
+    if (!inputs_list){
+        return {};
+    }
     const inputs = {};
     for (let i = 0; i < inputs_list.length; i++) {
         if (Array.isArray(inputs_list[i])) {
@@ -539,11 +542,11 @@ function inputsToDict(inputs_list) {
                 const id_str = `${JSON.stringify(inputsi[ii].id)}.${
                     inputsi[ii].property
                 }`;
-                inputs[id_str] = inputsi[ii].value;
+                inputs[id_str] = inputsi[ii].value ? inputsi[ii].value : null;
             }
         } else {
             const id_str = `${inputs_list[i].id}.${inputs_list[i].property}`;
-            inputs[id_str] = inputs_list[i].value;
+            inputs[id_str] = inputs_list[i].value ? inputs_list[i].value : null;
         }
     }
     return inputs;
@@ -578,9 +581,10 @@ function handleClientside(clientside_function, payload) {
                 prop_id => ({prop_id: prop_id, value: input_dict[prop_id]})
             );
         }
-        dc.callback_context.inputs_list = input_dict;
-        dc.callback_context.inputs = inputs;
-        // TODO: add the rest: states, states_list, response(??)
+        dc.callback_context.inputs_list = inputs;
+        dc.callback_context.inputs = input_dict;
+        dc.callback_context.states_list = state;
+        dc.callback_context.states = inputsToDict(state);
 
         const {namespace, function_name} = clientside_function;
         let args = inputs.map(getVals);

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -531,7 +531,7 @@ function inputsToDict(inputs_list) {
     // returns an Object (map):
     //  keys of the form `id.property` or `{"id": 0}.property`
     //  values contain the property value
-    if (!inputs_list){
+    if (!inputs_list) {
         return {};
     }
     const inputs = {};

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -539,14 +539,16 @@ function inputsToDict(inputs_list) {
         if (Array.isArray(inputs_list[i])) {
             const inputsi = inputs_list[i];
             for (let ii = 0; ii < inputsi.length; ii++) {
-                const id_str = `${JSON.stringify(inputsi[ii].id)}.${
+                const id_str = `${stringifyId(inputsi[ii].id)}.${
                     inputsi[ii].property
                 }`;
-                inputs[id_str] = inputsi[ii].value ? inputsi[ii].value : null;
+                inputs[id_str] = inputsi[ii].value ?? null;
             }
         } else {
-            const id_str = `${inputs_list[i].id}.${inputs_list[i].property}`;
-            inputs[id_str] = inputs_list[i].value ? inputs_list[i].value : null;
+            const id_str = `${stringifyId(inputs_list[i].id)}.${
+                inputs_list[i].property
+            }`;
+            inputs[id_str] = inputs_list[i].value ?? null;
         }
     }
     return inputs;

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -531,17 +531,18 @@ function inputsToDict(inputs_list) {
     // returns an Object (map):
     //  keys of the form `id.property` or `{"id": 0}.property`
     //  values contain the property value
-    let inputs = {};
+    const inputs = {};
     for (let i = 0; i < inputs_list.length; i++) {
         if (Array.isArray(inputs_list[i])) {
-            let inputsi = inputs_list[i];
+            const inputsi = inputs_list[i];
             for (let ii = 0; ii < inputsi.length; ii++) {
-                let id_str = `${JSON.stringify(inputsi[ii].id)}.${inputsi[ii].property}`;
+                const id_str = `${JSON.stringify(inputsi[ii].id)}.${
+                    inputsi[ii].property
+                }`;
                 inputs[id_str] = inputsi[ii].value;
             }
-        }
-        else {
-            let id_str = `${inputs_list[i].id}.${inputs_list[i].property}`;
+        } else {
+            const id_str = `${inputs_list[i].id}.${inputs_list[i].property}`;
             inputs[id_str] = inputs_list[i].value;
         }
     }
@@ -568,14 +569,14 @@ function handleClientside(clientside_function, payload) {
 
     try {
         // setup callback context
-        let input_dict = inputsToDict(inputs);
+        const input_dict = inputsToDict(inputs);
         dc.callback_context = {};
         if (payload.changedPropIds.length === 0) {
-            dc.callback_context.triggered = [{'prop_id': '.', 'value': null}];
-        }
-        else {
+            dc.callback_context.triggered = [{prop_id: '.', value: null}];
+        } else {
             dc.callback_context.triggered = payload.changedPropIds.map(
-                prop_id => ({'prop_id': prop_id, 'value': input_dict[prop_id]}));
+                prop_id => ({prop_id: prop_id, value: input_dict[prop_id]})
+            );
         }
         dc.callback_context.inputs_list = input_dict;
         dc.callback_context.inputs = inputs;

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -533,10 +533,16 @@ function inputsToDict(inputs_list) {
     //  values contain the property value
     let inputs = {};
     for (let i = 0; i < inputs_list.length; i++) {
-        let inputsi = Array.isArray(inputs_list[i]) ? inputs_list[i] : [inputs_list[i]];
-        for (let ii = 0; ii < inputsi.length; ii++) {
-            let id_str = `${JSON.stringify(inputsi[ii].id)}.${inputsi[ii].property}`;
-            inputs[id_str] = inputsi[ii].value;
+        if (Array.isArray(inputs_list[i])) {
+            let inputsi = inputs_list[i];
+            for (let ii = 0; ii < inputsi.length; ii++) {
+                let id_str = `${JSON.stringify(inputsi[ii].id)}.${inputsi[ii].property}`;
+                inputs[id_str] = inputsi[ii].value;
+            }
+        }
+        else {
+            let id_str = `${inputs_list[i].id}.${inputs_list[i].property}`;
+            inputs[id_str] = inputs_list[i].value;
         }
     }
     return inputs;
@@ -581,7 +587,7 @@ function handleClientside(clientside_function, payload) {
             args = concat(args, state.map(getVals));
         }
         returnValue = dc[namespace][function_name](...args);
-        
+
         delete dc.callback_context;
     } catch (e) {
         if (e === dc.PreventUpdate) {

--- a/dash-renderer/src/actions/index.js
+++ b/dash-renderer/src/actions/index.js
@@ -576,13 +576,10 @@ function handleClientside(clientside_function, payload) {
         // setup callback context
         const input_dict = inputsToDict(inputs);
         dc.callback_context = {};
-        if (payload.changedPropIds.length === 0) {
-            dc.callback_context.triggered = [{prop_id: '.', value: null}];
-        } else {
-            dc.callback_context.triggered = payload.changedPropIds.map(
-                prop_id => ({prop_id: prop_id, value: input_dict[prop_id]})
-            );
-        }
+        dc.callback_context.triggered = payload.changedPropIds.map(prop_id => ({
+            prop_id: prop_id,
+            value: input_dict[prop_id],
+        }));
         dc.callback_context.inputs_list = inputs;
         dc.callback_context.inputs = input_dict;
         dc.callback_context.states_list = state;

--- a/tests/integration/clientside/assets/clientside.js
+++ b/tests/integration/clientside/assets/clientside.js
@@ -56,6 +56,30 @@ window.dash_clientside.clientside = {
                 resolve('foo');
             }, 1);
         });
-    }
+    },
 
-}
+    triggered_to_str: function(n_clicks0, n_clicks1) {
+        const triggered = dash_clientside.callback_context.triggered;
+        return triggered.map(t => `${t.prop_id} = ${t.value}`).join(', ');
+    },
+
+    inputs_to_str: function(n_clicks0, n_clicks1) {
+        const inputs = dash_clientside.callback_context.inputs;
+        const keys = Object.keys(inputs);
+        return keys.map(k => `${k} = ${inputs[k]}`).join(', ');
+    },
+
+    inputs_list_to_str: function(n_clicks0, n_clicks1) {
+        return JSON.stringify(dash_clientside.callback_context.inputs_list);
+    },
+
+    states_to_str: function(val0, val1, st0, st1) {
+        const states = dash_clientside.callback_context.states;
+        const keys = Object.keys(states);
+        return keys.map(k => `${k} = ${states[k]}`).join(', ');
+    },
+
+    states_list_to_str: function(val0, val1, st0, st1) {
+        return JSON.stringify(dash_clientside.callback_context.states_list);
+    }
+};

--- a/tests/integration/clientside/test_clientside.py
+++ b/tests/integration/clientside/test_clientside.py
@@ -389,7 +389,7 @@ def test_clsd009_clientside_callback_context_triggered(dash_duo):
 
     dash_duo.start_server(app)
 
-    dash_duo.wait_for_text_to_equal("#output-clientside", ". = null")
+    dash_duo.wait_for_text_to_equal("#output-clientside", "")
 
     dash_duo.find_element("#btn0").click()
 
@@ -545,8 +545,6 @@ def test_clsd011_clientside_callback_context_inputs_list(dash_duo):
             '{"id":{"btn1":2},"property":"n_clicks","value":1}]]'
         ),
     )
-    # TODO: flush out these tests and make them look prettier.
-    #  Maybe one test for each of the callback_context properties?
 
 
 def test_clsd012_clientside_callback_context_states(dash_duo):

--- a/tests/integration/clientside/test_clientside.py
+++ b/tests/integration/clientside/test_clientside.py
@@ -385,7 +385,7 @@ def test_clsd009_clientside_callback_context(dash_duo):
         Output("output-serverside", "children"), [Input({"btn": ALL}, "n_clicks")]
     )
     def update_output(n_clicks):
-        return f"triggered: {dash.callback_context.triggered}"
+        return "triggered: %s" % dash.callback_context.triggered
 
     app.clientside_callback(
         """


### PR DESCRIPTION
## Clientside callback_context
Here’s a first pass at Issue-1213, adding callback_context to clientside callbacks. Before I get too much further into the weeds, I wanted to get a PR going to discuss.

The idea was to mimic the behavior of the serverside dash.callback_context as closely as possible. I think this is probably the way to go for consistency’s sake, but I am of course open to suggestions.
From within a clientside callback function, we can now use the trick with “triggered” to figure out which input triggered the callback:

`triggered = dash_clientside.callback_context.triggered.map(t => t[“prop_id”]);`

The first new test `test_clsd009_clientside_callback_context` is currently passing.

## Contributor Checklist

- [x] TODO
   -  [x] Add property `states`
   -  [x] Add property `states_list`
   -  [ ] ~~Add property `response` (need to check if this even makes sense in the clientside context)~~
   -  [x] Flush out tests for each of the context properties
- [x] All tests passing
----
#### Two quick off-topic things:
- I get the following warning when setting up `pip install -e .[testing,dev]`:
 
`requests 2.21.0 has requirement urllib3<1.25,>=1.21.1, but you'll have urllib3 1.25.9 which is incompatible.`

- I had to comment out all of /test/integration/test_generation.py to gets pytest to work.
I’m on Windows, Python 3.7
