### PR TITLE
Add an 'x' button to close the error messages box #1403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [UNRELEASED]
+### Added
+- [#1508](https://github.com/plotly/dash/pull/1508) Fix [#1403](https://github.com/plotly/dash/issues/1403): Adds an x button
+to close the error messages box.
+
 ### Changed
 - [#1503](https://github.com/plotly/dash/pull/1506) Fix [#1466](https://github.com/plotly/dash/issues/1466): loosen `dash[testing]` requirements for easier integration in external projects. This PR also bumps many `dash[dev]` requirements.
 

--- a/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
+++ b/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
@@ -6,19 +6,15 @@
     position: absolute;
     right: 0;
     top: 0;
-    color: #ccc;
+    color: #B9C2CE;
     font-size: 20px;
     cursor: pointer;
-<<<<<<< refs/remotes/origin/1403-x-button-to-close-error-box
-    margin-right: 5px
-=======
     margin-right: 10px
->>>>>>> One more css update to align the button  #1403
 }
 
 .dash-fe-error__icon-x:hover
 {
- color:black;
+ color:#a1a9b5;
 }
 
 

--- a/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
+++ b/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
@@ -9,7 +9,11 @@
     color: #ccc;
     font-size: 20px;
     cursor: pointer;
+<<<<<<< refs/remotes/origin/1403-x-button-to-close-error-box
     margin-right: 5px
+=======
+    margin-right: 10px
+>>>>>>> One more css update to align the button  #1403
 }
 
 .dash-fe-error__icon-x:hover

--- a/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
+++ b/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
@@ -9,6 +9,7 @@
     color: #ccc;
     font-size: 20px;
     cursor: pointer;
+    margin-right: 5px
 }
 
 .dash-fe-error__icon-x:hover

--- a/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
+++ b/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
@@ -3,13 +3,17 @@
 }
 
 .dash-fe-error__icon-x {
-    width: 16px;
-    height: 16px;
-    background-color: red;
-    margin-left: 75px;
-    border-radius: 4px;
-    border: 1px solid;
+    position: absolute;
+    right: 0;
+    top: 0;
+    color: #ccc;
+    font-size: 20px;
+    cursor: pointer;
+}
 
+.dash-fe-error__icon-x:hover
+{
+ color:black;
 }
 
 

--- a/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
+++ b/dash-renderer/src/components/error/FrontEnd/FrontEndError.css
@@ -2,6 +2,17 @@
     margin-top: 10px;
 }
 
+.dash-fe-error__icon-x {
+    width: 16px;
+    height: 16px;
+    background-color: red;
+    margin-left: 75px;
+    border-radius: 4px;
+    border: 1px solid;
+
+}
+
+
 .dash-fe-errors {
     min-width: 386px;
     max-width: 650px;

--- a/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
+++ b/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
@@ -36,7 +36,8 @@ class FrontEndErrorContainer extends Component {
                     </div>
                     <div
                         className='dash-fe-error__icon-x'
-                        onClick={() => clickHandler()}>
+                        onClick={() => clickHandler()}
+                    >
                         x
                     </div>
                 </div>

--- a/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
+++ b/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
@@ -1,6 +1,5 @@
 import React, {Component} from 'react';
 import './FrontEndError.css';
-import OffIcon from '../icons/OffIcon.svg';
 import PropTypes from 'prop-types';
 import {FrontEndError} from './FrontEndError.react';
 
@@ -36,13 +35,11 @@ class FrontEndErrorContainer extends Component {
                         ){connected ? null : '\u00a0 🚫 Server Unavailable'}
                     </div>
                     <div
-                        className='dash-error-card__message'
-                        onClick={() => clickHandler()}
-                    >
-                        <OffIcon className='dash-fe-error__icon-x' />
+                        className='dash-fe-error__icon-x'
+                        onClick={() => clickHandler()}>
+                        x
                     </div>
                 </div>
-
                 <div className='dash-error-card__list'>{errorElements}</div>
             </div>
         );

--- a/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
+++ b/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
@@ -1,5 +1,6 @@
 import React, {Component} from 'react';
 import './FrontEndError.css';
+import OffIcon from '../icons/OffIcon.svg';
 import PropTypes from 'prop-types';
 import {FrontEndError} from './FrontEndError.react';
 
@@ -9,9 +10,9 @@ class FrontEndErrorContainer extends Component {
     }
 
     render() {
-        const {errors, connected} = this.props;
+        const {errors, connected, errorsOpened, clickHandler} = this.props;
         const errorsLength = errors.length;
-        if (errorsLength === 0) {
+        if (errorsLength === 0 || !errorsOpened) {
             return null;
         }
 
@@ -34,7 +35,14 @@ class FrontEndErrorContainer extends Component {
                         </strong>
                         ){connected ? null : '\u00a0 🚫 Server Unavailable'}
                     </div>
+                    <div
+                        className='dash-error-card__message'
+                        onClick={() => clickHandler()}
+                    >
+                        <OffIcon className='dash-fe-error__icon-x' />
+                    </div>
                 </div>
+
                 <div className='dash-error-card__list'>{errorElements}</div>
             </div>
         );
@@ -42,9 +50,12 @@ class FrontEndErrorContainer extends Component {
 }
 
 FrontEndErrorContainer.propTypes = {
+    id: PropTypes.string,
     errors: PropTypes.array,
     connected: PropTypes.bool,
-    inAlertsTray: PropTypes.any
+    inAlertsTray: PropTypes.any,
+    errorsOpened: PropTypes.any,
+    clickHandler: PropTypes.func
 };
 
 FrontEndErrorContainer.propTypes = {

--- a/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
+++ b/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
@@ -38,7 +38,7 @@ class FrontEndErrorContainer extends Component {
                         className='dash-fe-error__icon-x'
                         onClick={() => clickHandler()}
                     >
-                        x
+                        ×
                     </div>
                 </div>
                 <div className='dash-error-card__list'>{errorElements}</div>

--- a/dash-renderer/src/components/error/GlobalErrorOverlay.css
+++ b/dash-renderer/src/components/error/GlobalErrorOverlay.css
@@ -53,6 +53,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+    position: relative;
 }
 .dash-error-card__message {
     font-size: 14px;

--- a/dash-renderer/src/components/error/GlobalErrorOverlay.react.js
+++ b/dash-renderer/src/components/error/GlobalErrorOverlay.react.js
@@ -11,7 +11,7 @@ export default class GlobalErrorOverlay extends Component {
     }
 
     render() {
-        const {visible, error, errorsOpened} = this.props;
+        const {visible, error, errorsOpened, clickHandler} = this.props;
 
         let frontEndErrors;
         if (errorsOpened) {
@@ -21,6 +21,8 @@ export default class GlobalErrorOverlay extends Component {
                 <FrontEndErrorContainer
                     errors={errors}
                     connected={error.backEndConnected}
+                    errorsOpened={errorsOpened}
+                    clickHandler={clickHandler}
                 />
             );
         }
@@ -41,5 +43,6 @@ GlobalErrorOverlay.propTypes = {
     children: PropTypes.object,
     visible: PropTypes.bool,
     error: PropTypes.object,
-    errorsOpened: PropTypes.any
+    errorsOpened: PropTypes.any,
+    clickHandler: PropTypes.func
 };

--- a/dash-renderer/src/components/error/icons/OffIcon.svg
+++ b/dash-renderer/src/components/error/icons/OffIcon.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 24">
-<path d="M18 2l18 18m0-18l-18 18" stroke-width="6" stroke="#fff"></path>
+<path d="M18 2l18 18m0-18l-18 18" stroke-width="4" stroke="#fff"></path>
 </svg>

--- a/dash-renderer/src/components/error/icons/OffIcon.svg
+++ b/dash-renderer/src/components/error/icons/OffIcon.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 54 24">
-<path d="M18 2l18 18m0-18l-18 18" stroke-width="4" stroke="#fff"></path>
+<path d="M18 2l18 18m0-18l-18 18" stroke-width="6" stroke="#fff"></path>
 </svg>

--- a/dash-renderer/src/components/error/menu/DebugMenu.react.js
+++ b/dash-renderer/src/components/error/menu/DebugMenu.react.js
@@ -147,6 +147,7 @@ class DebugMenu extends Component {
                     error={error}
                     visible={errCount > 0}
                     errorsOpened={errorsOpened}
+                    clickHandler={toggleErrors}
                 >
                     {this.props.children}
                 </GlobalErrorOverlay>


### PR DESCRIPTION
This is a potential solution for https://github.com/plotly/dash/issues/1403
It works in my local environment, but needs better css for the x button