### PR TITLE
don't override document.title if set to None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 ### Added
+- [#1343](https://github.com/plotly/dash/pull/1343) Add `title` parameter to set the
+document title. This is the recommended alternative to setting app.title or overriding
+the index HTML.
 - [#1315](https://github.com/plotly/dash/pull/1315) Add `update_title` parameter to set or disable the "Updating...." document title during updates. Closes [#856](https://github.com/plotly/dash/issues/856) and [#732](https://github.com/plotly/dash/issues/732)
 
 ## [1.13.4] - 2020-06-25

--- a/dash-renderer/src/components/core/DocumentTitle.react.js
+++ b/dash-renderer/src/components/core/DocumentTitle.react.js
@@ -7,13 +7,19 @@ class DocumentTitle extends Component {
         super(props);
         const {update_title} = props.config;
         this.state = {
+            title: document.title,
             update_title,
         };
     }
 
     UNSAFE_componentWillReceiveProps(props) {
-        if (this.state.update_title && props.isLoading) {
-            document.title = this.state.update_title;
+        if (props.isLoading) {
+            this.setState({title: document.title});
+            if (this.state.update_title) {
+                document.title = this.state.update_title;
+            }
+        } else {
+            document.title = this.state.title;
         }
     }
 

--- a/dash-renderer/src/components/core/DocumentTitle.react.js
+++ b/dash-renderer/src/components/core/DocumentTitle.react.js
@@ -7,7 +7,6 @@ class DocumentTitle extends Component {
         super(props);
         const {update_title} = props.config;
         this.state = {
-            initialTitle: document.title,
             update_title,
         };
     }
@@ -15,8 +14,6 @@ class DocumentTitle extends Component {
     UNSAFE_componentWillReceiveProps(props) {
         if (this.state.update_title && props.isLoading) {
             document.title = this.state.update_title;
-        } else {
-            document.title = this.state.initialTitle;
         }
     }
 

--- a/dash-renderer/src/components/core/DocumentTitle.react.js
+++ b/dash-renderer/src/components/core/DocumentTitle.react.js
@@ -13,13 +13,21 @@ class DocumentTitle extends Component {
     }
 
     UNSAFE_componentWillReceiveProps(props) {
+        if (!this.state.update_title) {
+            // Let callbacks or other components have full control over title
+            return;
+        }
         if (props.isLoading) {
             this.setState({title: document.title});
             if (this.state.update_title) {
                 document.title = this.state.update_title;
             }
         } else {
-            document.title = this.state.title;
+            if (document.title === this.state.update_title) {
+                document.title = this.state.title;
+            } else {
+                this.setState({title: document.title});
+            }
         }
     }
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -227,6 +227,15 @@ class Dash(object):
         with a ``plug`` method, taking a single argument: this app, which will
         be called after the Flask server is attached.
     :type plugins: list of objects
+
+    :param title: Default ``Dash``. Configures the document.title
+    (the text that appears in a browser tab).
+
+    :param update_title: Default ``Updating...``. Configures the document.title
+    (the text that appears in a browser tab) text when a callback is being run.
+    Set to None or '' if you don't want the document.title to change or if you
+    want to control the document.title through a separate component or
+    clientside callback.
     """
 
     def __init__(
@@ -252,6 +261,7 @@ class Dash(object):
         prevent_initial_callbacks=False,
         show_undo_redo=False,
         plugins=None,
+        title='Dash',
         update_title="Updating...",
         **obsolete
     ):
@@ -320,6 +330,9 @@ class Dash(object):
             "Invalid config key. Some settings are only available "
             "via the Dash constructor"
         )
+
+        # keep title as a class property for backwards compatability
+        self.title = title
 
         # list of dependencies - this one is used by the back end for dispatching
         self.callback_map = {}
@@ -725,7 +738,6 @@ class Dash(object):
         config = self._generate_config_html()
         metas = self._generate_meta_html()
         renderer = self._generate_renderer()
-        title = getattr(self, "title", "Dash")
 
         if self._favicon:
             favicon_mod_time = os.path.getmtime(

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -738,6 +738,7 @@ class Dash(object):
         config = self._generate_config_html()
         metas = self._generate_meta_html()
         renderer = self._generate_renderer()
+        title = self.config.title
 
         if self._favicon:
             favicon_mod_time = os.path.getmtime(

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -741,7 +741,7 @@ class Dash(object):
         renderer = self._generate_renderer()
 
         # use self.title instead of app.config.title for backwards compatibility
-        title = self.title  
+        title = self.title
 
         if self._favicon:
             favicon_mod_time = os.path.getmtime(

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -739,7 +739,9 @@ class Dash(object):
         config = self._generate_config_html()
         metas = self._generate_meta_html()
         renderer = self._generate_renderer()
-        title = self.config.title
+
+        # use self.title instead of app.config.title for backwards compatibility
+        title = self.title  
 
         if self._favicon:
             favicon_mod_time = os.path.getmtime(

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -310,6 +310,7 @@ class Dash(object):
             ),
             prevent_initial_callbacks=prevent_initial_callbacks,
             show_undo_redo=show_undo_redo,
+            title=title,
             update_title=update_title,
         )
         self.config.set_read_only(

--- a/requires-dev.txt
+++ b/requires-dev.txt
@@ -1,5 +1,6 @@
 dash_flow_example==0.0.5
 dash-dangerously-set-inner-html
+isort==4.3.21
 mock==4.0.1;python_version>="3.0"
 mock==3.0.5;python_version=="2.7"
 flake8==3.7.9

--- a/tests/integration/renderer/test_loading_states.py
+++ b/tests/integration/renderer/test_loading_states.py
@@ -262,19 +262,18 @@ def test_rdls004_update_title_chained_callbacks(dash_duo, update_title):
             html.Div(id="final-output")
         ]
     )
-    if clientside_title:
-        app.clientside_callback(
-            """
-            function(n_clicks) {
-                if (n_clicks > 0) {
-                    document.title = 'Page ' + n_clicks;
-                }
-                return n_clicks;
+    app.clientside_callback(
+        """
+        function(n_clicks) {
+            if (n_clicks > 0) {
+                document.title = 'Page ' + n_clicks;
             }
-            """,
-            Output("page-output", "children"),
-            [Input("page-title", "n_clicks")],
-        )
+            return n_clicks;
+        }
+        """,
+        Output("page-output", "children"),
+        [Input("page-title", "n_clicks")],
+    )
 
     @app.callback(
         Output("final-output", "children"),

--- a/tests/integration/renderer/test_loading_states.py
+++ b/tests/integration/renderer/test_loading_states.py
@@ -230,7 +230,7 @@ def test_rdls003_update_title(
         until(lambda: dash_duo.driver.title == expected_update_title, timeout=1)
 
     dash_duo.find_element("#page").click()
-    dash_duo.wait_for_text_to_equal("dummy", "1")
+    dash_duo.wait_for_text_to_equal("#dummy", "1")
     if clientside_title:
         until(lambda: dash_duo.driver.title == "Page 1", timeout=1)
     else:
@@ -283,7 +283,7 @@ def test_rdls004_update_title_chained_callbacks(dash_duo, update_title):
             return n
 
     # check for original title after loading
-    dash_duo.wait_for_text_to_equal("final-output", "0")
+    dash_duo.wait_for_text_to_equal("#final-output", "0")
     until(lambda: dash_duo.driver.title == initial_title, timeout=1)
 
     with lock:
@@ -294,5 +294,5 @@ def test_rdls004_update_title_chained_callbacks(dash_duo, update_title):
         else:
             until(lambda: dash_duo.driver.title == 'Page 1', timeout=1)
 
-    dash_duo.wait_for_text_to_equal("final-output", "1")
+    dash_duo.wait_for_text_to_equal("#final-output", "1")
     until(lambda: dash_duo.driver.title == 'Page 1', timeout=1)

--- a/tests/integration/renderer/test_loading_states.py
+++ b/tests/integration/renderer/test_loading_states.py
@@ -172,15 +172,21 @@ def test_rdls002_chained_loading_states(dash_duo):
 
 
 @pytest.mark.parametrize(
-    "kwargs, expected_update_title",
+    "kwargs, expected_update_title, clientside_title",
     [
-        ({}, "Updating..."),
-        ({"update_title": None}, "Dash"),
-        ({"update_title": ""}, "Dash"),
-        ({"update_title": "Hello World"}, "Hello World"),
-    ]
+        ({}, "Updating...", False),
+        ({"update_title": None}, "Dash", False),  # fail
+        ({"update_title": ""}, "Dash", False),    # fail
+        ({"update_title": "Hello World"}, "Hello World", False),
+        ({}, "Updating...", True),            # fail
+        ({"update_title": None}, "Dash", True), # fail
+        ({"update_title": ""}, "Dash", True),   # fail
+        ({"update_title": "Hello World"}, "Hello World", True),  # fail
+    ],
 )
-def test_rdls003_update_title(dash_duo, kwargs, expected_update_title):
+def test_rdls003_update_title(
+    dash_duo, kwargs, expected_update_title, clientside_title
+):
     app = dash.Dash("Dash", **kwargs)
     lock = Lock()
 
@@ -189,13 +195,23 @@ def test_rdls003_update_title(dash_duo, kwargs, expected_update_title):
             html.H3("Press button see document title updating"),
             html.Div(id="output"),
             html.Button("Update", id="button", n_clicks=0),
+            html.Button("Update Page", id="page", n_clicks=0),
+            html.Div(id="dummy"),
         ]
     )
+    if clientside_title:
+        app.clientside_callback(
+            """
+            function(n_clicks) {
+                document.title = 'Page ' + n_clicks;
+                return n_clicks;
+            }
+            """,
+            Output("dummy", "children"),
+            [Input("page", "n_clicks")],
+        )
 
-    @app.callback(
-        Output("output", "children"),
-        [Input("button", "n_clicks")]
-    )
+    @app.callback(Output("output", "children"), [Input("button", "n_clicks")])
     def update(n):
         with lock:
             return n
@@ -206,9 +222,22 @@ def test_rdls003_update_title(dash_duo, kwargs, expected_update_title):
         until(lambda: dash_duo.driver.title == expected_update_title, timeout=1)
 
     # check for original title after loading
-    until(lambda: dash_duo.driver.title == "Dash", timeout=1)
+    until(lambda: dash_duo.driver.title == "Page 0" if clientside_title else "Dash", timeout=1)
 
     with lock:
         dash_duo.find_element("#button").click()
         # check for update-title while processing callback
         until(lambda: dash_duo.driver.title == expected_update_title, timeout=1)
+
+    dash_duo.find_element("#page").click()
+    dash_duo.wait_for_text_to_equal("dummy", "1")
+    if clientside_title:
+        until(lambda: dash_duo.driver.title == "Page 1", timeout=1)
+    else:
+        until(lambda: dash_duo.driver.title == "Dash", timeout=1)
+
+    dash_duo.find_element("#button").click()
+    if clientside_title:
+        until(lambda: dash_duo.driver.title == "Page 2", timeout=1)
+    else:
+        until(lambda: dash_duo.driver.title == "Dash", timeout=1)

--- a/tests/integration/renderer/test_loading_states.py
+++ b/tests/integration/renderer/test_loading_states.py
@@ -175,13 +175,13 @@ def test_rdls002_chained_loading_states(dash_duo):
     "kwargs, expected_update_title, clientside_title",
     [
         ({}, "Updating...", False),
-        ({"update_title": None}, "Dash", False),  # fail
-        ({"update_title": ""}, "Dash", False),    # fail
+        ({"update_title": None}, "Dash", False),
+        ({"update_title": ""}, "Dash", False),
         ({"update_title": "Hello World"}, "Hello World", False),
-        ({}, "Updating...", True),            # fail
-        ({"update_title": None}, "Dash", True), # fail
-        ({"update_title": ""}, "Dash", True),   # fail
-        ({"update_title": "Hello World"}, "Hello World", True),  # fail
+        ({}, "Updating...", True),
+        ({"update_title": None}, "Dash", True),
+        ({"update_title": ""}, "Dash", True),
+        ({"update_title": "Hello World"}, "Hello World", True),
     ],
 )
 def test_rdls003_update_title(

--- a/tests/integration/renderer/test_loading_states.py
+++ b/tests/integration/renderer/test_loading_states.py
@@ -204,7 +204,7 @@ def test_rdls003_update_title(
             """
             function(n_clicks) {
                 document.title = 'Page ' + n_clicks;
-                return n_clicks;
+                return 'Page ' + n_clicks;
             }
             """,
             Output("dummy", "children"),
@@ -229,16 +229,16 @@ def test_rdls003_update_title(
         # check for update-title while processing callback
         until(lambda: dash_duo.driver.title == expected_update_title, timeout=1)
 
-    dash_duo.find_element("#page").click()
-    dash_duo.wait_for_text_to_equal("#dummy", "1")
+    if clientside_title:
+        dash_duo.find_element("#page").click()
+        dash_duo.wait_for_text_to_equal("#dummy", "Page 1")
+        until(lambda: dash_duo.driver.title == "Page 1", timeout=1)
+
+    # verify that when a separate callback runs, the page title gets restored
+    dash_duo.find_element("#button").click()
+    dash_duo.wait_for_text_to_equal("#output", "2")
     if clientside_title:
         until(lambda: dash_duo.driver.title == "Page 1", timeout=1)
-    else:
-        until(lambda: dash_duo.driver.title == "Dash", timeout=1)
-
-    dash_duo.find_element("#button").click()
-    if clientside_title:
-        until(lambda: dash_duo.driver.title == "Page 2", timeout=1)
     else:
         until(lambda: dash_duo.driver.title == "Dash", timeout=1)
 

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -314,3 +314,13 @@ def test_proxy_failure(mocker, empty_environ):
         )
     assert "port: 8055 is incompatible with the proxy" in excinfo.exconly()
     assert "you must use port: 8155" in excinfo.exconly()
+
+
+def test_title():
+    app = Dash()
+    assert '<title>Dash</title>' in app.index()
+    app = Dash()
+    app.title = 'Hello World'
+    assert '<title>Hello World</title>' in app.index()
+    app = Dash(title='Custom Title')
+    assert '<title>Custom Title</title>' in app.index()


### PR DESCRIPTION
As requested by a [Dash Enterprise](https://plotly.com/dash) customer.

This allows users to override `document.title` during runtime with a
clientside callback or a special component
(https://github.com/plotly/dash-core-components/issues/833)

Example of modifying during runtime:
```python
import dash
import dash_html_components as html
import dash_core_components as dcc
from dash.dependencies import Input, Output

app = dash.Dash(__name__, update_title=None)


app.layout = app.layout = html.Div([
    dcc.Input(id='input'),
    html.Div(id='output'),

    html.Div(id='dummy'),
    dcc.Tabs(id='tabs-example', value='tab-1', children=[
        dcc.Tab(label='Tab one', value='tab-1'),
        dcc.Tab(label='Tab two', value='tab-2'),
    ]),
    html.Div(id='tabs-example-content')
])


app.clientside_callback(
    """
    function(tab_value) {
        console.log(tab_value);
        document.title = tab_value;
        return null; // dummy output
    }
    """,
    Output('dummy', 'children'),
    [Input('tabs-example', 'value')]
)


@app.callback(Output('output', 'children'), [Input('input', 'value')])
def update_output(value):
    return value

if __name__ == '__main__':
    app.run_server(debug=True)
```

Example with custom table title via index string:
```python
import dash
import dash_html_components as html
import dash_core_components as dcc
from dash.dependencies import Input, Output

app = dash.Dash(__name__, update_title=None)

app.index_string = '''
<!DOCTYPE html>
<html>
    <head>
        {%metas%}
        <title>Hello World</title>
        {%favicon%}
        {%css%}
    </head>
    <body>
        <div>My Custom header</div>
        {%app_entry%}
        <footer>
            {%config%}
            {%scripts%}
            {%renderer%}
        </footer>
        <div>My Custom footer</div>
    </body>
</html>
'''


app.layout = app.layout = html.Div([
    dcc.Input(id='input'),
    html.Div(id='output'),

    html.Div(id='dummy'),
    dcc.Tabs(id='tabs-example', value='tab-1', children=[
        dcc.Tab(label='Tab one', value='tab-1'),
        dcc.Tab(label='Tab two', value='tab-2'),
    ]),
    html.Div(id='tabs-example-content')
])


@app.callback(Output('output', 'children'), [Input('input', 'value')])
def update_output(value):
    return value

if __name__ == '__main__':
    app.run_server(debug=True)
```

 This is a follow up of https://github.com/plotly/dash/pull/1315/.