### PR TITLE
fix #919 - protect against pytest item with no funcargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - [#1237](https://github.com/plotly/dash/pull/1237) Closes [#920](https://github.com/plotly/dash/issues/920): Converts hot reload fetch failures into a server status indicator showing whether the latest fetch succeeded or failed. Callback fetch failures still appear as errors but have a clearer message.
 
+### Fixed
+- [#1249](https://github.com/plotly/dash/pull/1249) Fixes [#919](https://github.com/plotly/dash/issues/919) so `dash.testing` is compatible with more `pytest` plugins, particularly `pytest-flake8` and `pytest-black`.
+
 ## [1.12.0] - 2020-05-05
 ### Added
 - [#1228](https://github.com/plotly/dash/pull/1228) Adds control over firing callbacks on page (or layout chunk) load. Individual callbacks can have their initial calls disabled in their definition `@app.callback(..., prevent_initial_call=True)` and similar for `app.clientside_callback`. The app-wide default can also be changed with `app=Dash(prevent_initial_callbacks=True)`, then individual callbacks may disable this behavior.

--- a/dash/testing/plugin.py
+++ b/dash/testing/plugin.py
@@ -75,7 +75,7 @@ def pytest_runtest_makereport(item, call):  # pylint: disable=unused-argument
     rep = outcome.get_result()
 
     # we only look at actual failing test calls, not setup/teardown
-    if rep.when == "call" and rep.failed:
+    if rep.when == "call" and rep.failed and hasattr(item, "funcargs"):
         for name, fixture in item.funcargs.items():
             try:
                 if name in {"dash_duo", "dash_br", "dashr"}:


### PR DESCRIPTION
In #919 the error seems to be that some `item` arguments, when you're running `pytest` with other plugins, don't have a `funcargs` attribute. I don't see any documentation of this attribute, but it seems harmless to just skip any `item` without it - this is only a post-failure extra diagnostic anyway.

- [x] I have added entry in the `CHANGELOG.md`
