### PR TITLE
Generate Julia package metadata for Dash components

### DIFF
--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -111,6 +111,10 @@ def generate_components(
         )
 
     if jlprefix is not False:
+        if pkg_data is None:
+            with open("package.json", "r") as f:
+                pkg_data = safe_json_loads(f.read())
+
         generator_methods.append(
             functools.partial(generate_struct_file, prefix=jlprefix)
         )
@@ -140,6 +144,7 @@ def generate_components(
             project_shortname,
             components,
             metadata,
+            pkg_data,
             jlprefix
         )
 


### PR DESCRIPTION
Added generation of the main project file and Project.toml. The components generated by this generator work with [this PR](https://github.com/plotly/Dash.jl/pull/18)