### PR TITLE
Issue 1424 - Latest flask-compress (1.6.0) breaks Dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+### Fixed
+
+
 ## [1.16.2] - 2020-09-25
 ### Fixed
 - [#1415](https://github.com/plotly/dash/pull/1415) Fix a regression with some layouts callbacks involving dcc.Tabs, not yet loaded dash_table.DataTable and dcc.Graph to not be called

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Unreleased
 ### Fixed
-
+- [#1426](https://github.com/plotly/dash/pull/1426) Fix a regression caused by `flask-compress==1.6.0` causing performance degradation on server requests
 
 ## [1.16.2] - 2020-09-25
 ### Fixed

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -280,6 +280,11 @@ class Dash(object):
         elif isinstance(server, bool):
             name = name if name else "__main__"
             self.server = flask.Flask(name) if server else None
+            if self.server is not None:
+                # flask-compress==1.6.0 changed default to ['br', 'gzip']
+                # and non-overridable default compression with Brotli is
+                # causing performance issues
+                self.server.config["COMPRESS_ALGORITHM"] = ["gzip"]
         else:
             raise ValueError("server must be a Flask app or a boolean")
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 
+
 import os
 import sys
 import collections
@@ -20,6 +21,7 @@ from future.moves.urllib.parse import urlparse
 import flask
 from flask_compress import Compress
 from werkzeug.debug.tbtools import get_current_traceback
+from pkg_resources import get_distribution, parse_version
 
 import plotly
 import dash_renderer
@@ -48,6 +50,8 @@ from ._utils import (
 )
 from . import _validate
 from . import _watch
+
+flask_compress_version = parse_version(get_distribution("flask-compress").version)
 
 # Add explicit mapping for map files
 mimetypes.add_type("application/json", ".map", True)
@@ -280,7 +284,9 @@ class Dash(object):
         elif isinstance(server, bool):
             name = name if name else "__main__"
             self.server = flask.Flask(name) if server else None
-            if self.server is not None:
+            if self.server is not None and flask_compress_version >= parse_version(
+                "1.6.0"
+            ):
                 # flask-compress==1.6.0 changed default to ['br', 'gzip']
                 # and non-overridable default compression with Brotli is
                 # causing performance issues

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -284,15 +284,18 @@ class Dash(object):
         elif isinstance(server, bool):
             name = name if name else "__main__"
             self.server = flask.Flask(name) if server else None
-            if self.server is not None and _flask_compress_version >= parse_version(
-                "1.6.0"
-            ):
-                # flask-compress==1.6.0 changed default to ['br', 'gzip']
-                # and non-overridable default compression with Brotli is
-                # causing performance issues
-                self.server.config["COMPRESS_ALGORITHM"] = ["gzip"]
         else:
             raise ValueError("server must be a Flask app or a boolean")
+
+        if (
+            self.server is not None
+            and not hasattr(self.server.config, "COMPRESS_ALGORITHM")
+            and _flask_compress_version >= parse_version("1.6.0")
+        ):
+            # flask-compress==1.6.0 changed default to ['br', 'gzip']
+            # and non-overridable default compression with Brotli is
+            # causing performance issues
+            self.server.config["COMPRESS_ALGORITHM"] = ["gzip"]
 
         base_prefix, routes_prefix, requests_prefix = pathname_configs(
             url_base_pathname, routes_pathname_prefix, requests_pathname_prefix

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -51,7 +51,7 @@ from ._utils import (
 from . import _validate
 from . import _watch
 
-flask_compress_version = parse_version(get_distribution("flask-compress").version)
+_flask_compress_version = parse_version(get_distribution("flask-compress").version)
 
 # Add explicit mapping for map files
 mimetypes.add_type("application/json", ".map", True)
@@ -284,7 +284,7 @@ class Dash(object):
         elif isinstance(server, bool):
             name = name if name else "__main__"
             self.server = flask.Flask(name) if server else None
-            if self.server is not None and flask_compress_version >= parse_version(
+            if self.server is not None and _flask_compress_version >= parse_version(
                 "1.6.0"
             ):
                 # flask-compress==1.6.0 changed default to ['br', 'gzip']

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-
 import os
 import sys
 import collections

--- a/requires-install.txt
+++ b/requires-install.txt
@@ -1,5 +1,5 @@
 Flask>=1.0.2
-flask-compress==1.5.0
+flask-compress
 plotly
 dash_renderer==1.8.2
 dash-core-components==1.12.1


### PR DESCRIPTION
Fixes #1424 

Proposes to override the default `COMPRESSION_ALGORITHM` to `['gzip']` so as to avoid the costly, and currently non-configurable, Brotli compression.