### PR TITLE
Add flaky decorator to long_callback tests to retry up to 3 times

### DIFF
--- a/requires-testing.txt
+++ b/requires-testing.txt
@@ -13,3 +13,4 @@ multiprocess>=0.70.12
 redis>=3.5.3
 psutil>=5.8.0
 celery[redis]>=5.1.2
+flaky>=3.7.0

--- a/tests/integration/long_callback/test_basic_long_callback.py
+++ b/tests/integration/long_callback/test_basic_long_callback.py
@@ -6,6 +6,7 @@ import tempfile
 import pytest
 import shutil
 import time
+from flaky import flaky
 
 from dash.testing.application_runners import import_app
 import psutil
@@ -86,6 +87,7 @@ def setup_long_callback_app(manager_name, app_name):
             os.environ.pop("DISKCACHE_DIR")
 
 
+@flaky(max_runs=3)
 def test_lcbc001_fast_input(dash_duo, manager):
     """
     Make sure that we settle to the correct final value when handling rapid inputs
@@ -107,6 +109,7 @@ def test_lcbc001_fast_input(dash_duo, manager):
     assert dash_duo.get_logs() == []
 
 
+@flaky(max_runs=3)
 def test_lcbc002_long_callback_running(dash_duo, manager):
     with setup_long_callback_app(manager, "app2") as app:
         dash_duo.start_server(app)
@@ -134,6 +137,7 @@ def test_lcbc002_long_callback_running(dash_duo, manager):
     assert dash_duo.get_logs() == []
 
 
+@flaky(max_runs=3)
 def test_lcbc003_long_callback_running_cancel(dash_duo, manager):
     lock = Lock()
 
@@ -174,6 +178,7 @@ def test_lcbc003_long_callback_running_cancel(dash_duo, manager):
     assert dash_duo.get_logs() == []
 
 
+@flaky(max_runs=3)
 def test_lcbc004_long_callback_progress(dash_duo, manager):
     with setup_long_callback_app(manager, "app4") as app:
         dash_duo.start_server(app)
@@ -207,6 +212,7 @@ def test_lcbc004_long_callback_progress(dash_duo, manager):
     assert dash_duo.get_logs() == []
 
 
+@flaky(max_runs=3)
 def test_lcbc005_long_callback_caching(dash_duo, manager):
     lock = Lock()
 
@@ -274,6 +280,7 @@ def test_lcbc005_long_callback_caching(dash_duo, manager):
         assert dash_duo.get_logs() == []
 
 
+@flaky(max_runs=3)
 def test_lcbc006_long_callback_caching_multi(dash_duo, manager):
     lock = Lock()
 
@@ -383,6 +390,7 @@ def test_lcbc006_long_callback_caching_multi(dash_duo, manager):
         assert dash_duo.get_logs() == []
 
 
+@flaky(max_runs=3)
 def test_lcbc007_validation_layout(dash_duo, manager):
     with setup_long_callback_app(manager, "app7") as app:
         dash_duo.start_server(app)


### PR DESCRIPTION
:adhesive_bandage: to retry the long_callback tests up to 3 times.  A `===Flaky Test Report===` section should be printed out in the test logs that reports whether tests had to be rerun.