### PR TITLE
Updating CI Python images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ jobs:
 
   artifacts:
     docker:
-      - image: circleci/python:3.7.6-stretch-node-browsers
+      - image: circleci/python:3.7.9-stretch-node-browsers
         auth:
           username: dashautomation
           password: $DASH_PAT_DOCKERHUB
@@ -33,7 +33,7 @@ jobs:
   lint-unit-37: &lint-unit
     working_directory: ~/dash
     docker:
-      - image: circleci/python:3.7.6-stretch-node-browsers
+      - image: circleci/python:3.7.9-stretch-node-browsers
         auth:
           username: dashautomation
           password: $DASH_PAT_DOCKERHUB
@@ -73,7 +73,7 @@ jobs:
   lint-unit-36:
       <<: *lint-unit
       docker:
-        - image: circleci/python:3.6.9-stretch-node-browsers
+        - image: circleci/python:3.6.12-stretch-node-browsers
           auth:
             username: dashautomation
             password: $DASH_PAT_DOCKERHUB
@@ -95,7 +95,7 @@ jobs:
   build-core-37: &build-core
     working_directory: ~/dash
     docker:
-      - image: circleci/python:3.7.6-stretch-node-browsers
+      - image: circleci/python:3.7.9-stretch-node-browsers
         auth:
           username: dashautomation
           password: $DASH_PAT_DOCKERHUB
@@ -133,7 +133,7 @@ jobs:
   build-core-36:
       <<: *build-core
       docker:
-        - image: circleci/python:3.6.9-stretch-node-browsers
+        - image: circleci/python:3.6.12-stretch-node-browsers
           auth:
             username: dashautomation
             password: $DASH_PAT_DOCKERHUB
@@ -153,7 +153,7 @@ jobs:
   build-misc-37: &build-misc
     working_directory: ~/dash
     docker:
-      - image: circleci/python:3.7.6-stretch-node-browsers
+      - image: circleci/python:3.7.9-stretch-node-browsers
         auth:
           username: dashautomation
           password: $DASH_PAT_DOCKERHUB
@@ -192,7 +192,7 @@ jobs:
   build-misc-36:
       <<: *build-misc
       docker:
-        - image: circleci/python:3.6.9-stretch-node-browsers
+        - image: circleci/python:3.6.12-stretch-node-browsers
           auth:
             username: dashautomation
             password: $DASH_PAT_DOCKERHUB
@@ -341,7 +341,7 @@ jobs:
   test-37: &test
     working_directory: ~/dash
     docker:
-      - image: circleci/python:3.7.6-stretch-node-browsers
+      - image: circleci/python:3.7.9-stretch-node-browsers
         auth:
           username: dashautomation
           password: $DASH_PAT_DOCKERHUB
@@ -386,7 +386,7 @@ jobs:
   test-36:
       <<: *test
       docker:
-        - image: circleci/python:3.6.9-stretch-node-browsers
+        - image: circleci/python:3.6.12-stretch-node-browsers
           auth:
             username: dashautomation
             password: $DASH_PAT_DOCKERHUB

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -431,6 +431,7 @@ class Browser(DashPageMixin):
 
         capabilities = DesiredCapabilities.CHROME
         capabilities["loggingPrefs"] = {"browser": "SEVERE"}
+        capabilities["goog:loggingPrefs"] = {"browser": "SEVERE"}
 
         if "DASH_TEST_CHROMEPATH" in os.environ:
             options.binary_location = os.environ["DASH_TEST_CHROMEPATH"]

--- a/tests/integration/renderer/test_iframe.py
+++ b/tests/integration/renderer/test_iframe.py
@@ -57,4 +57,4 @@ def test_rdif001_sandbox_allow_scripts(dash_duo):
     dash_duo.wait_for_element_by_id("btn").click()
     dash_duo.wait_for_element("#output-0").text == "0=1"
 
-    assert len(dash_duo.get_logs()) != 0
+    assert dash_duo.get_logs() == []


### PR DESCRIPTION
We've previously had issues moving to newer versions of these CI images, at least part of the issue seems to be that Chromedriver 75 changed a capabilities flag for logging.

https://chromedriver.chromium.org/downloads
```
Renamed capability loggingPrefs to goog:loggingPrefs, as required by W3C standard
```

This PR proposes to add the flag (while keeping the old one for non-core projects still using older CI images

---

Also changes expected behavior for `rdif001` as as of Chrome 87 running this test only results in warnings, now correctly not being picked up by `get_logs()`. As of Chrome 89 this behavior will change and at least 1 error will be present. This will require the test to be updated again and to have a different behavior in Python 2.7 vs. 3.x unless we manually update the version of Chrome used in that test.
