### PR TITLE
New docs extras

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [UNRELEASED]
 
 ## Dash and Dash Renderer
+### Added
+- [#1675](https://github.com/plotly/dash/pull/1675) Add new `Dash` constructor argument `extra_hot_reload_paths`. This allows you to re-initialize the Python code of the app when non-Python files change, if you know that these files impact the app.
+
 ### Changed
+- [#1675](https://github.com/plotly/dash/pull/1675) Remove the constraint that `requests_pathname_prefix` ends with `routes_pathname_prefix`. When you are serving your app behind a reverse proxy that rewrites URLs that constraint needs to be violated.
 - [#1611](https://github.com/plotly/dash/pull/1611) Package dash-renderer artifacts and dependencies with Dash, and source renderer resources from within Dash.
 - [#1567](https://github.com/plotly/dash/pull/1567) Julia component generator puts components into `src/jl` - fixes an issue on case-insensitive filesystems when the component name and module name match (modulo case) and no prefix is used. Also reduces JS/Julia clutter in the overloaded `src` directory.
 

--- a/dash/_configs.py
+++ b/dash/_configs.py
@@ -117,9 +117,5 @@ def pathname_configs(
         raise exceptions.InvalidConfig(
             "`requests_pathname_prefix` needs to start with `/`"
         )
-    if not requests_pathname_prefix.endswith(routes_pathname_prefix):
-        raise exceptions.InvalidConfig(
-            "`requests_pathname_prefix` needs to ends with `routes_pathname_prefix`."
-        )
 
     return url_base_pathname, routes_pathname_prefix, requests_pathname_prefix

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -232,6 +232,11 @@ class Dash(object):
         and redo buttons for stepping through the history of the app state.
     :type show_undo_redo: boolean
 
+    :param extra_hot_reload_paths: A list of paths to watch for changes, in
+        addition to assets and known Python and JS code, if hot reloading is
+        enabled.
+    :type extra_hot_reload_paths: list of strings
+
     :param plugins: Extend Dash functionality by passing a list of objects
         with a ``plug`` method, taking a single argument: this app, which will
         be called after the Flask server is attached.
@@ -269,6 +274,7 @@ class Dash(object):
         suppress_callback_exceptions=None,
         prevent_initial_callbacks=False,
         show_undo_redo=False,
+        extra_hot_reload_paths=None,
         plugins=None,
         title="Dash",
         update_title="Updating...",
@@ -329,6 +335,7 @@ class Dash(object):
             ),
             prevent_initial_callbacks=prevent_initial_callbacks,
             show_undo_redo=show_undo_redo,
+            extra_hot_reload_paths=extra_hot_reload_paths or [],
             title=title,
             update_title=update_title,
         )
@@ -1729,5 +1736,15 @@ class Dash(object):
                 display_url = (protocol, host, ":{}".format(port), path)
 
             self.logger.info("Dash is running on %s://%s%s%s\n", *display_url)
+
+        if self.config.extra_hot_reload_paths:
+            extra_files = flask_run_options["extra_files"] = []
+            for path in self.config.extra_hot_reload_paths:
+                if os.path.isdir(path):
+                    for dirpath, _, filenames in os.walk(path):
+                        for fn in filenames:
+                            extra_files.append(os.path.join(dirpath, fn))
+                elif os.path.isfile(path):
+                    extra_files.append(path)
 
         self.server.run(host=host, port=port, debug=debug, **flask_run_options)

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -50,7 +50,6 @@ def generate_components(
     rsuggests="",
     jlprefix=None,
     metadata=None,
-    quiet=False,
 ):
 
     project_shortname = project_shortname.replace("-", "_").rstrip("/\\")


### PR DESCRIPTION
Several updates to dash, designed to enable multi-language docs generated from markdown to work better:
- https://github.com/plotly/dash/commit/8503dfa8dc10abc4413b50af793d974a71835fca - `extra_hot_reload_paths`: specify paths to be watched recursively for changes in _any_ file, when you know that the app behavior depends on these files. I want this because I'm reading markdown files and converting them to Dash components.
- https://github.com/plotly/dash/commit/77c15c5add9f7f83eaf44b3bdaf5817daf5152ca - provide more granular entry points to the component generator. I already have all the `metadata.json`( and `package.json`) files for all our component packages, I just want to use these to generate non-Python backends in order to read out the docstrings.
- https://github.com/plotly/dash/commit/9d0e821625c1facd222c1337f21afd5d92d78e80 - remove the constraint that `requests_pathname_prefix` ends with `routes_pathname_prefix`. This coincidentally just came up in https://github.com/plotly/dash/issues/1665 but when you are serving your app behind a reverse proxy that rewrites URLs that constraint needs to be violated.

## Contributor Checklist

- [ ] I have added entry in the `CHANGELOG.md`
