### PR TITLE
Wait for proper non-stale element reference in WebDriverWait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [UNRELEASED]
 ### Fixed
 - [#1434](https://github.com/plotly/dash/pull/1434) Fix [#1432](https://github.com/plotly/dash/issues/1432) for Julia to import non-core component packages without possible errors.
+- [#1447](https://github.com/plotly/dash/pull/1447) Fix [#1164](https://github.com/plotly/dash/issues/1164). Commands like `dash_duo.wait_for_element(some_search_pattern, timeout=some_timeout)` now waits until a _non-stale_ reference exists, and (still) raises `TimeoutException` if not satisfied within the timeout. Previously, `wait_for_element` could occasionally fail with `StaleElementReferenceException`.
 
 ## [1.16.3] - 2020-10-07
 ### Fixed


### PR DESCRIPTION
Resolves #1164.

My experience is that the stale reference appears more frequently in multi-page apps using `dcc.Location` / `dcc.Link`, compared with `dcc.Tabs`. When it happens, it is difficult to debug, as it happens a bit by random (even in CI context, with same initial setup, multiple test runs on a Dash app can sometimes go fine, sometimes fail with `StaleElementReferenceException`).

This PR ensures that the `WebDriverWait` waits until a proper non-stale reference exists to the element, inspired by link to StackOverflow post provided in #1164. By [default `selenium.webdriver.support.wait.WebDriverWait` only ignores `NoSuchElementException`](https://selenium-python.readthedocs.io/api.html#module-selenium.webdriver.support.wait).

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  [x] Add `StaleElementReferenceException` to list of ignored selenium errors while waiting on element.
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`