### PR TITLE
update get_asset_url function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -694,3 +694,9 @@ app = dash.Dash(...)
 
 ## 0.17.3 - 2017-06-22
 ✨ This is the initial open-source release of Dash.
+
+### Fixed
+- [#1527](https://github.com/plotly/dash/issues/1527)🐛 `get_asset_url` now pulls from an external source if `assets_external_path` is set.
+- updated `_add_assets_resource` to build asset urls the same way as `get_asset_url`.
+- updated doc string for `assets_external_path` Dash argument to be more clear that it will allways be joined with 
+the `assets_url_path` argument when determining the url to an external asset.

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1194,7 +1194,7 @@ class Dash(object):
         else:
             asset = get_asset_path(
                 self.config.requests_pathname_prefix,
-            path,
+                path,
                 self.config.assets_url_path.lstrip("/"),
             )
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1100,10 +1100,7 @@ class Dash(object):
     def _add_assets_resource(self, url_path, file_path):
         res = {"asset_path": url_path, "filepath": file_path}
         if self.config.assets_external_path:
-            res["external_url"] = "/".join([
-                self.config.assets_external_path.rstrip('/'), self.config.assets_url_path.strip('/'), url_path.lstrip('/')
-            ]
-            )
+            res["external_url"] = self.get_asset_url(url_path.lstrip("/"))
         self._assets_files.append(file_path)
         return res
 
@@ -1193,11 +1190,7 @@ class Dash(object):
         else:
             prefix = self.config.requests_pathname_prefix
 
-        asset = get_asset_path(
-            prefix,
-            path,
-            self.config.assets_url_path.lstrip("/")
-        )
+        asset = get_asset_path(prefix, path, self.config.assets_url_path.lstrip("/"))
 
         return asset
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1185,11 +1185,18 @@ class Dash(object):
         ]
 
     def get_asset_url(self, path):
-        asset = get_asset_path(
-            self.config.requests_pathname_prefix,
+        if self.config.assets_external_path:
+            asset = get_asset_path(
+                self.config.assets_external_path,
+                path,
+                self.config.assets_url_path.lstrip("/"),
+            )
+        else:
+            asset = get_asset_path(
+                self.config.requests_pathname_prefix,
             path,
-            self.config.assets_url_path.lstrip("/"),
-        )
+                self.config.assets_url_path.lstrip("/"),
+            )
 
         return asset
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -150,10 +150,12 @@ class Dash(object):
     :type assets_ignore: string
 
     :param assets_external_path: an absolute URL from which to load assets.
-        Use with ``serve_locally=False``. Dash can still find js and css to
-        automatically load if you also keep local copies in your assets
-        folder that Dash can index, but external serving can improve
-        performance and reduce load on the Dash server.
+        Use with ``serve_locally=False``. assets_external_path is joined
+        with assets_url_path to determine the absolute url to the
+        asset folder. Dash can still find js and css to automatically load
+        if you also keep local copies in your assets folder that Dash can index,
+        but external serving can improve performance and reduce load on
+        the Dash server.
         env: ``DASH_ASSETS_EXTERNAL_PATH``
     :type assets_external_path: string
 
@@ -1098,8 +1100,9 @@ class Dash(object):
     def _add_assets_resource(self, url_path, file_path):
         res = {"asset_path": url_path, "filepath": file_path}
         if self.config.assets_external_path:
-            res["external_url"] = "{}{}".format(
-                self.config.assets_external_path, url_path
+            res["external_url"] = "/".join([
+                self.config.assets_external_path.rstrip('/'), self.config.assets_url_path.strip('/'), url_path.lstrip('/')
+            ]
             )
         self._assets_files.append(file_path)
         return res
@@ -1186,17 +1189,15 @@ class Dash(object):
 
     def get_asset_url(self, path):
         if self.config.assets_external_path:
-            asset = get_asset_path(
-                self.config.assets_external_path,
-                path,
-                self.config.assets_url_path.lstrip("/"),
-            )
+            prefix = self.config.assets_external_path
         else:
-            asset = get_asset_path(
-                self.config.requests_pathname_prefix,
-                path,
-                self.config.assets_url_path.lstrip("/"),
-            )
+            prefix = self.config.requests_pathname_prefix
+
+        asset = get_asset_path(
+            prefix,
+            path,
+            self.config.assets_url_path.lstrip("/")
+        )
 
         return asset
 

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -112,8 +112,8 @@ def test_pathname_prefix_assets(empty_environ, req, expected):
         ("/app/" , None                        , "assets" , '/app/assets/reset.css'),
         (None    , None                        , "css"    , "/css/reset.css"),
         ("/app/" , None                        , "css"    , "/app/css/reset.css"),
-        (None    , "http:\\external.com/", "assets" , "http:\\external.com/assets/reset.css"),
-        ("/app/" , "http:\\external.com/", "css"    , "http:\\external.com/css/reset.css"),
+        (None    , "http://external.com/", "assets" , "http://external.com/assets/reset.css"),
+        ("/app/" , "http://external.com/", "css"    , "http://external.com/css/reset.css"),
 
     ],)
 def test_asset_url(empty_environ, requests_pathname_prefix, assets_external_path, assets_url_path, expected):

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -105,6 +105,28 @@ def test_pathname_prefix_assets(empty_environ, req, expected):
     assert path == expected
 
 
+@pytest.mark.parametrize(
+    "requests_pathname_prefix, assets_external_path, assets_url_path, expected",
+    [
+        (None    , None                        , "assets" , "/assets/reset.css"),
+        ("/app/" , None                        , "assets" , '/app/assets/reset.css'),
+        (None    , None                        , "css"    , "/css/reset.css"),
+        ("/app/" , None                        , "css"    , "/app/css/reset.css"),
+        (None    , "http:\\external.com/", "assets" , "http:\\external.com/assets/reset.css"),
+        ("/app/" , "http:\\external.com/", "css"    , "http:\\external.com/css/reset.css"),
+
+    ],)
+def test_asset_url(empty_environ, requests_pathname_prefix, assets_external_path, assets_url_path, expected):
+    app = Dash('Dash',
+               requests_pathname_prefix=requests_pathname_prefix,
+               assets_external_path=assets_external_path,
+               assets_url_path=assets_url_path
+               )
+
+    path = app.get_asset_url('reset.css')
+    assert path == expected
+
+
 def test_get_combined_config_dev_tools_ui(empty_environ):
     val1 = get_combined_config("ui", None, default=False)
     assert (

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -108,22 +108,34 @@ def test_pathname_prefix_assets(empty_environ, req, expected):
 @pytest.mark.parametrize(
     "requests_pathname_prefix, assets_external_path, assets_url_path, expected",
     [
-        (None    , None                        , "assets" , "/assets/reset.css"),
-        ("/app/" , None                        , "assets" , '/app/assets/reset.css'),
-        (None    , None                        , "css"    , "/css/reset.css"),
-        ("/app/" , None                        , "css"    , "/app/css/reset.css"),
-        (None    , "http://external.com/", "assets" , "http://external.com/assets/reset.css"),
-        ("/app/" , "http://external.com/", "css"    , "http://external.com/css/reset.css"),
+        (None, None, "assets", "/assets/reset.css"),
+        ("/app/", None, "assets", "/app/assets/reset.css"),
+        (None, None, "css", "/css/reset.css"),
+        ("/app/", None, "css", "/app/css/reset.css"),
+        (
+            None,
+            "http://external.com/",
+            "assets",
+            "http://external.com/assets/reset.css",
+        ),
+        ("/app/", "http://external.com/", "css", "http://external.com/css/reset.css"),
+    ],
+)
+def test_asset_url(
+    empty_environ,
+    requests_pathname_prefix,
+    assets_external_path,
+    assets_url_path,
+    expected,
+):
+    app = Dash(
+        "Dash",
+        requests_pathname_prefix=requests_pathname_prefix,
+        assets_external_path=assets_external_path,
+        assets_url_path=assets_url_path,
+    )
 
-    ],)
-def test_asset_url(empty_environ, requests_pathname_prefix, assets_external_path, assets_url_path, expected):
-    app = Dash('Dash',
-               requests_pathname_prefix=requests_pathname_prefix,
-               assets_external_path=assets_external_path,
-               assets_url_path=assets_url_path
-               )
-
-    path = app.get_asset_url('reset.css')
+    path = app.get_asset_url("reset.css")
     assert path == expected
 
 


### PR DESCRIPTION
This pull request addresses #1527 by adding and if statement to the `get_asset_url` function in dash.py instructing the app to use the external asset path if it is defined. 

I have tested this with an short I wrote and [published](https://github.com/karosc/Dash_Tester). If you run the app and examine the src attribute of the image, it references and image on my own site karosc.github.io.

