### PR TITLE
Remove references to cleanModules job

### DIFF
--- a/dash/development/build_process.py
+++ b/dash/development/build_process.py
@@ -76,7 +76,6 @@ class BuildProcess(object):
         self.npm()
         self.bundles(build)
         self.digest()
-        self.cleanModules()
 
     @job("compute the hash digest for assets")
     def digest(self):
@@ -155,12 +154,6 @@ class BuildProcess(object):
             self._concat(self.build_folder, os.pardir, "_dash_renderer.py"), "w"
         ) as fp:
             fp.write(t.safe_substitute(versions))
-
-    @job("clean node_modules directory 🧹")
-    def cleanModules(self):
-        """Job to clean node_modules directory from Dash package."""
-        os.chdir(self.main)
-        run_command_with_process("rm -rf node_modules")
 
 
 class Renderer(BuildProcess):


### PR DESCRIPTION
This PR provides a minor fix to the `dash-renderer` build process by removing the job to clean `node_modules` following the bundle generation. As pointed out by @alexcjohnson , this job is unnecessary and causes the following error:

```
> rm -rf lib && babel src --extensions=".ts,.tsx,.js,.jsx" --out-dir lib --copy-files
sh: babel: command not found
```
