### PR TITLE
Add support for adding "extra components" to an app's layout

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -491,15 +491,13 @@ class Dash(object):
         return self._layout
 
     def _layout_value(self):
+        from dash_html_components import Div  # pylint: disable=import-outside-toplevel
+
         layout = self._layout() if self._layout_is_function else self._layout
 
-        # Add extra hidden components
+        # Add any extra components
         if self._extra_components:
-            if not hasattr(layout, "children"):
-                setattr(layout, "children", [])
-            for c in self._extra_components:
-                if c not in layout.children:
-                    layout.children.append(c)
+            layout = Div(children=[layout] + self._extra_components)
 
         return layout
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -400,6 +400,7 @@ class Dash(object):
         self._layout = None
         self._layout_is_function = False
         self.validation_layout = None
+        self._extra_components = []
 
         self._setup_dev_tools()
         self._hot_reload = AttributeDict(
@@ -491,7 +492,17 @@ class Dash(object):
         return self._layout
 
     def _layout_value(self):
-        return self._layout() if self._layout_is_function else self._layout
+        layout = self._layout() if self._layout_is_function else self._layout
+
+        # Add extra hidden components
+        if self._extra_components:
+            if not hasattr(layout, "children"):
+                setattr(layout, "children", [])
+            for c in self._extra_components:
+                if c not in layout.children:
+                    layout.children.append(c)
+
+        return layout
 
     @layout.setter
     def layout(self, value):


### PR DESCRIPTION
This PR is a foundational part of the coming `long_callback` PR, which will bring the `long_callback` decorator from Dash Labs to Dash.  I think it may be useful in other contexts as well, so I thought I'd split it off into a separate PR for discussion.

I added a new private `_extra_components` property to `dash.Dash` app instances that is initialized to an empty list. When components are added to this list, they are appended to the layout returned by `_layout_value`.

The motivation is to make it possible for `long_callback` to add `Interval` and `Store` components to the layout without returning them to the user and requiring the user to position them in the layout themselves.






