### PR TITLE
Quieten browser init in test setup

### DIFF
--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -77,10 +77,10 @@ class Browser(DashPageMixin):
             )
             self.percy_runner.initialize_build()
 
-        logger.info("initialize browser with arguments")
-        logger.info("  headless => %s", self._headless)
-        logger.info("  download_path => %s", self._download_path)
-        logger.info("  percy asset root => %s", os.path.abspath(percy_assets_root))
+        logger.debug("initialize browser with arguments")
+        logger.debug("  headless => %s", self._headless)
+        logger.debug("  download_path => %s", self._download_path)
+        logger.debug("  percy asset root => %s", os.path.abspath(percy_assets_root))
 
     def __enter__(self):
         return self

--- a/requires-testing.txt
+++ b/requires-testing.txt
@@ -6,6 +6,7 @@ pytest-mock>=2.0.0,<3;python_version=="2.7"
 lxml>=4.6.2
 selenium>=3.141.0
 percy>=2.0.2
+cryptography<3.4;python_version<"3.7"
 requests[security]>=2.21.0
 beautifulsoup4>=4.8.2,<=4.9.3;python_version=="2.7"
 beautifulsoup4>=4.8.2;python_version>="3.0"


### PR DESCRIPTION
This code is shared by the DE automated end to end integration tests (e2e). The information logged here is never useful to us so this adds a significant amount of noise to our tests. If it's useful to you folks (in a non-debugging context), I'd be happy to make it configurable in the `Browser()` constructor! @plotly/dash-core Please let me know!

Example output [from a recent e2e run](https://app.circleci.com/pipelines/github/plotly/dash-deployment-server/5605/workflows/6ee1768b-b212-4fbc-ac36-15fefdc0c140/jobs/67254):

```
INFO     dash.testing.browser:browser.py:80 initialize browser with arguments
INFO     dash.testing.browser:browser.py:81   headless => False
INFO     dash.testing.browser:browser.py:82   download_path => /tmp/pytest-of-circleci/pytest-0/test_dds_snapshot_engine_pdf0/aws_ha_eks_download
INFO     dash.testing.browser:browser.py:83   percy asset root => /home/circleci/dds/tests/integration/tests/assets
```

These (or similar messages) are repeated a total of 192 times in the run above!

## Contributor Checklist

- [ ] I'll test this PR to make sure it works for us on Wednesday!