### PR TITLE
fix: make devtools text visible with dark themes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#1611](https://github.com/plotly/dash/pull/1611) Package dash-renderer artifacts and dependencies with Dash, and source renderer resources from within Dash.
 
 ### Fixed
+- [#1664](https://github.com/plotly/dash/pull/1664) Fix [#1649](https://github.com/plotly/dash/issues/1649), makes the devtools readable with a dark theme.
 - [#1640](https://github.com/plotly/dash/pull/1640) Fix [#1475](https://github.com/plotly/dash/issues/1475), missing `timing_information` after certain modifications to Flask behavior
 
 ## [1.20.0] - 2021-04-08

--- a/dash/dash-renderer/src/components/error/GlobalErrorOverlay.css
+++ b/dash/dash-renderer/src/components/error/GlobalErrorOverlay.css
@@ -5,6 +5,7 @@
     font-family: monospace;
     font-size: 14px;
     font-variant-ligatures: common-ligatures;
+    color: rgb(50, 50, 50);
 }
 
 .dash-error-card {

--- a/dash/dash-renderer/src/components/error/menu/DebugMenu.css
+++ b/dash/dash-renderer/src/components/error/menu/DebugMenu.css
@@ -163,6 +163,7 @@
     border-radius: 32px;
     background-color: white;
     padding: 4px;
+    color: rgb(50, 50, 50);
 }
 
 .dash-debug-error-count {

--- a/tests/integration/devtools/test_devtools_error_handling.py
+++ b/tests/integration/devtools/test_devtools_error_handling.py
@@ -7,7 +7,10 @@ from dash.exceptions import PreventUpdate
 
 
 def app_with_errors():
-    app = dash.Dash(__name__)
+    darkly = (
+        "https://stackpath.bootstrapcdn.com/bootswatch/4.5.2/darkly/bootstrap.min.css"
+    )
+    app = dash.Dash(__name__, external_stylesheets=[darkly])
 
     app.layout = html.Div(
         [


### PR DESCRIPTION
This is the revised  #1659 PR 

Fixes  #1649 - makes the devtools readable with a dark theme.