### PR TITLE
Disable compression by default in Dash 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.0.0] - 2021-??-??
+
+## Dash and Dash Renderer
+
+### Changed
+- [#1707](https://github.com/plotly/dash/pull/1707) Change the default value of the `compress` argument to the `dash.Dash` constructor to `False`. This change reduces CPU usage, and was made in recognition of the fact that many deployment platforms (e.g. Dash Enterprise) already apply their own compression. If deploying to an environment that does not already provide compression, the Dash 1 behavior may be restored by adding `compress=True` to the `dash.Dash` constructor. 
+
 ## [1.21.0] - 2021-07-09
 
 ## Dash and Dash Renderer

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -197,7 +197,7 @@ class Dash(object):
     :type serve_locally: boolean
 
     :param compress: Use gzip to compress files and data served by Flask.
-        Default ``True``
+        Default ``False``
     :type compress: boolean
 
     :param meta_tags: html <meta> tags to be added to the index page.

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -336,7 +336,7 @@ class Dash(object):
             routes_pathname_prefix=routes_prefix,
             requests_pathname_prefix=requests_prefix,
             serve_locally=serve_locally,
-            compress=get_combined_config("compress", compress, True),
+            compress=get_combined_config("compress", compress, False),
             meta_tags=meta_tags or [],
             external_scripts=external_scripts or [],
             external_stylesheets=external_stylesheets or [],


### PR DESCRIPTION
This PR changes the default value of the `compress` argument to the `dash.Dash` constructor from `True` to `False`.

Rational: Compression has a performance penalty, and is often handled at a higher level in the deployment stack (e.g. by NGINX or Dash Enterprise).  This PR makes Flask-level compression opt-in rather than opt-out for Dash 2.
