### PR TITLE
Fix typo in julia components generator

### DIFF
--- a/dash/development/_jl_components_generation.py
+++ b/dash/development/_jl_components_generation.py
@@ -82,7 +82,7 @@ uuid = "{package_uuid}"
 [deps]
 {base_package} = "{dash_uuid}"
 
-[compact]
+[compat]
 julia = "1.2"
 {base_package} = ">=0.1"
 """


### PR DESCRIPTION
Fix typo `compact` -> `compat` in generated `Project.toml`