### PR TITLE
Input output callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - [#1508](https://github.com/plotly/dash/pull/1508) Fix [#1403](https://github.com/plotly/dash/issues/1403): Adds an x button
 to close the error messages box.
+- [#1525] (https://github.com/plotly/dash/pull/1525): Add support for callbacks which have overlapping inputs and outputs. Combined with `dash.callback_context` this addresses many use cases which require circular callbacks.
 
 ### Changed
 - [#1503](https://github.com/plotly/dash/pull/1506) Fix [#1466](https://github.com/plotly/dash/issues/1466): loosen `dash[testing]` requirements for easier integration in external projects. This PR also bumps many `dash[dev]` requirements.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - [#1508](https://github.com/plotly/dash/pull/1508) Fix [#1403](https://github.com/plotly/dash/issues/1403): Adds an x button
 to close the error messages box.
-- [#1525] (https://github.com/plotly/dash/pull/1525): Add support for callbacks which have overlapping inputs and outputs. Combined with `dash.callback_context` this addresses many use cases which require circular callbacks.
+- [#1525](https://github.com/plotly/dash/pull/1525) Adds support for callbacks which have overlapping inputs and outputs. Combined with `dash.callback_context` this addresses many use cases which require circular callbacks.
 
 ### Changed
 - [#1503](https://github.com/plotly/dash/pull/1506) Fix [#1466](https://github.com/plotly/dash/issues/1466): loosen `dash[testing]` requirements for easier integration in external projects. This PR also bumps many `dash[dev]` requirements.

--- a/dash-renderer/src/actions/dependencies.js
+++ b/dash-renderer/src/actions/dependencies.js
@@ -363,32 +363,21 @@ function findDuplicateOutputs(outputs, head, dispatchError, outStrs, outObjs) {
     });
 }
 
-function findInOutOverlap(outputs, inputs, head, dispatchError) {
-    outputs.forEach((out, outi) => {
+function checkInOutOverlap(out, inputs) {
         const {id: outId, property: outProp} = out;
-        inputs.forEach((in_, ini) => {
+    return inputs.some(in_ => {
             const {id: inId, property: inProp} = in_;
             if (outProp !== inProp || typeof outId !== typeof inId) {
-                return;
+            return false;
             }
             if (typeof outId === 'string') {
                 if (outId === inId) {
-                    dispatchError('Same `Input` and `Output`', [
-                        head,
-                        `Input ${ini} (${combineIdAndProp(in_)})`,
-                        `matches Output ${outi} (${combineIdAndProp(out)})`
-                    ]);
+                return true;
                 }
             } else if (wildcardOverlap(in_, [out])) {
-                dispatchError('Same `Input` and `Output`', [
-                    head,
-                    `Input ${ini} (${combineIdAndProp(in_)})`,
-                    'can match the same component(s) as',
-                    `Output ${outi} (${combineIdAndProp(out)})`
-                ]);
+            return true;
             }
         });
-    });
 }
 
 function findMismatchedWildcards(outputs, inputs, state, head, dispatchError) {
@@ -748,15 +737,52 @@ export function computeGraphs(dependencies, dispatchError) {
         return idList;
     }
 
+    /* multiGraph is used only for testing circularity
+     * 
+     * Each component+property that is used as an input or output is added as a node
+     * to a directed graph with a dependency from each input to each output. The
+     * function triggerDefaultState in index.js then checks this graph for circularity.
+     * 
+     * In order to allow the same component+property to be both an input and output
+     * of the same callback, a two pass approach is used.
+     * 
+     * In the first pass, the graph is built up normally with the exception that
+     * in cases where an output is also an input to the same callback a special 
+     * "output" node is added and the dependencies target this output node instead.
+     * For example, if `slider.value` is both an input and an output, then the a new
+     * node `slider.value__output` will be added with a dependency from `slide.value`
+     * to `slider.value__output`. Splitting the input and output into separate nodes
+     * removes the circularity.
+     * 
+     * In order to still detect other forms of circularity, it is necessary to do a
+     * second pass and add the new output nodes as a dependency in any *other* callbacks
+     * where the original node was an input. Continuing the example, any other callback
+     * that had `slider.value` as an input dependency also needs to have
+     * `slider.value__output` as a dependency. To make this efficient, all the inputs
+     * and outputs for each callback are stored during the first pass.
+     */
+
+    const outputTag = "__output";
+    const duplicateOutputs = [];
+    const cbIn = [];
+    const cbOut = [];
+
+    function addInputToMulti(inIdProp, outIdProp, firstPass=true) {
+        multiGraph.addNode(inIdProp);
+        multiGraph.addDependency(inIdProp, outIdProp);
+        // only store callback inputs and outputs during the first pass
+        if (firstPass){
+            cbIn[cbIn.length-1].push(inIdProp);
+            cbOut[cbOut.length-1].push(outIdProp);
+        }
+    }
+
     parsedDependencies.forEach(function registerDependency(dependency) {
         const {outputs, inputs} = dependency;
 
-        // multiGraph - just for testing circularity
-
-        function addInputToMulti(inIdProp, outIdProp) {
-            multiGraph.addNode(inIdProp);
-            multiGraph.addDependency(inIdProp, outIdProp);
-        }
+        // new callback, add an empty array for its inputs and outputs
+        cbIn.push([]);
+        cbOut.push([]);
 
         function addOutputToMulti(outIdFinal, outIdProp) {
             multiGraph.addNode(outIdProp);
@@ -790,15 +816,29 @@ export function computeGraphs(dependencies, dispatchError) {
 
         outputs.forEach(outIdProp => {
             const {id: outId, property} = outIdProp;
+            // check if this output is also an input to the same callback
+            const alsoInput = checkInOutOverlap(outIdProp, inputs);
             if (typeof outId === 'object') {
                 const outIdList = makeAllIds(outId, {});
                 outIdList.forEach(id => {
-                    addOutputToMulti(id, combineIdAndProp({id, property}));
+                    let tempOutIdProp = {id, property};
+                    let outIdName = combineIdAndProp(tempOutIdProp);
+                    // if this output is also an input, add `outputTag` to the name
+                    if (alsoInput){
+                        duplicateOutputs.push(tempOutIdProp);
+                        outIdName += outputTag;
+                    }
+                    addOutputToMulti(id, outIdName);
                 });
-
                 addPattern(outputPatterns, outId, property, finalDependency);
             } else {
-                addOutputToMulti({}, combineIdAndProp(outIdProp));
+                let outIdName = combineIdAndProp(outIdProp);
+                // if this output is also an input, add `outputTag` to the name
+                if (alsoInput){
+                    duplicateOutputs.push(outIdProp);
+                    outIdName += outputTag;
+                }
+                addOutputToMulti({}, outIdName);
                 addMap(outputMap, outId, property, finalDependency);
             }
         });
@@ -811,6 +851,25 @@ export function computeGraphs(dependencies, dispatchError) {
                 addMap(inputMap, inId, inProp, finalDependency);
             }
         });
+    });
+
+    // second pass for adding new output nodes as dependencies where needed 
+    duplicateOutputs.forEach(dupeOutIdProp => {
+        let originalName = combineIdAndProp(dupeOutIdProp);
+        let newName = originalName.concat(outputTag);
+        for (var cnt=0; cnt<cbIn.length; cnt++){
+            // check if input to the callback
+            if (cbIn[cnt].some(inName=>(inName==originalName))){
+                /* make sure it's not also an output of the callback
+                 * (this will be the original callback)
+                 */
+                if(!cbOut[cnt].some(outName=>(outName==newName))){
+                    cbOut[cnt].forEach(outName => {
+                        addInputToMulti(newName, outName, false);
+                    });
+                }
+            }
+        }
     });
 
     return finalGraphs;

--- a/dash-renderer/src/actions/dependencies.js
+++ b/dash-renderer/src/actions/dependencies.js
@@ -750,7 +750,7 @@ export function computeGraphs(dependencies, dispatchError) {
      * in cases where an output is also an input to the same callback a special 
      * "output" node is added and the dependencies target this output node instead.
      * For example, if `slider.value` is both an input and an output, then the a new
-     * node `slider.value__output` will be added with a dependency from `slide.value`
+     * node `slider.value__output` will be added with a dependency from `slider.value`
      * to `slider.value__output`. Splitting the input and output into separate nodes
      * removes the circularity.
      * 

--- a/dash-renderer/src/actions/dependencies.js
+++ b/dash-renderer/src/actions/dependencies.js
@@ -239,7 +239,6 @@ function validateDependencies(parsedDependencies, dispatchError) {
         });
 
         findDuplicateOutputs(outputs, head, dispatchError, outStrs, outObjs);
-        findInOutOverlap(outputs, inputs, head, dispatchError);
         findMismatchedWildcards(outputs, inputs, state, head, dispatchError);
     });
 }

--- a/dash-renderer/src/actions/dependencies_ts.ts
+++ b/dash-renderer/src/actions/dependencies_ts.ts
@@ -170,7 +170,7 @@ export const getReadyCallbacks = (
     // Outputs which overlap an input do not count as an outstanding output
     return filter(
         cb =>
-            all(
+            all<ILayoutCallbackProperty>(
                 cbp => !outputsMap[combineIdAndProp(cbp)],
                 difference(
                     flatten(cb.getInputs(paths)),

--- a/dash-renderer/src/actions/dependencies_ts.ts
+++ b/dash-renderer/src/actions/dependencies_ts.ts
@@ -167,11 +167,15 @@ export const getReadyCallbacks = (
     forEach(output => (outputsMap[output] = true), outputs);
 
     // Find `requested` callbacks that do not depend on a outstanding output (as either input or state)
+    // Outputs which overlap an input do not count as an outstanding output
     return filter(
         cb =>
             all(
                 cbp => !outputsMap[combineIdAndProp(cbp)],
-                flatten(cb.getInputs(paths))
+                difference(
+                    flatten(cb.getInputs(paths)),
+                    flatten(cb.getOutputs(paths))
+                )
             ),
         candidates
     );

--- a/tests/integration/callbacks/test_basic_callback.py
+++ b/tests/integration/callbacks/test_basic_callback.py
@@ -658,7 +658,7 @@ def test_cbsc015_input_output_callback(dash_duo):
 
     app = dash.Dash(__name__)
     app.layout = html.Div(
-        [html.Div(id="input-text"), dcc.Input(id="input", type="number", value=0),]
+        [html.Div(id="input-text"), dcc.Input(id="input", type="number", value=0)]
     )
 
     @app.callback(

--- a/tests/integration/callbacks/test_basic_callback.py
+++ b/tests/integration/callbacks/test_basic_callback.py
@@ -658,15 +658,11 @@ def test_cbsc015_input_output_callback(dash_duo):
 
     app = dash.Dash(__name__)
     app.layout = html.Div(
-        [
-            html.Div(id="input-text"),
-            dcc.Input(id="input", type="number", value=0),
-        ]
+        [html.Div(id="input-text"), dcc.Input(id="input", type="number", value=0),]
     )
 
     @app.callback(
-        Output("input", "value"),
-        Input("input", "value"),
+        Output("input", "value"), Input("input", "value"),
     )
     def circular_output(v):
         ctx = dash.callback_context
@@ -677,9 +673,9 @@ def test_cbsc015_input_output_callback(dash_duo):
         return value
 
     call_count = Value("i", 0)
+
     @app.callback(
-        Output("input-text", "children"),
-        Input("input", "value"),
+        Output("input-text", "children"), Input("input", "value"),
     )
     def follower_output(v):
         with lock:

--- a/tests/integration/callbacks/test_basic_callback.py
+++ b/tests/integration/callbacks/test_basic_callback.py
@@ -651,3 +651,54 @@ def test_cbsc014_multiple_properties_update_at_same_time_on_same_component(dash_
     assert timestamp_2.value > timestamp_1.value
     assert call_count.value == 4
     dash_duo.percy_snapshot("button-2 click again")
+
+
+def test_cbsc015_input_output_callback(dash_duo):
+    lock = Lock()
+
+    app = dash.Dash(__name__)
+    app.layout = html.Div(
+        [
+            html.Div(id="input-text"),
+            dcc.Input(id="input", type="number", value=0),
+        ]
+    )
+
+    @app.callback(
+        Output("input", "value"),
+        Input("input", "value"),
+    )
+    def circular_output(v):
+        ctx = dash.callback_context
+        if not ctx.triggered:
+            value = v
+        else:
+            value = v + 1
+        return value
+
+    call_count = Value("i", 0)
+    @app.callback(
+        Output("input-text", "children"),
+        Input("input", "value"),
+    )
+    def follower_output(v):
+        with lock:
+            call_count.value = call_count.value + 1
+            return str(v)
+
+    dash_duo.start_server(app)
+
+    wait.until(lambda: dash_duo.find_element("#input-text").text == "0", 2)
+
+    input_ = dash_duo.find_element("#input")
+    for key in "2":
+        with lock:
+            input_.send_keys(key)
+
+    wait.until(lambda: dash_duo.find_element("#input-text").text == "3", 2)
+
+    assert call_count.value == 2, "initial + changed once"
+
+    assert not dash_duo.redux_state_is_loading
+
+    assert dash_duo.get_logs() == []

--- a/tests/integration/callbacks/test_basic_callback.py
+++ b/tests/integration/callbacks/test_basic_callback.py
@@ -658,7 +658,7 @@ def test_cbsc015_input_output_callback(dash_duo):
 
     app = dash.Dash(__name__)
     app.layout = html.Div(
-        [html.Div(id="input-text"), dcc.Input(id="input", type="number", value=0)]
+        [html.Div("0", id="input-text"), dcc.Input(id="input", type="number", value=0)]
     )
 
     @app.callback(
@@ -683,8 +683,6 @@ def test_cbsc015_input_output_callback(dash_duo):
             return str(v)
 
     dash_duo.start_server(app)
-
-    wait.until(lambda: dash_duo.find_element("#input-text").text == "0", 2)
 
     input_ = dash_duo.find_element("#input")
     for key in "2":

--- a/tests/integration/clientside/assets/clientside.js
+++ b/tests/integration/clientside/assets/clientside.js
@@ -81,5 +81,22 @@ window.dash_clientside.clientside = {
 
     states_list_to_str: function(val0, val1, st0, st1) {
         return JSON.stringify(dash_clientside.callback_context.states_list);
+    },
+
+    input_output_callback: function(inputValue) {
+        const triggered = dash_clientside.callback_context.triggered;
+        if (triggered.length==0){
+            return inputValue;
+        } else {
+            return inputValue + 1;
+        }
+    },
+
+    input_output_follower: function(inputValue) {
+        if (!window.callCount) {
+            window.callCount = 0
+        }
+        window.callCount += 1;
+        return inputValue.toString();
     }
 };

--- a/tests/integration/devtools/test_callback_validation.py
+++ b/tests/integration/devtools/test_callback_validation.py
@@ -799,17 +799,11 @@ def test_dvcv016_circular_with_input_output(dash_duo):
     )
 
     @app.callback(
-        [
-            Output("a", "children"),
-            Output("b", "children"),
-        ],
-        [
-            Input("a", "children"),
-            Input("b", "children"),
-            Input("c", "children"),
-        ])
-    def c1(a,b,c):
-        return a,b
+        [Output("a", "children"), Output("b", "children")],
+        [Input("a", "children"), Input("b", "children"), Input("c", "children")],
+    )
+    def c1(a, b, c):
+        return a, b
 
     @app.callback(Output("c", "children"), [Input("a", "children")])
     def c2(children):

--- a/tests/integration/devtools/test_callback_validation.py
+++ b/tests/integration/devtools/test_callback_validation.py
@@ -5,6 +5,7 @@ import dash_core_components as dcc
 import dash_html_components as html
 from dash import Dash
 from dash.dependencies import Input, Output, State, MATCH, ALL, ALLSMALLER
+from dash.testing import wait
 
 debugging = dict(
     debug=True, use_reloader=False, use_debugger=True, dev_tools_hot_reload=False
@@ -91,9 +92,7 @@ def test_dvcv002_blank_id_prop(dash_duo):
 
     dash_duo.start_server(app, **debugging)
 
-    # the first one is just an artifact... the other 4 we care about
     specs = [
-        ["Same `Input` and `Output`", []],
         [
             "Callback item missing ID",
             ['Input[0].id = ""', "Every item linked to a callback needs an ID"],
@@ -252,33 +251,9 @@ def test_dvcv005_input_output_overlap(dash_duo):
 
     dash_duo.start_server(app, **debugging)
 
-    specs = [
-        [
-            "Same `Input` and `Output`",
-            [
-                'Input 0 ({"b":MATCH,"c":1}.children)',
-                "can match the same component(s) as",
-                'Output 1 ({"b":MATCH,"c":1}.children)',
-            ],
-        ],
-        [
-            "Same `Input` and `Output`",
-            [
-                'Input 0 ({"a":1}.children)',
-                "can match the same component(s) as",
-                'Output 0 ({"a":ALL}.children)',
-            ],
-        ],
-        [
-            "Same `Input` and `Output`",
-            ["Input 0 (c.children)", "matches Output 1 (c.children)"],
-        ],
-        [
-            "Same `Input` and `Output`",
-            ["Input 0 (a.children)", "matches Output 0 (a.children)"],
-        ],
-    ]
-    check_errors(dash_duo, specs)
+    # input/output overlap is now legal, shouldn't throw any errors
+    wait.until(lambda: ~dash_duo.redux_state_is_loading, 2)
+    assert dash_duo.get_logs() == []
 
 
 def test_dvcv006_inconsistent_wildcards(dash_duo):


### PR DESCRIPTION
Allow circular callbacks in the special case of passing a component+property as an input and output of the same callback.  By combining this capability with `dash.callback_context` it is straightforward to have multiple components remain synchronized.  Other forms of circularity (involving multiple callbacks) are still detected and blocked.  This is related to: https://github.com/plotly/dash/issues/889 

Example code for a linked slider and numeric input:
```
import dash
from dash.dependencies import Input, Output
import dash_core_components as dcc
import dash_html_components as html

external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
app = dash.Dash(__name__, external_stylesheets=external_stylesheets)

app.layout = html.Div(children=[
    html.H1(children='Circular Test'),
    dcc.Slider(
        id='slider',
        min=0, max=20,
    ),
    dcc.Input(
        id='input',
        type='number',
        debounce=False,
        value=3
    ),
])

@app.callback(
    Output('input', 'value'),
    Output('slider', 'value'),
    Input('input', 'value'),
    Input('slider', 'value'),
)
def callback(iv, sv):
    ctx = dash.callback_context
    if not ctx.triggered:
        # default to input value at init
        if iv is not None:
            value = iv
        else:
            value = sv
    else:
        trigger_id = ctx.triggered[0]["prop_id"].split(".")[0]
        if trigger_id=='input':
            value = iv
        else:
            value = sv
    return value, value

app.run_server(debug=True)
```

Result:
![circular_test](https://user-images.githubusercontent.com/32653331/104497949-14b25e80-55a9-11eb-993a-f750faf657ae.gif)



## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Disable checking for input/output overlap
   -  [x] Disable checking for circularity in the special case that an output is also an input
   -  [x] Make changes to ensure callbacks execute correctly (wasn't needed)
   -  [x] Modify tests
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

