### PR TITLE
Type annotations in `dash` (+ add `mypy` tests in CI)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,3 +10,4 @@ include dash/html/*
 include dash/dash_table/*
 include dash/dash-renderer/build/*.js
 include dash/dash-renderer/build/*.map
+include dash/py.typed

--- a/dash/_callback_context.py
+++ b/dash/_callback_context.py
@@ -35,17 +35,17 @@ falsy_triggered = FalsyList([{"prop_id": ".", "value": None}])
 
 # pylint: disable=no-init
 class CallbackContext:
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def inputs(self):
         return getattr(flask.g, "input_values", {})
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def states(self):
         return getattr(flask.g, "state_values", {})
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def triggered(self):
         # For backward compatibility: previously `triggered` always had a
@@ -54,17 +54,17 @@ class CallbackContext:
         # look empty, but you can still do `triggered[0]["prop_id"].split(".")`
         return getattr(flask.g, "triggered_inputs", []) or falsy_triggered
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def args_grouping(self):
         return getattr(flask.g, "args_grouping", [])
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def outputs_grouping(self):
         return getattr(flask.g, "outputs_grouping", [])
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def outputs_list(self):
         if self.using_outputs_grouping:
@@ -75,7 +75,7 @@ class CallbackContext:
 
         return getattr(flask.g, "outputs_list", [])
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def inputs_list(self):
         if self.using_args_grouping:
@@ -86,7 +86,7 @@ class CallbackContext:
 
         return getattr(flask.g, "inputs_list", [])
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def states_list(self):
         if self.using_args_grouping:
@@ -96,7 +96,7 @@ class CallbackContext:
             )
         return getattr(flask.g, "states_list", [])
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def response(self):
         return getattr(flask.g, "dash_response")
@@ -125,7 +125,7 @@ class CallbackContext:
 
         setattr(flask.g, "timing_information", timing_information)
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def using_args_grouping(self):
         """
@@ -134,7 +134,7 @@ class CallbackContext:
         """
         return getattr(flask.g, "using_args_grouping", [])
 
-    @property
+    @property  # type: ignore[misc]
     @has_context
     def using_outputs_grouping(self):
         """

--- a/dash/_configs.py
+++ b/dash/_configs.py
@@ -1,11 +1,12 @@
 import os
+from typing import Union, Optional, Tuple
 
 # noinspection PyCompatibility
 from . import exceptions
 from ._utils import AttributeDict
 
 
-def load_dash_env_vars():
+def load_dash_env_vars() -> AttributeDict:
     return AttributeDict(
         {
             var: os.getenv(var, os.getenv(var.lower()))
@@ -40,7 +41,9 @@ def load_dash_env_vars():
 DASH_ENV_VARS = load_dash_env_vars()  # used in tests
 
 
-def get_combined_config(name, val, default=None):
+def get_combined_config(
+    name: str, val: Optional[Union[bool, str]], default: Union[bool, str] = None
+) -> Optional[Union[bool, str]]:
     """Consolidate the config with priority from high to low provided init
     value > OS environ > default."""
 
@@ -55,8 +58,10 @@ def get_combined_config(name, val, default=None):
 
 
 def pathname_configs(
-    url_base_pathname=None, routes_pathname_prefix=None, requests_pathname_prefix=None
-):
+    url_base_pathname: str = None,
+    routes_pathname_prefix: str = None,
+    requests_pathname_prefix: str = None,
+) -> Tuple[str, str, str]:
     _pathname_config_error_message = """
     {} This is ambiguous.
     To fix this, set `routes_pathname_prefix` instead of `url_base_pathname`.

--- a/dash/_grouping.py
+++ b/dash/_grouping.py
@@ -46,7 +46,7 @@ def flatten_grouping(grouping, schema=None):
     return [grouping]
 
 
-def grouping_len(grouping):
+def grouping_len(grouping) -> int:
     """
     Get the length of a grouping. The length equal to the number of scalar values
     contained in the grouping, which is equivalent to the length of the list that would

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -9,6 +9,8 @@ import logging
 import io
 import json
 from functools import wraps
+from typing import Dict
+
 from . import exceptions
 
 logger = logging.getLogger()
@@ -21,7 +23,7 @@ def to_json(value):
     return to_json_plotly(value)
 
 
-def interpolate_str(template, **data):
+def interpolate_str(template, **data) -> str:
     s = template
     for k, v in data.items():
         key = "{%" + k + "%}"
@@ -29,7 +31,13 @@ def interpolate_str(template, **data):
     return s
 
 
-def format_tag(tag_name, attributes, inner="", closed=False, opened=False):
+def format_tag(
+    tag_name: str,
+    attributes: Dict[str, str],
+    inner: str = "",
+    closed: bool = False,
+    opened: bool = False,
+) -> str:
     tag = "<{tag} {attributes}"
     if closed:
         tag += "/>"

--- a/dash/_watch.py
+++ b/dash/_watch.py
@@ -2,18 +2,24 @@ import collections
 import os
 import re
 import time
+from typing import List, Callable, DefaultDict
 
 
-def watch(folders, on_change, pattern=None, sleep_time=0.1):
-    pattern = re.compile(pattern) if pattern else None
-    watched = collections.defaultdict(lambda: -1)
+def watch(
+    folders: List[str],
+    on_change: Callable,
+    pattern: str = None,
+    sleep_time: float = 0.1,
+) -> None:
+    compiled_pattern = re.compile(pattern) if pattern else None
+    watched: DefaultDict[str, float] = collections.defaultdict(lambda: -1)
 
-    def walk():
+    def walk() -> None:
         walked = []
         for folder in folders:
             for current, _, files in os.walk(folder):
                 for f in files:
-                    if pattern and not pattern.search(f):
+                    if compiled_pattern and not compiled_pattern.search(f):
                         continue
                     path = os.path.join(current, f)
 

--- a/dash/exceptions.py
+++ b/dash/exceptions.py
@@ -2,7 +2,7 @@ from textwrap import dedent
 
 
 class DashException(Exception):
-    def __init__(self, msg=""):
+    def __init__(self, msg: str = "") -> None:
         super().__init__(dedent(msg).strip())
 
 

--- a/dash/fingerprint.py
+++ b/dash/fingerprint.py
@@ -1,10 +1,11 @@
 import re
+from typing import Tuple
 
 cache_regex = re.compile(r"^v[\w-]+m[0-9a-fA-F]+$")
 version_clean = re.compile(r"[^\w-]")
 
 
-def build_fingerprint(path, version, hash_value):
+def build_fingerprint(path: str, version: str, hash_value: str) -> str:
     path_parts = path.split("/")
     filename, extension = path_parts[-1].split(".", 1)
 
@@ -16,7 +17,7 @@ def build_fingerprint(path, version, hash_value):
     )
 
 
-def check_fingerprint(path):
+def check_fingerprint(path: str) -> Tuple[str, bool]:
     path_parts = path.split("/")
     name_parts = path_parts[-1].split(".")
 

--- a/dash/py.typed
+++ b/dash/py.typed
@@ -1,0 +1,1 @@
+# Marker file to indicate that this package supports typing, ref PEP 561

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,43 @@
+# Global options
+
+[mypy]
+ignore_missing_imports = True
+disallow_untyped_defs = True
+show_error_codes = True
+
+#########################
+
+[mypy-dash.development.*]
+ignore_errors=True
+
+[mypy-dash.testing.*]
+ignore_errors=True
+
+[mypy-dash.dash]
+ignore_errors=True
+
+[mypy-dash.resources]
+ignore_errors=True
+
+[mypy-dash._callback_context]
+ignore_errors=True
+
+[mypy-dash._validate]
+ignore_errors=True
+
+[mypy-dash.dependencies]
+ignore_errors=True
+
+#########################
+
+[mypy-dash.html.*]
+ignore_errors=True
+
+[mypy-dash.dcc.*]
+ignore_errors=True
+
+[mypy-dash.dash_table.*]
+ignore_errors=True
+
+[mypy-dash.long_callback.managers.*]
+ignore_errors=True

--- a/requires-dev.txt
+++ b/requires-dev.txt
@@ -11,3 +11,4 @@ coloredlogs==15.0.1
 flask-talisman==0.8.1
 orjson==3.3.1;python_version<"3.7"
 orjson==3.6.1;python_version>="3.7"
+mypy==0.910


### PR DESCRIPTION
With Python 2 dropped, we would love to see Dash type hinted. Benefits:

- Wrong usage of the `dash` package APIs can be captured using `mypy` when writing Dash apps, even directly in editors.
- Easier to help with community PRs (easier to read code that is type hinted).
- It is a prerequisite to later take a look at a killer feature: Type hint/editor help on props in the `TypeScript/ReactProp` ↔ `mypy`/Python hint border: https://github.com/plotly/dash/issues/719#issuecomment-844406378.

Type hinted code base will also make it easier for Plotly to onboard new developers to `plotly/dash`. And it well help you detect type flow issues/bugs in the Python code not already covered (so far I found two type issues).

Happy to take this further if interest. What do you think @alexcjohnson et al.?