### PR TITLE
dedent error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [UNRELEASED]
 ### Fixed
 - [#1493](https://github.com/plotly/dash/pull/1493) Fix [#1143](https://github.com/plotly/dash/issues/1143), a bug where having a file with one of several common names (test.py, code.py, org.py, etc) that imports a dash component package would make `import dash` fail with a cryptic error message asking whether you have a file named "dash.py"
-- [#1501](https://github.com/plotly/dash/1499) Dedented error messages.
+- [#1501](https://github.com/plotly/dash/pull/1501) Dedented error messages.
 
 
 ## [1.18.1] - 2020-12-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [UNRELEASED]
 ### Fixed
 - [#1493](https://github.com/plotly/dash/pull/1493) Fix [#1143](https://github.com/plotly/dash/issues/1143), a bug where having a file with one of several common names (test.py, code.py, org.py, etc) that imports a dash component package would make `import dash` fail with a cryptic error message asking whether you have a file named "dash.py"
+- [#1501](https://github.com/plotly/dash/1499) Dedented error messages.
+
 
 ## [1.18.1] - 2020-12-09
 


### PR DESCRIPTION
Our error messages are printed in the terminal & in the dash dev tools console. In both cases, we treat white space literally in order to display nice tracebacks. However, some of our error messages are indented. This PR dedents these error messages.

Example of behavior: 

![image](https://user-images.githubusercontent.com/1280389/102123670-2d4a2000-3e15-11eb-8105-d60e9bfbbe4b.png)

### optionals

- [x] I have added entry in the `CHANGELOG.md`
