### PR TITLE
data-table: fixes warning about missing key prop

### DIFF
--- a/components/dash-table/CHANGELOG.md
+++ b/components/dash-table/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Fixed
+- [#1778](https://github.com/plotly/dash/pull/1778) Fix React warnings stating
+  that each child in a list should have a unique "key" prop
+
 ## [4.12.0] - 2021-07-09
 ### Fixed
 - [#907](https://github.com/plotly/dash-table/pull/907)

--- a/components/dash-table/demo/index.html
+++ b/components/dash-table/demo/index.html
@@ -5,8 +5,8 @@
     </head>
     <body>
         <div id='root'></div>
-        <script src='https://unpkg.com/react@17.0.1/umd/react.production.min.js'></script>
-        <script src='https://unpkg.com/react-dom@17.0.1/umd/react-dom.production.min.js'></script>
+        <script src='https://unpkg.com/react@16.14.0/umd/react.development.js'></script>
+        <script src='https://unpkg.com/react-dom@16.14.0/umd/react-dom.development.js'></script>
 
         <script src="./demo.js"></script>
     </body>

--- a/components/dash-table/src/dash-table/derived/header/content.tsx
+++ b/components/dash-table/src/dash-table/derived/header/content.tsx
@@ -283,7 +283,7 @@ function getter(
                         );
 
                     return (
-                        <div>
+                        <div key={columnIndex}>
                             {!column_selectable || !selectable ? null : (
                                 <span className='column-header--select'>
                                     <input

--- a/components/dash-table/tests/selenium/test_header.py
+++ b/components/dash-table/tests/selenium/test_header.py
@@ -127,3 +127,18 @@ def test_head004_change_single_row_header(test):
 
     assert target.column("rows").get_text(0) == "Chill"
     assert test.get_log_errors() == []
+
+
+def test_head005_no_warnings_emitted(test):
+    test.start_server(
+        get_app(dict(merge_duplicate_headers=True)),
+        debug=True,
+        use_reloader=False,
+        use_debugger=True,
+        dev_tools_hot_reload=False,
+    )
+
+    target = test.table("table")
+
+    wait.until(lambda: target.column(6).get().get_attribute("colspan") == "4", 3)
+    assert test.get_logs() == []


### PR DESCRIPTION
Closes https://github.com/plotly/dash-table/issues/860 and potentially https://github.com/plotly/dash/issues/1433

As pointed out in https://github.com/plotly/dash-table/pull/690#issue-565576435, in order to see the warnings on the demo page, we need to use React's dev bundles (see https://github.com/plotly/dash/commit/3eac50a0e07dbad395c5d56149126a0e941a8cb0). I also changed the version of the React bundle to match the one used in `package-lock.json`. I don't know if this should stay in the PR but @chabb made a good argument for it to stay in.

The fix itself can be found in https://github.com/plotly/dash/commit/a25cca92254c34ff82cafe38d9e591703f465cda. It adds the one missing `key` prop. After this commit, the missing key warning disappears in the demo page!

cc @alexcjohnson 

## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
