### PR TITLE
Adjust z-index of dash error menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 - [#1531](https://github.com/plotly/dash/pull/1531) Update the format of the docstrings to make them easier to read in the reference pages of Dash Docs and in the console.  This also addresses [#1205](https://github.com/plotly/dash/issues/1205)
+- [#1553](https://github.com/plotly/dash/pull/1553) Increase the z-index of the Dash error menu from 1001 to 1100 in order to make sure it appears above Bootstrap components.
 
 ### Fixed
 - [#1546](https://github.com/plotly/dash/pull/1546) Validate callback request `outputs` vs `output` to avoid a perceived security issue.

--- a/dash-renderer/src/components/error/GlobalErrorOverlay.css
+++ b/dash-renderer/src/components/error/GlobalErrorOverlay.css
@@ -44,7 +44,7 @@
     max-height: calc(100vh - 50px);
     margin: 10px;
     overflow: auto;
-    z-index: 1001;  /* above the plotly.js toolbar */
+    z-index: 1100;  /* above the plotly.js toolbar and Bootstrap components */
 }
 
 .dash-error-card__topbar {


### PR DESCRIPTION
Hello,

This very small PR adjusts the z-index of the dash error menu container. The motivation is that the current value (1001) is lower than some common Bootstrap components resulting in the error menu being obscured in some cases. The largest z-index in Bootstrap CSS is 1070 (used for tooltips), I rounded this up somewhat arbitrarily to 1100, but could reduce to 1071 I guess.

Here is a simple example app demonstrating the issue observed with a sticky navbar

```python
import dash
import dash_bootstrap_components as dbc
import dash_html_components as html
from dash.dependencies import Input, Output

app = dash.Dash(external_stylesheets=[dbc.themes.BOOTSTRAP])

navbar = dbc.NavbarSimple(
    brand="dbc.NavbarSimple", sticky="top", color="primary", id="navbar"
)

app.layout = html.Div(navbar, id="layout")


# arbitrary callback to force error menu to appear
@app.callback(Output("layout", "children"), Input("navbar", "color"))
def raise_error(_):
    raise RuntimeError


if __name__ == "__main__":
    app.run_server(debug=True)
```

This was originally raised by a community member in facultyai/dash-bootstrap-components#515. I have verified that my change resolves the issue.

Happy to discuss or make any additional changes you would like.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Adjust the z-index of dash-error-menu
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR (N/A)
