### PR TITLE
Fix pytest import

### DIFF
--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -22,7 +22,7 @@ from ._utils import (
 from . import _validate
 
 
-class NoUpdate(object):
+class NoUpdate:
     # pylint: disable=too-few-public-methods
     pass
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -16,7 +16,6 @@ import hashlib
 import base64
 
 from future.moves.urllib.parse import urlparse
-from _pytest.assertion.rewrite import AssertionRewritingHook
 
 import flask
 from flask_compress import Compress
@@ -1826,12 +1825,18 @@ class Dash:
 
             # # additional condition to account for AssertionRewritingHook object
             # # loader when running pytest
-            for index, package in enumerate(packages):
-                if isinstance(package, AssertionRewritingHook):
-                    dash_spec = importlib.util.find_spec("dash")
-                    dash_test_path = dash_spec.submodule_search_locations[0]
-                    setattr(dash_spec, "path", dash_test_path)
-                    packages[index] = dash_spec
+
+            if "_pytest" in sys.modules:
+                from _pytest.assertion.rewrite import (  # pylint: disable=import-outside-toplevel
+                    AssertionRewritingHook,
+                )
+
+                for index, package in enumerate(packages):
+                    if isinstance(package, AssertionRewritingHook):
+                        dash_spec = importlib.util.find_spec("dash")
+                        dash_test_path = dash_spec.submodule_search_locations[0]
+                        setattr(dash_spec, "path", dash_test_path)
+                        packages[index] = dash_spec
 
             component_packages_dist = [
                 dash_test_path

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-from functools import wraps
 import os
 import sys
 import collections

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1828,7 +1828,6 @@ class Dash:
             # # loader when running pytest
             for index, package in enumerate(packages):
                 if isinstance(package, AssertionRewritingHook):
-                    print("YES")
                     dash_spec = importlib.util.find_spec("dash")
                     dash_test_path = dash_spec.submodule_search_locations[0]
                     setattr(dash_spec, "path", dash_test_path)

--- a/requires-install.txt
+++ b/requires-install.txt
@@ -2,3 +2,4 @@ Flask>=1.0.4
 flask-compress
 plotly>=5.0.0
 future
+pytest>=6.0.2

--- a/requires-install.txt
+++ b/requires-install.txt
@@ -2,4 +2,3 @@ Flask>=1.0.4
 flask-compress
 plotly>=5.0.0
 future
-pytest>=6.0.2

--- a/tests/integration/callbacks/test_global_dash_callback.py
+++ b/tests/integration/callbacks/test_global_dash_callback.py
@@ -1,7 +1,5 @@
-import dash_core_components as dcc
-import dash_html_components as html
 import dash
-from dash.dependencies import Input, Output
+from dash import Input, Output, dcc, html
 
 
 def test_dash_callback_001(dash_duo):


### PR DESCRIPTION
This PR cleans up some the changes to the `dash-monorepo`, and adds a check before importing the pytest `AssertionRewritingHook` object. 