### PR TITLE
julia non-core components: require Dash 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED]
+### Fixed
+- [#1434](https://github.com/plotly/dash/pull/1434) Fix [#1432](https://github.com/plotly/dash/issues/1432) for Julia to import non-core component packages without possible errors.
+
 ## [1.16.3] - 2020-10-07
 ### Fixed
 - [#1426](https://github.com/plotly/dash/pull/1426) Fix a regression caused by `flask-compress==1.6.0` causing performance degradation on server requests

--- a/dash/development/_jl_components_generation.py
+++ b/dash/development/_jl_components_generation.py
@@ -84,8 +84,13 @@ uuid = "{package_uuid}"
 
 [compat]
 julia = "1.2"
-{base_package} = "0.1"
+{base_package} = "{base_version}"
 """
+
+jl_base_version = {
+    "Dash": "0.1.3",
+    "DashBase": "0.1",
+}
 
 jl_component_include_string = 'include("{name}.jl")'
 
@@ -417,12 +422,15 @@ def generate_toml_file(project_shortname, pkg_data):
         'authors = ["{}"]\n'.format(package_author) if package_author else ""
     )
 
+    base_package = base_package_name(project_shortname)
+
     toml_string = jl_projecttoml_string.format(
         package_name=package_name,
         package_uuid=package_uuid,
         version=project_ver,
         authors=authors_string,
-        base_package=base_package_name(project_shortname),
+        base_package=base_package,
+        base_version=jl_base_version[base_package],
         dash_uuid=base_package_uid(project_shortname),
     )
     file_path = "Project.toml"


### PR DESCRIPTION
Closes #1432 (to require https://github.com/plotly/Dash.jl/pull/68)

- [x] I have added entry in the `CHANGELOG.md`

@rpkyle can you test this with https://github.com/facultyai/dash-bootstrap-components/pull/464?