### PR TITLE
Update pinned dependencies in order to use Dash on Py39

### DIFF
--- a/requires-testing.txt
+++ b/requires-testing.txt
@@ -3,7 +3,7 @@ pytest==4.6.9;python_version=="2.7"
 pytest-sugar==0.9.4
 pytest-mock==3.2.0;python_version>="3.0"
 pytest-mock==2.0.0;python_version=="2.7"
-lxml==4.5.0
+lxml==4.6.1
 selenium==3.141.0
 percy==2.0.2
 cryptography==3.0


### PR DESCRIPTION
Updated pinned dependency `lxml` in order to use Dash on Python 3.9 (`lxml>=4.5.2` has pre-compiled wheels built for Python 3.9).

---

Has it been considered earlier to remove pinning of test dependencies? I guess the reason originally was to try to achieve reproducible runs, but since the ordinary non-testing dependencies (as well as indirect dependencies) are not pinned this is not the case even with pinned direct test dependencies. And [`pip install dash[testing]` is also a "public API"](https://dash.plotly.com/testing) similarly to `pip install dash`. 

Projects using `dash[testing]` together with their own test dependencies might [face increased version conflicts with `pip>=20.3` scheduled to be released this month](https://pip.pypa.io/en/latest/user_guide/#changes-to-the-pip-dependency-resolver-in-20-2-2020).

One way of quickly picking up new releases of ordinary + test dependencies breaking the project is to e.g. do [scheduled CI runs](https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#schedule). This could also be done in combination with e.g. `testdependency~=x.y` if you want to only allow minor+patch version to update and not major versions (as a step towards loosening up test dependency pinning).
