### PR TITLE
Remove `future`, `__future__` and `py2/py3`

### DIFF
--- a/components/dash-core-components/dash_core_components_base/__init__.py
+++ b/components/dash-core-components/dash_core_components_base/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function as _
-
 import json
 import os as _os
 import sys as _sys

--- a/components/dash-core-components/dash_core_components_base/express.py
+++ b/components/dash-core-components/dash_core_components_base/express.py
@@ -1,16 +1,6 @@
 import io
 import ntpath
 import base64
-from functools import partial
-
-# Py2 StringIO.StringIO handles unicode but io.StringIO doesn't
-try:
-    from StringIO import StringIO as _StringIO
-
-    py2 = True
-except ImportError:
-    _StringIO = io.StringIO
-    py2 = False
 
 # region Utils for Download component
 
@@ -56,7 +46,7 @@ def send_string(src, filename, type=None, **kwargs):
     :param type: type of the file (optional, passed to Blob in the javascript layer)
     :return: dict of data frame content (NOT base64 encoded) and meta data used by the Download component
     """
-    content = src if isinstance(src, str) else _io_to_str(_StringIO(), src, **kwargs)
+    content = src if isinstance(src, str) else _io_to_str(io.StringIO(), src, **kwargs)
     return dict(content=content, filename=filename, type=type, base64=False)
 
 
@@ -110,7 +100,7 @@ _data_frame_senders = {
     "to_parquet": send_bytes,
     "to_msgpack": send_bytes,
     "to_stata": send_bytes,
-    "to_pickle": partial(send_bytes, compression=None) if py2 else send_bytes,
+    "to_pickle": send_bytes,
 }
 
 # endregion

--- a/components/dash-html-components/dash_html_components_base/__init__.py
+++ b/components/dash-html-components/dash_html_components_base/__init__.py
@@ -1,6 +1,5 @@
 """Vanilla HTML components for Dash"""
 
-from __future__ import print_function as _
 from ._imports_ import *  # noqa: E402, F401, F403
 from ._imports_ import __all__  # noqa: E402
 

--- a/components/dash-table/dash_table_base/__init__.py
+++ b/components/dash-table/dash_table_base/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os as _os
 import sys as _sys
 import json

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import shlex
 import sys
 import uuid
@@ -10,14 +9,9 @@ import logging
 import io
 import json
 from functools import wraps
-from future import utils
 from . import exceptions
 
 logger = logging.getLogger()
-
-# py2/3 json.dumps-compatible strings - these are equivalent in py3, not in py2
-# note because we import unicode_literals u"" and "" are both unicode
-_strings = (type(""), type(utils.bytes_to_native_str(b"")))
 
 
 def to_json(value):
@@ -109,7 +103,7 @@ def strip_relative_path(requests_pathname, path):
 
 # pylint: disable=no-member
 def patch_collections_abc(member):
-    return getattr(collections if utils.PY2 else collections.abc, member)
+    return getattr(collections.abc, member)
 
 
 class AttributeDict(dict):

--- a/dash/_validate.py
+++ b/dash/_validate.py
@@ -5,7 +5,7 @@ from textwrap import dedent
 from ._grouping import grouping_len, map_grouping
 from .development.base_component import Component
 from . import exceptions
-from ._utils import patch_collections_abc, _strings, stringify_id
+from ._utils import patch_collections_abc, stringify_id
 
 
 def validate_callback(outputs, inputs, state, extra_args, types):
@@ -41,7 +41,7 @@ def validate_callback(outputs, inputs, state, extra_args, types):
 
 
 def validate_callback_arg(arg):
-    if not isinstance(getattr(arg, "component_property", None), _strings):
+    if not isinstance(getattr(arg, "component_property", None), str):
         raise exceptions.IncorrectTypeException(
             dedent(
                 """
@@ -61,7 +61,7 @@ def validate_callback_arg(arg):
     if isinstance(arg.component_id, dict):
         validate_id_dict(arg)
 
-    elif isinstance(arg.component_id, _strings):
+    elif isinstance(arg.component_id, str):
         validate_id_string(arg)
 
     else:
@@ -81,7 +81,7 @@ def validate_id_dict(arg):
         # Need to keep key type validation on the Python side, since
         # non-string keys will be converted to strings in json.dumps and may
         # cause unwanted collisions
-        if not isinstance(k, _strings):
+        if not isinstance(k, str):
             raise exceptions.IncorrectTypeException(
                 dedent(
                     """
@@ -198,7 +198,7 @@ def validate_multi_return(outputs_list, output_value, callback_id):
 
 
 def fail_callback_output(output_value, output):
-    valid = _strings + (dict, int, float, type(None), Component)
+    valid = (str, dict, int, float, type(None), Component)
 
     def _raise_invalid(bad_val, outer_val, path, index=None, toplevel=False):
         bad_type = type(bad_val).__name__

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import sys
 import collections
@@ -13,8 +11,7 @@ import time
 import mimetypes
 import hashlib
 import base64
-
-from future.moves.urllib.parse import urlparse
+from urllib.parse import urlparse
 
 import flask
 from flask_compress import Compress

--- a/dash/dash_table/__init__.py
+++ b/dash/dash_table/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os as _os
 import sys as _sys
 import json

--- a/dash/dcc/__init__.py
+++ b/dash/dcc/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import print_function as _
-
 import json
 import os as _os
 import sys as _sys

--- a/dash/dcc/express.py
+++ b/dash/dcc/express.py
@@ -1,16 +1,6 @@
 import io
 import ntpath
 import base64
-from functools import partial
-
-# Py2 StringIO.StringIO handles unicode but io.StringIO doesn't
-try:
-    from StringIO import StringIO as _StringIO
-
-    py2 = True
-except ImportError:
-    _StringIO = io.StringIO
-    py2 = False
 
 # region Utils for Download component
 
@@ -56,7 +46,7 @@ def send_string(src, filename, type=None, **kwargs):
     :param type: type of the file (optional, passed to Blob in the javascript layer)
     :return: dict of data frame content (NOT base64 encoded) and meta data used by the Download component
     """
-    content = src if isinstance(src, str) else _io_to_str(_StringIO(), src, **kwargs)
+    content = src if isinstance(src, str) else _io_to_str(io.StringIO(), src, **kwargs)
     return dict(content=content, filename=filename, type=type, base64=False)
 
 
@@ -110,7 +100,7 @@ _data_frame_senders = {
     "to_parquet": send_bytes,
     "to_msgpack": send_bytes,
     "to_stata": send_bytes,
-    "to_pickle": partial(send_bytes, compression=None) if py2 else send_bytes,
+    "to_pickle": send_bytes,
 }
 
 # endregion

--- a/dash/development/_jl_components_generation.py
+++ b/dash/development/_jl_components_generation.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
 import copy
 import os
 import shutil

--- a/dash/development/_r_components_generation.py
+++ b/dash/development/_r_components_generation.py
@@ -1,6 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
-
 import os
 import sys
 import shutil

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -1,9 +1,8 @@
 import abc
 import inspect
 import sys
-from future.utils import with_metaclass
 
-from .._utils import patch_collections_abc, _strings, stringify_id
+from .._utils import patch_collections_abc, stringify_id
 
 MutableSequence = patch_collections_abc("MutableSequence")
 
@@ -59,7 +58,7 @@ def _check_if_has_indexable_children(item):
         raise KeyError
 
 
-class Component(with_metaclass(ComponentMeta, object)):
+class Component(metaclass=ComponentMeta):
     class _UNDEFINED:
         def __repr__(self):
             return "undefined"
@@ -124,17 +123,17 @@ class Component(with_metaclass(ComponentMeta, object)):
             if k == "id":
                 if isinstance(v, dict):
                     for id_key, id_val in v.items():
-                        if not isinstance(id_key, _strings):
+                        if not isinstance(id_key, str):
                             raise TypeError(
                                 "dict id keys must be strings,\n"
                                 + "found {!r} in id {!r}".format(id_key, v)
                             )
-                        if not isinstance(id_val, _strings + (int, float, bool)):
+                        if not isinstance(id_val, (str, int, float, bool)):
                             raise TypeError(
                                 "dict id values must be strings, numbers or bools,\n"
                                 + "found {!r} in id {!r}".format(id_val, v)
                             )
-                elif not isinstance(v, _strings):
+                elif not isinstance(v, str):
                     raise TypeError(
                         "`id` prop must be a string or dict, not {!r}".format(v)
                     )

--- a/dash/development/build_process.py
+++ b/dash/development/build_process.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 import os
 import sys
 import json

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 from collections import OrderedDict
 
 import json

--- a/dash/development/update_components.py
+++ b/dash/development/update_components.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import subprocess
 import shlex

--- a/dash/html/__init__.py
+++ b/dash/html/__init__.py
@@ -1,6 +1,5 @@
 """Vanilla HTML components for Dash"""
 
-from __future__ import print_function as _
 from ._imports_ import *  # noqa: E402, F401, F403
 from ._imports_ import __all__  # noqa: E402
 

--- a/dash/testing/application_runners.py
+++ b/dash/testing/application_runners.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 import os
 import uuid
@@ -14,7 +12,6 @@ import runpy
 import flask
 import requests
 
-from future import utils
 from dash.testing.errors import NoAppFoundError, TestingTimeoutError, ServerCloseError
 from dash.testing import wait
 
@@ -222,15 +219,11 @@ class ProcessRunner(BaseDashRunner):
                 if self.tmp_app_path and os.path.exists(self.tmp_app_path):
                     logger.debug("removing temporary app path %s", self.tmp_app_path)
                     shutil.rmtree(self.tmp_app_path)
-                if utils.PY3:
-                    # pylint:disable=no-member
-                    _except = subprocess.TimeoutExpired
-                    # pylint: disable=unexpected-keyword-arg
-                    self.proc.communicate(timeout=self.stop_timeout)
-                else:
-                    _except = Exception
-                    logger.info("ruthless kill the process to avoid zombie")
-                    self.proc.kill()
+
+                _except = subprocess.TimeoutExpired  # pylint:disable=no-member
+                self.proc.communicate(
+                    timeout=self.stop_timeout  # pylint: disable=unexpected-keyword-arg
+                )
             except _except:
                 logger.exception(
                     "subprocess terminate not success, trying to kill "

--- a/requires-install.txt
+++ b/requires-install.txt
@@ -1,4 +1,3 @@
 Flask>=1.0.4
 flask-compress
 plotly>=5.0.0
-future


### PR DESCRIPTION
As Python 2 support is dropped in `dev` :tada: here is a community PR on the transition of the code base.

`grep -rnw . -e 'substring'` now returns an empty list for all substrings `py2`, `py3`, `from future`, `import future`, `__future__`, `_strings`.

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  [X] Checked for the substrings above and removed them + simplified code that followed from that.
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))