### PR TITLE
Move Dash logger.setLevel to init + remove now redundant startup message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED]
+### Added
+- [#1355](https://github.com/plotly/dash/pull/1355) Removed redundant log message and consolidated logger initialization. You can now control the log level - for example suppress informational messages from Dash with `app.logger.setLevel(logging.WARNING)`.
+
 ## [1.14.0] - 2020-07-27
 ### Added
 - [#1343](https://github.com/plotly/dash/pull/1343) Add `title` parameter to set the

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -385,6 +385,8 @@ class Dash(object):
         if self.server is not None:
             self.init_app()
 
+        self.logger.setLevel(logging.INFO)
+
     def init_app(self, app=None):
         """Initialize the parts of Dash that require a flask app."""
         config = self.config
@@ -1351,8 +1353,6 @@ class Dash(object):
         if dev_tools.silence_routes_logging:
             logging.getLogger("werkzeug").setLevel(logging.ERROR)
 
-        self.logger.setLevel(logging.INFO)
-
         if dev_tools.hot_reload:
             _reload = self._hot_reload
             _reload.hash = generate_hash()
@@ -1624,11 +1624,5 @@ class Dash(object):
                 display_url = (protocol, host, ":{}".format(port), path)
 
             self.logger.info("Dash is running on %s://%s%s%s\n", *display_url)
-            self.logger.info(
-                " Warning: This is a development server. Do not use app.run_server"
-            )
-            self.logger.info(
-                " in production, use a production WSGI server like gunicorn instead.\n"
-            )
 
         self.server.run(host=host, port=port, debug=debug, **flask_run_options)

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -1,4 +1,5 @@
 import os
+import logging
 
 import pytest
 from flask import Flask
@@ -256,15 +257,25 @@ def test_port_env_fail_range(empty_environ):
     )
 
 
-def test_no_proxy_success(mocker, caplog, empty_environ):
+@pytest.mark.parametrize(
+    "setlevel_warning", [False, True],
+)
+def test_no_proxy_success(mocker, caplog, empty_environ, setlevel_warning):
     app = Dash()
+
+    if setlevel_warning:
+        app.logger.setLevel(logging.WARNING)
 
     # mock out the run method so we don't actually start listening forever
     mocker.patch.object(app.server, "run")
 
     app.run_server(port=8787)
 
-    assert "Dash is running on http://127.0.0.1:8787/\n" in caplog.text
+    STARTUP_MESSAGE = "Dash is running on http://127.0.0.1:8787/\n"
+    if setlevel_warning:
+        assert caplog.text is None or STARTUP_MESSAGE not in caplog.text
+    else:
+        assert STARTUP_MESSAGE in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Resolves #1354.

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  [X] Move `setLevel` to `__init__`
   -  [X] Remove two now redundant messages.
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### Optionals

- [X] I have added entry in the `CHANGELOG.md` ~_(not added, this PR probably is not regarded as a "notable change", let me know if an entry should be added)_~.
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follow
    -  [ ] this github [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in plotly dash community 
