### PR TITLE
Update pytest for testing extra (Fixes #1365)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [UNRELEASED]
+### Changed
+- [#1368](https://github.com/plotly/dash/pull/1368) Updated pytest to v6.0.1. To avoid deprecation warnings, this also updated pytest-sugar to 0.9.4 and pytest-mock to 3.2.0. The pytest-mock update only effects python >= 3.0. Pytest-mock remains pinned at 2.0.0 for python == 2.7.
+
 ### Added
 - [#1355](https://github.com/plotly/dash/pull/1355) Removed redundant log message and consolidated logger initialization. You can now control the log level - for example suppress informational messages from Dash with `app.logger.setLevel(logging.WARNING)`.
 

--- a/requires-testing.txt
+++ b/requires-testing.txt
@@ -1,7 +1,8 @@
 pytest==6.0.1;python_version>="3.0"
 pytest==4.6.9;python_version=="2.7"
 pytest-sugar==0.9.4
-pytest-mock==3.2.0
+pytest-mock==3.2.0;python_version>="3.0"
+pytest-mock==2.0.0;python_version=="2.7"
 lxml==4.5.0
 selenium==3.141.0
 percy==2.0.2

--- a/requires-testing.txt
+++ b/requires-testing.txt
@@ -1,7 +1,7 @@
 pytest==6.0.1;python_version>="3.0"
 pytest==4.6.9;python_version=="2.7"
-pytest-sugar==0.9.2
-pytest-mock==2.0.0
+pytest-sugar==0.9.4
+pytest-mock==3.2.0
 lxml==4.5.0
 selenium==3.141.0
 percy==2.0.2

--- a/requires-testing.txt
+++ b/requires-testing.txt
@@ -1,4 +1,4 @@
-pytest==5.3.5;python_version>="3.0"
+pytest==6.0.1;python_version>="3.0"
 pytest==4.6.9;python_version=="2.7"
 pytest-sugar==0.9.2
 pytest-mock==2.0.0


### PR DESCRIPTION
Update pytest and plugins to most recent version for testing extra.

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  [X] Update pytest to 6.0.1
   -  [X] Update pytest-sugar to 0.9.4
   -  [X] Update pytest-mock to 3.2.0 for python 3 only!

### optionals

- [X] I have added entry in the `CHANGELOG.md`
