### PR TITLE
Support code injection in webpack 5

### DIFF
--- a/@plotly/dash-component-plugins/LICENSE
+++ b/@plotly/dash-component-plugins/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Plotly
+Copyright (c) 2021 Plotly, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/@plotly/webpack-dash-dynamic-import/LICENSE
+++ b/@plotly/webpack-dash-dynamic-import/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Plotly
+Copyright (c) 2021 Plotly, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/@plotly/webpack-dash-dynamic-import/LICENSE
+++ b/@plotly/webpack-dash-dynamic-import/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Plotly
+Copyright (c) 2021 Plotly
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/@plotly/webpack-dash-dynamic-import/package.json
+++ b/@plotly/webpack-dash-dynamic-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plotly/webpack-dash-dynamic-import",
-  "version": "1.1.5",
+  "version": "1.2.0",
   "description": "Webpack Plugin for Dynamic Import in Dash",
   "repository": {
     "type": "git",

--- a/@plotly/webpack-dash-dynamic-import/src/index.js
+++ b/@plotly/webpack-dash-dynamic-import/src/index.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const webpack = require('webpack');
 
 function getFingerprint() {
     const package = fs.readFileSync('./package.json');

--- a/@plotly/webpack-dash-dynamic-import/src/index.js
+++ b/@plotly/webpack-dash-dynamic-import/src/index.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const webpack = require('webpack');
 
 function getFingerprint() {
     const package = fs.readFileSync('./package.json');
@@ -78,10 +79,11 @@ class WebpackDashDynamicImport {
     apply(compiler) {
         compiler.hooks.compilation.tap('WebpackDashDynamicImport', compilation => {
             compilation.mainTemplate.hooks.requireExtensions.tap('WebpackDashDynamicImport > RequireExtensions', (source, chunk, hash) => {
-                return [
-                    source,
-                    resolveImportSource()
-                ]
+                if (/^5[.]/.test(webpack.version)) {
+                    return source + resolveImportSource();
+                } else {
+                    return [source, resolveImportSource()];
+                }
             });
         });
     }

--- a/@plotly/webpack-dash-dynamic-import/src/index.js
+++ b/@plotly/webpack-dash-dynamic-import/src/index.js
@@ -79,11 +79,7 @@ class WebpackDashDynamicImport {
     apply(compiler) {
         compiler.hooks.compilation.tap('WebpackDashDynamicImport', compilation => {
             compilation.mainTemplate.hooks.requireExtensions.tap('WebpackDashDynamicImport > RequireExtensions', (source, chunk, hash) => {
-                if (/^5[.]/.test(webpack.version)) {
-                    return source + resolveImportSource();
-                } else {
-                    return [source, resolveImportSource()];
-                }
+                return source + resolveImportSource();
             });
         });
     }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Plotly, Inc
+Copyright (c) 2021 Plotly, Inc
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The webpack-dash-dynamic-import plugin was written with Webpack 4.x in mind. With Webpack 5.x the API for plugins changed in a way that makes the existing code injection produce invalid JS bundles. This PR makes the injection work with both 4.x and 5.x.

Related to https://github.com/plotly/dash-table/pull/875
Sanity check against Webpack 4.x project: https://app.circleci.com/pipelines/github/plotly/dash-core-components?branch=sanity-webpack-4and5