### PR TITLE
fixed bug causing 'dash_html_components.' to be imported instead of d…

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -619,7 +619,7 @@ class Dash:
         # for cache busting
         def _relative_url_path(relative_package_path="", namespace=""):
             if any(
-                relative_package_path.startswith(x + '/')
+                relative_package_path.startswith(x + "/")
                 for x in ["dcc", "html", "dash_table"]
             ):
                 relative_package_path = relative_package_path.replace("dash.", "")

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -619,7 +619,7 @@ class Dash:
         # for cache busting
         def _relative_url_path(relative_package_path="", namespace=""):
             if any(
-                relative_package_path.startswith(x)
+                relative_package_path.startswith(x + '/')
                 for x in ["dcc", "html", "dash_table"]
             ):
                 relative_package_path = relative_package_path.replace("dash.", "")

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -618,7 +618,10 @@ class Dash:
         # add the version number of the package as a query parameter
         # for cache busting
         def _relative_url_path(relative_package_path="", namespace=""):
-            if any(x in relative_package_path for x in ["dcc", "html", "dash_table"]):
+            if any(
+                relative_package_path.startswith(x)
+                for x in ["dcc", "html", "dash_table"]
+            ):
                 relative_package_path = relative_package_path.replace("dash.", "")
                 version = importlib.import_module(
                     "{}.{}".format(namespace, os.path.split(relative_package_path)[0])

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -1,7 +1,6 @@
 import mock
 import dash
 from dash import dcc, html  # noqa: F401
-import sys
 
 from dash.development.base_component import ComponentRegistry
 
@@ -112,15 +111,14 @@ def test_collect_and_register_resources(mocker):
     )
     with mock.patch("dash.dash.os.stat", return_value=StatMock()):
         with mock.patch("dash.dash.importlib.import_module") as import_mock:
-            sys.modules["dash_html_components"] = dcc
-
-            import_mock.return_value = dcc
-            app._collect_and_register_resources(
-                [
-                    {
-                        "namespace": "dash_html_components",
-                        "relative_package_path": "dash_html_components.min.js",
-                    },
-                ]
-            )
-            import_mock.assert_any_call("dash_html_components")
+            with mock.patch("sys.modules", {"dash_html_components": dcc}):
+                import_mock.return_value = dcc
+                app._collect_and_register_resources(
+                    [
+                        {
+                            "namespace": "dash_html_components",
+                            "relative_package_path": "dash_html_components.min.js",
+                        },
+                    ]
+                )
+                import_mock.assert_any_call("dash_html_components")

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -1,6 +1,7 @@
 import mock
 import dash
 from dash import dcc, html  # noqa: F401
+import sys
 
 from dash.development.base_component import ComponentRegistry
 
@@ -102,3 +103,24 @@ def test_internal(mocker):
     ), "Dynamic resource not available in registered path {}".format(
         app.registered_paths["dash"]
     )
+
+
+def test_collect_and_register_resources(mocker):
+
+    app = dash.Dash(
+        __name__, assets_folder="tests/assets", assets_ignore="load_after.+.js"
+    )
+    with mock.patch("dash.dash.os.stat", return_value=StatMock()):
+        with mock.patch("dash.dash.importlib.import_module") as import_mock:
+            sys.modules["dash_html_components"] = dcc
+
+            import_mock.return_value = dcc
+            app._collect_and_register_resources(
+                [
+                    {
+                        "namespace": "dash_html_components",
+                        "relative_package_path": "dash_html_components.min.js",
+                    },
+                ]
+            )
+            import_mock.assert_any_call("dash_html_components")


### PR DESCRIPTION
…ash_html_components

Fixes bug in preparing resource fingerprints. The code accidentally imports "dash_html_components" as "dash_html_components." and this PR fixes that.

This issue causes problems with dash_embedded CI tests.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Fix and test.
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
