### PR TITLE
Preserve schema key order when flattening a dict grouping

### DIFF
--- a/dash/_grouping.py
+++ b/dash/_grouping.py
@@ -30,6 +30,8 @@ def flatten_grouping(grouping, schema=None):
     """
     if schema is None:
         schema = grouping
+    else:
+        validate_grouping(grouping, schema)
 
     if isinstance(schema, (tuple, list)):
         return [
@@ -39,11 +41,7 @@ def flatten_grouping(grouping, schema=None):
         ]
 
     if isinstance(schema, dict):
-        return [
-            g
-            for group_el, schema_el in zip(grouping.values(), schema.values())
-            for g in flatten_grouping(group_el, schema_el)
-        ]
+        return [g for k in schema for g in flatten_grouping(grouping[k], schema[k])]
 
     return [grouping]
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -55,7 +55,6 @@ from . import _validate
 from . import _watch
 from ._grouping import (
     flatten_grouping,
-    validate_grouping,
     map_grouping,
     make_grouping_by_index,
     grouping_len,
@@ -1075,10 +1074,8 @@ class Dash(object):
                         # list or tuple
                         output_value = list(output_value)
 
+                    # Flatten grouping and validate grouping structure
                     flat_output_values = flatten_grouping(output_value, output)
-
-                # Validate grouping structure
-                validate_grouping(output_value, output)
 
                 _validate.validate_multi_return(
                     output_spec, flat_output_values, callback_id

--- a/tests/unit/dash/test_grouping.py
+++ b/tests/unit/dash/test_grouping.py
@@ -45,6 +45,17 @@ def test_flatten_dict(dict_grouping_size):
     assert len(result) == grouping_len(grouping)
 
 
+def test_flatten_dict_key_order(dict_grouping_size):
+    grouping, size = dict_grouping_size
+    expected = list(range(size))
+
+    # Reverse key order of value dict to make sure order is preserved
+    rev_grouping = {k: grouping[k] for k in reversed(grouping)}
+    result = flatten_grouping(rev_grouping, grouping)
+    assert expected == result
+    assert len(result) == grouping_len(grouping)
+
+
 def test_flatten_mixed(mixed_grouping_size):
     grouping, size = mixed_grouping_size
     expected = list(range(size))

--- a/tests/unit/dash/test_grouping.py
+++ b/tests/unit/dash/test_grouping.py
@@ -50,7 +50,7 @@ def test_flatten_dict_key_order(dict_grouping_size):
     expected = list(range(size))
 
     # Reverse key order of value dict to make sure order is preserved
-    rev_grouping = {k: grouping[k] for k in reversed(grouping)}
+    rev_grouping = {k: grouping[k] for k in reversed(list(grouping.keys()))}
     result = flatten_grouping(rev_grouping, grouping)
     assert expected == result
     assert len(result) == grouping_len(grouping)


### PR DESCRIPTION
Small follow-on fix for flexible callback support added in https://github.com/plotly/dash/pull/1691.

For the case of a callback that returns a dictionary grouping, this fix removes the unintentional requirement that the dictionary key order of the returned value match the key order of the dependency specification.

For example, this case now works properly:

```python
@app.callback(dict(a=Output(...), b=Output(...)), ...)
def callback(...):
    return dict(b=0, a=1)
```