### PR TITLE
dedent error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [UNRELEASED]
 ### Fixed
 - [#1493](https://github.com/plotly/dash/pull/1493) Fix [#1143](https://github.com/plotly/dash/issues/1143), a bug where having a file with one of several common names (test.py, code.py, org.py, etc) that imports a dash component package would make `import dash` fail with a cryptic error message asking whether you have a file named "dash.py"
+- [#1500](https://github.com/plotly/dash/1499) Dedented error messages.
 
 ## [1.18.1] - 2020-12-09
 

--- a/dash/dash-renderer/.eslintignore
+++ b/dash/dash-renderer/.eslintignore
@@ -1,0 +1,16 @@
+build/
+dist/
+lib/
+node_modules/
+.npm
+vv/
+venv/
+*.pyc
+*.egg-info
+*.log
+.DS_Store
+dist
+*egg-info*
+
+dash_renderer/**/*.js
+tests/test_clientside/

--- a/dash/dash-renderer/.eslintrc.json
+++ b/dash/dash-renderer/.eslintrc.json
@@ -1,0 +1,150 @@
+{
+    "extends": ["eslint:recommended", "prettier"],
+    "settings": {
+      "react": {
+        "createClass": "createReactClass", // Regex for Component Factory to use,
+                                           // default to "createReactClass"
+        "pragma": "React",  // Pragma to use, default to "React"
+        "version": "detect" // React version. "detect" automatically picks the version you have installed.
+                             // You can also use `16.0`, `16.3`, etc, if you want to override the detected value.
+                             // default to latest and warns if missing
+                             // It will default to "detect" in the future
+      },
+      "propWrapperFunctions": [
+          // The names of any function used to wrap propTypes, e.g. `forbidExtraProps`. If this isn't set, any propTypes wrapped in a function will be skipped.
+          "forbidExtraProps",
+          {"property": "freeze", "object": "Object"},
+          {"property": "myFavoriteWrapper"}
+      ],
+      "linkComponents": [
+        // Components used as alternatives to <a> for linking, eg. <Link to={ url } />
+        "Hyperlink",
+        {"name": "Link", "linkAttribute": "to"}
+      ]
+    },
+    "parser": "babel-eslint",
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module",
+      "ecmaFeatures": {
+        "arrowFunctions": true,
+        "blockBindings": true,
+        "classes": true,
+        "defaultParams": true,
+        "destructuring": true,
+        "forOf": true,
+        "generators": true,
+        "modules": true,
+        "templateStrings": true,
+        "jsx": true
+      }
+    },
+    "env": {
+      "browser": true,
+      "es6": true,
+      "jasmine": true,
+      "jest": true,
+      "node": true
+    },
+    "globals": {
+      "jest": true
+    },
+    "plugins": [
+      "react",
+      "import"
+    ],
+    "rules": {
+      "accessor-pairs": ["error"],
+      "block-scoped-var": ["error"],
+      "consistent-return": ["error"],
+      "curly": ["error", "all"],
+      "default-case": ["error"],
+      "dot-location": ["off"],
+      "dot-notation": ["error"],
+      "eqeqeq": ["error"],
+      "guard-for-in": ["off"],
+      "import/export": "error",
+      "import/named": ["off"],
+      "import/namespace": ["off"],
+      "import/no-duplicates": ["error"],
+      "import/no-named-as-default": ["error"],
+      "import/no-unresolved": ["off"],
+      "new-cap": ["error", {
+        "capIsNewExceptions": ["Radium"],
+        "capIsNewExceptionPattern": "Immutable\\.*"
+      }],
+      "no-alert": ["off"],
+      "no-caller": ["error"],
+      "no-case-declarations": ["error"],
+      "no-console": ["error"],
+      "no-div-regex": ["error"],
+      "no-dupe-keys": ["error"],
+      "no-else-return": ["error"],
+      "no-empty-pattern": ["error"],
+      "no-eq-null": ["error"],
+      "no-eval": ["error"],
+      "no-extend-native": ["error"],
+      "no-extra-bind": ["error"],
+      "no-extra-boolean-cast": ["error"],
+      "no-inline-comments": ["error"],
+      "no-implicit-coercion": ["error"],
+      "no-implied-eval": ["error"],
+      "no-inner-declarations": ["off"],
+      "no-invalid-this": ["error"],
+      "no-iterator": ["error"],
+      "no-labels": ["error"],
+      "no-lone-blocks": ["error"],
+      "no-loop-func": ["error"],
+      "no-multi-str": ["error"],
+      "no-native-reassign": ["error"],
+      "no-new": ["error"],
+      "no-new-func": ["error"],
+      "no-new-wrappers": ["error"],
+      "no-param-reassign": ["error"],
+      "no-process-env": ["warn"],
+      "no-prototype-builtins": ["off"],
+      "no-proto": ["error"],
+      "no-redeclare": ["error"],
+      "no-return-assign": ["error"],
+      "no-script-url": ["error"],
+      "no-self-compare": ["error"],
+      "no-sequences": ["error"],
+      "no-shadow": ["off"],
+      "no-throw-literal": ["error"],
+      "no-unused-expressions": ["error"],
+      "no-use-before-define": ["error", "nofunc"],
+      "no-useless-call": ["error"],
+      "no-useless-concat": ["error"],
+      "no-with": ["error"],
+      "prefer-const": ["error"],
+      "radix": ["error"],
+      "react/jsx-no-duplicate-props": ["error"],
+      "react/jsx-no-undef": ["error"],
+      "react/jsx-uses-react": ["error"],
+      "react/jsx-uses-vars": ["error"],
+      "react/no-did-update-set-state": ["error"],
+      "react/no-direct-mutation-state": ["error"],
+      "react/no-is-mounted": ["error"],
+      "react/no-unknown-property": ["error"],
+      "react/prefer-es6-class": ["error", "always"],
+      "react/prop-types": "error",
+      "valid-jsdoc": ["error"],
+      "yoda": ["error"],
+      "spaced-comment": ["error", "always", {
+        "block": {
+          "exceptions": ["*"]
+        }
+      }],
+      "no-unused-vars": ["error", {
+          "args": "after-used",
+          "argsIgnorePattern": "^_",
+          "caughtErrorsIgnorePattern": "^e$"
+      }],
+      "no-magic-numbers": ["error", {
+        "ignoreArrayIndexes": true,
+        "ignore": [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 100, 10, 16, 0.5, 25, 200, 500]
+      }],
+      "no-underscore-dangle": ["off"],
+      "no-useless-escape": ["off"]
+    }
+  }

--- a/dash/dash-renderer/.npmignore
+++ b/dash/dash-renderer/.npmignore
@@ -1,0 +1,8 @@
+node_modules/
+.npm
+.git/
+vv/
+venv/
+*.pyc
+*.log
+.DS_Store

--- a/dash/dash-renderer/.prettierrc
+++ b/dash/dash-renderer/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "tabWidth": 4,
+    "singleQuote": true,
+    "bracketSpacing": false,
+    "trailingComma": "es5"
+}

--- a/dash/dash-renderer/MANIFEST.in
+++ b/dash/dash-renderer/MANIFEST.in
@@ -1,0 +1,4 @@
+include package.json
+include digest.json
+include dash_renderer/*.js
+include dash_renderer/*.map

--- a/dash/dash-renderer/babel.config.js
+++ b/dash/dash-renderer/babel.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+    presets: [
+        '@babel/preset-env',
+        '@babel/preset-react'
+    ],
+    env: {
+        test: {
+            plugins: [
+                '@babel/plugin-transform-modules-commonjs'
+            ]
+        }
+    }
+};

--- a/dash/dash-renderer/config/eslint/eslintrc-node.json
+++ b/dash/dash-renderer/config/eslint/eslintrc-node.json
@@ -1,0 +1,27 @@
+{
+    "env": {
+        "node": true,
+        "browser": true
+    },
+    "extends": [
+        "eslint:recommended",
+        "plugin:import/errors",
+        "plugin:import/warnings",
+        "plugin:react/recommended"
+    ],
+    "plugins": [
+        "import", "react"
+    ],
+    "parserOptions": {
+        "ecmaVersion": "2015",
+        "sourceType": "module",
+        "ecmaFeatures": {
+            "jsx": true,
+            "experimentalObjectRestSpread": true
+        }
+    },
+    "rules": {
+        "import/no-commonjs": 0,
+        "import/no-nodejs-modules": 0
+    }
+}

--- a/dash/dash-renderer/index.html
+++ b/dash/dash-renderer/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+    </head>
+    <body>
+        <div id="react-entry-point"></div>
+    </body>
+
+    <script>
+
+    </script>
+
+    <script src="build/bundle.js"></script>
+</html>

--- a/dash/dash-renderer/init.template
+++ b/dash/dash-renderer/init.template
@@ -1,0 +1,55 @@
+import sys
+
+__file__
+__version__ = "$version"
+
+_js_dist_dependencies = [
+    {
+        "external_url": {
+            "prod": [
+                "https://unpkg.com/@babel/polyfill@$polyfill/dist/polyfill.min.js",
+                "https://unpkg.com/react@$react/umd/react.production.min.js",
+                "https://unpkg.com/react-dom@$reactdom/umd/react-dom.production.min.js",
+                "https://unpkg.com/prop-types@$proptypes/prop-types.min.js",
+            ],
+            "dev": [
+                "https://unpkg.com/@babel/polyfill@$polyfill/dist/polyfill.min.js",
+                "https://unpkg.com/react@$react/umd/react.development.js",
+                "https://unpkg.com/react-dom@$reactdom/umd/react-dom.development.js",
+                "https://unpkg.com/prop-types@$proptypes/prop-types.js",
+            ],
+        },
+        "relative_package_path": {
+            "prod": [
+                "polyfill@$polyfill.min.js",
+                "react@$react.min.js",
+                "react-dom@$reactdom.min.js",
+                "prop-types@$proptypes.min.js",
+            ],
+            "dev": [
+                "polyfill@$polyfill.min.js",
+                "react@$react.js",
+                "react-dom@$reactdom.js",
+                "prop-types@$proptypes.js",
+            ],
+        },
+        "namespace": "dash_renderer",
+    }
+]
+
+
+_js_dist = [
+    {
+        "relative_package_path": "{}.min.js".format(__name__),
+        "dev_package_path": "{}.dev.js".format(__name__),
+        "external_url": "https://unpkg.com/dash-renderer@$version"
+        "/dash_renderer/dash_renderer.min.js",
+        "namespace": "dash_renderer",
+    },
+    {
+        "relative_package_path": "{}.min.js.map".format(__name__),
+        "dev_package_path": "{}.dev.js.map".format(__name__),
+        "namespace": "dash_renderer",
+        "dynamic": True,
+    },
+]

--- a/dash/dash-renderer/jest.config.js
+++ b/dash/dash-renderer/jest.config.js
@@ -1,0 +1,183 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  // All imported modules in your tests should be mocked automatically
+  // automock: false,
+
+  // Stop running tests after the first failure
+  // bail: false,
+
+  // Respect "browser" field in package.json when resolving modules
+  // browser: false,
+
+  // The directory where Jest should store its cached dependency information
+  // cacheDirectory: "/var/folders/8m/wrr89jfx5kg5xhp7q2127bcc0000gn/T/jest_dx",
+
+  // Automatically clear mock calls and instances between every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  // collectCoverage: false,
+
+  // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // collectCoverageFrom: null,
+
+  // The directory where Jest should output its coverage files
+  coverageDirectory: "coverage",
+
+  // An array of regexp pattern strings used to skip coverage collection
+  // coveragePathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  // coverageReporters: [
+  //   "json",
+  //   "text",
+  //   "lcov",
+  //   "clover"
+  // ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  // coverageThreshold: null,
+
+  // Make calling deprecated APIs throw helpful error messages
+  // errorOnDeprecated: false,
+
+  // Force coverage collection from ignored files usin a array of glob patterns
+  // forceCoverageMatch: [],
+
+  // A path to a module which exports an async function that is triggered once before all test suites
+  // globalSetup: null,
+
+  // A path to a module which exports an async function that is triggered once after all test suites
+  // globalTeardown: null,
+
+  // A set of global variables that need to be available in all test environments
+  // globals: {},
+
+  // An array of directory names to be searched recursively up from the requiring module's location
+  // moduleDirectories: [
+  //   "node_modules"
+  // ],
+
+  // An array of file extensions your modules use
+  // moduleFileExtensions: [
+  //   "js",
+  //   "json",
+  //   "jsx",
+  //   "node"
+  // ],
+
+  // A map from regular expressions to module names that allow to stub out resources with a single module
+  moduleNameMapper: {
+    "\\.(css|less)$": "identity-obj-proxy"
+  },
+
+  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
+  // modulePathIgnorePatterns: [],
+
+  // Activates notifications for test results
+  // notify: false,
+
+  // An enum that specifies notification mode. Requires { notify: true }
+  // notifyMode: "always",
+
+  // A preset that is used as a base for Jest's configuration
+  // preset: null,
+
+  // Run tests from one or more projects
+  // projects: null,
+
+  // Use this configuration option to add custom reporters to Jest
+  // reporters: undefined,
+
+  // Automatically reset mock state between every test
+  // resetMocks: false,
+
+  // Reset the module registry before running each individual test
+  // resetModules: false,
+
+  // A path to a custom resolver
+  // resolver: null,
+
+  // Automatically restore mock state between every test
+  // restoreMocks: false,
+
+  // The root directory that Jest should scan for tests and modules within
+  // rootDir: null,
+
+  // A list of paths to directories that Jest should use to search for files in
+  roots: [
+    "<rootDir>/tests"
+  ],
+
+  // Allows you to use a custom runner instead of Jest's default test runner
+  // runner: "jest-runner",
+
+  // The paths to modules that run some code to configure or set up the testing environment before each test
+  setupFiles: [
+    '<rootDir>/jest.init.js'
+  ],
+
+  // The path to a module that runs some code to configure or set up the testing framework before each test
+  // setupTestFrameworkScriptFile: null,
+
+  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
+  // snapshotSerializers: [],
+
+  // The test environment that will be used for testing
+  testEnvironment: "jsdom",
+
+  // Options that will be passed to the testEnvironment
+  // testEnvironmentOptions: {},
+
+  // Adds a location field to test results
+  // testLocationInResults: false,
+
+  // The glob patterns Jest uses to detect test files
+  testMatch: [
+    "**/?(*.)+(spec|test).js?(x)"
+  ],
+
+  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
+  // testPathIgnorePatterns: [
+  //   "/node_modules/"
+  // ],
+
+  // The regexp pattern Jest uses to detect test files
+  // testRegex: "",
+
+  // This option allows the use of a custom results processor
+  // testResultsProcessor: null,
+
+  // This option allows use of a custom test runner
+  // testRunner: "jasmine2",
+
+  // This option sets the URL for the jsdom environment. It is reflected in properties such as location.href
+  // testURL: "http://localhost",
+
+  // Setting this value to "fake" allows the use of fake timers for functions such as "setTimeout"
+  // timers: "real",
+
+  // A map from regular expressions to paths to transformers
+  // transform: null,
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  transformIgnorePatterns: [
+    "/node_modules/(?!@plotly).+\\.js"
+  ],
+
+  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // unmockedModulePathPatterns: undefined,
+
+  // Indicates whether each individual test should be reported during the run
+  // verbose: null,
+
+  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
+  // watchPathIgnorePatterns: [],
+
+  // Whether to use watchman for file crawling
+  // watchman: true,
+};

--- a/dash/dash-renderer/jest.init.js
+++ b/dash/dash-renderer/jest.init.js
@@ -1,0 +1,1 @@
+import '@babel/polyfill';


### PR DESCRIPTION
Our error messages are printed in the terminal & in the dash dev tools console. In both cases, we treat white space literally in order to display nice tracebacks. However, some of our error messages are indented. This PR dedents these error messages.

Example of behavior: 

![image](https://user-images.githubusercontent.com/1280389/102123670-2d4a2000-3e15-11eb-8105-d60e9bfbbe4b.png)

### optionals

- [x] I have added entry in the `CHANGELOG.md`
