### PR TITLE
Build renderer prior to invoking npm run prepublishOnly

### DIFF
--- a/dash-renderer/package.json
+++ b/dash-renderer/package.json
@@ -14,7 +14,7 @@
     "build:js": "webpack --build release",
     "build:dev": "webpack --build local",
     "build:local": "renderer build local",
-    "build": "npm run prepublishOnly && renderer build",
+    "build": "renderer build && npm run prepublishOnly",
     "postbuild": "es-check es5 dash_renderer/*.js",
     "start": "webpack-serve ./webpack.serve.config.js",
     "test": "jest",


### PR DESCRIPTION
This PR proposes to run `renderer build` prior to running `npm run prepublishOnly`, which should resolve CI build errors in `dash-bio`, and potentially other repositories as well.