### PR TITLE
CI / flask-compress `1.6.0`

### DIFF
--- a/requires-install.txt
+++ b/requires-install.txt
@@ -1,5 +1,5 @@
 Flask>=1.0.2
-flask-compress
+flask-compress==1.5.0
 plotly
 dash_renderer==1.8.2
 dash-core-components==1.12.1


### PR DESCRIPTION
`flask-compress` was updated to 1.6.0 yesterday and is breaking, amongst other things, `dash-table` builds. This is meant as (a) a stopgag while we figure out why this is problematic, (b) provide version locking in future versions of Dash, as this apparently has an impact.