### PR TITLE
hard reload targets just this window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [#1237](https://github.com/plotly/dash/pull/1237) Closes [#920](https://github.com/plotly/dash/issues/920): Converts hot reload fetch failures into a server status indicator showing whether the latest fetch succeeded or failed. Callback fetch failures still appear as errors but have a clearer message.
 
 ### Fixed
+- [#1255](https://github.com/plotly/dash/pull/1255) Hard hot reload targets only the current window, not the top - so if your app is in an iframe you will only reload the app
 - [#1249](https://github.com/plotly/dash/pull/1249) Fixes [#919](https://github.com/plotly/dash/issues/919) so `dash.testing` is compatible with more `pytest` plugins, particularly `pytest-flake8` and `pytest-black`.
 - [#1248](https://github.com/plotly/dash/pull/1248) Fixes [#1245](https://github.com/plotly/dash/issues/1245), so you can use prop persistence with components that have dict IDs, ie for pattern-matching callbacks.
 - [#1185](https://github.com/plotly/dash/pull/1185) Sort asset directories, same as we sort files inside those directories. This way if you need your assets loaded in a certain order, you can add prefixes to subdirectory names and enforce that order.

--- a/dash-renderer/src/components/core/Reloader.react.js
+++ b/dash-renderer/src/components/core/Reloader.react.js
@@ -148,7 +148,7 @@ class Reloader extends React.Component {
                     // Assets file have changed
                     // or a component lib has been added/removed -
                     // Must do a hard reload
-                    window.top.location.reload();
+                    window.location.reload();
                 }
             } else {
                 // Backend code changed - can do a soft reload in place

--- a/tests/integration/devtools/hr_assets/hot_reload.js
+++ b/tests/integration/devtools/hr_assets/hot_reload.js
@@ -1,0 +1,2 @@
+
+window.cheese = 'roquefort';

--- a/tests/integration/renderer/test_due_diligence.py
+++ b/tests/integration/renderer/test_due_diligence.py
@@ -54,6 +54,7 @@ def test_rddd001_initial_state(dash_duo):
     # fmt:on
 
     dash_duo.start_server(app)
+    dash_duo.wait_for_text_to_equal(r"#p\.c\.5", "")
 
     # Note: this .html file shows there's no undo/redo button by default
     with open(


### PR DESCRIPTION
For some reason we had `window.top.location.reload()` for dev tools hot reloading - but if your app is in an iframe there's no reason you need (or want!) the parent to reload, is there?

- [x] Extend existing hot reload test to cover both soft and hard reload. I don't really feel the need to test the iframe case though - seems like a huge hassle for something we're not likely to mess with again. Reasonable?
- [x] I have added entry in the `CHANGELOG.md`
