### PR TITLE
support named callback args not wrapped in a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,13 @@ All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [UNRELEASED]
-### Changed
-- [#1368](https://github.com/plotly/dash/pull/1368) Updated pytest to v6.0.1. To avoid deprecation warnings, this also updated pytest-sugar to 0.9.4 and pytest-mock to 3.2.0. The pytest-mock update only effects python >= 3.0. Pytest-mock remains pinned at 2.0.0 for python == 2.7.
-
 ### Added
 - [#1355](https://github.com/plotly/dash/pull/1355) Removed redundant log message and consolidated logger initialization. You can now control the log level - for example suppress informational messages from Dash with `app.logger.setLevel(logging.WARNING)`.
 
 ### Changed
-- [#1180](https://github.com/plotly/dash/pull/1180) `Input`, `Output`, and `State` in callback definitions don't need to be in lists. You still need to provide `Output` items first, then `Input` items, then `State`, and the list form is still supported. In particular, if you want to return a single output item wrapped in a length-1 list, you should still wrap the `Output` in a list. This can be useful for procedurally-generated callbacks.
+- [#1180](https://github.com/plotly/dash/pull/1180) and [#1375](https://github.com/plotly/dash/pull/1375) `Input`, `Output`, and `State` in callback definitions don't need to be in lists. You still need to provide `Output` items first, then `Input` items, then `State`, and the list form is still supported. In particular, if you want to return a single output item wrapped in a length-1 list, you should still wrap the `Output` in a list. This can be useful for procedurally-generated callbacks.
+- [#1368](https://github.com/plotly/dash/pull/1368) Updated pytest to v6.0.1. To avoid deprecation warnings, this also updated pytest-sugar to 0.9.4 and pytest-mock to 3.2.0. The pytest-mock update only effects python >= 3.0. Pytest-mock remains pinned at 2.0.0 for python == 2.7.
+
 
 ## [1.14.0] - 2020-07-27
 ### Added

--- a/dash/dependencies.py
+++ b/dash/dependencies.py
@@ -140,7 +140,13 @@ class ClientsideFunction:  # pylint: disable=too-few-public-methods
 def extract_callback_args(args, kwargs, name, type_):
     """Extract arguments for callback from a name and type"""
     parameters = kwargs.get(name, [])
-    if not parameters:
+    if parameters:
+        if not isinstance(parameters, (list, tuple)):
+            # accept a single item, not wrapped in a list, for any of the
+            # categories as a named arg (even though previously only output
+            # could be given unwrapped)
+            return [parameters]
+    else:
         while args and isinstance(args[0], type_):
             parameters.append(args.pop(0))
     return parameters
@@ -163,6 +169,9 @@ def handle_callback_args(args, kwargs):
     if len(outputs) == 1:
         out0 = kwargs.get("output", args[0] if args else None)
         if not isinstance(out0, (list, tuple)):
+            # unless it was explicitly provided as a list, a single output
+            # sholuld be unwrapped. That ensures the return value of the
+            # callback is also not expected to be wrapped in a list.
             outputs = outputs[0]
 
     inputs = extract_callback_args(flat_args, kwargs, "inputs", Input)


### PR DESCRIPTION
Fixes #1366 
I opted to allow any of the callback args to be provided as a list or not, rather than a narrower fix of just the `output=Output(...)` regression. My rationale is it's unambiguous what the user means, so there's no harm accepting it.

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
- [x] I have added entry in the `CHANGELOG.md`
