### PR TITLE
Typo: documentation link in warning message

### DIFF
--- a/dash/resources.py
+++ b/dash/resources.py
@@ -68,7 +68,7 @@ class Resources:
                         "`app.scripts.append_script` "
                         "or `app.css.append_css`, use `external_scripts` "
                         "or `external_stylesheets` instead.\n"
-                        "See https://dash.plot.com/external-resources"
+                        "See https://dash.plotly.com/external-resources"
                     ).format(s["external_url"])
                 )
                 continue


### PR DESCRIPTION
Warning message in `resources.py` links to [`dash.plot.com`](https://dash.plot.com); changed to [`dash.plotly.com`](https://dash.plotly.com).