### PR TITLE
enable changing of url relative to selenium

### DIFF
--- a/dash/testing/application_runners.py
+++ b/dash/testing/application_runners.py
@@ -52,6 +52,8 @@ class BaseDashRunner(object):
     """Base context manager class for running applications."""
 
     def __init__(self, keep_open, stop_timeout):
+        self.scheme = 'http'
+        self.host = 'localhost'
         self.port = 8050
         self.started = None
         self.keep_open = keep_open
@@ -92,7 +94,7 @@ class BaseDashRunner(object):
     @property
     def url(self):
         """The default server url."""
-        return "http://localhost:{}".format(self.port)
+        return "{}://{}:{}".format(self.scheme, self.host, self.port)
 
     @property
     def is_windows(self):


### PR DESCRIPTION
Currently, there is no way to use Selenium grid in a separate container/pod because `BaseDashRunner` assumes that the Dash server will be on localhost relative to the Selenium host. In other words, for a setup where the Dash app lives in container1 and Selenium lives in container 2, pytest can be invoked with `pytest --remote-url http://container2:4444` but it will fail because Selenium in container2 will attempt to connect to localhost rather than container1 (since url@BaseDashRunner is hardcoded to localhost).

This MR adds `host` and `scheme` attributes to BaseDashRunner so that the user can better specify the location of the app relative to Selenium.