### PR TITLE
Fix DashBase compat borders in Julia components generator

### DIFF
--- a/dash/development/_jl_components_generation.py
+++ b/dash/development/_jl_components_generation.py
@@ -84,7 +84,7 @@ uuid = "{package_uuid}"
 
 [compat]
 julia = "1.2"
-{base_package} = ">=0.1"
+{base_package} = "0.1"
 """
 
 jl_component_include_string = 'include("{name}.jl")'


### PR DESCRIPTION
Package dependencies in Julia must have an upper bound on the compatible version. Despite the fact that DashBase is an internal package, the guys from the pkg-registration asked to fix this in the next versions of the core packages for Julia