### PR TITLE
Serialization and Percy updates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,9 +367,9 @@ jobs:
           name: 🧪 Run Integration Tests
           command: |
             . venv/bin/activate && rm -rf dash_core_components && ls -la
+            pip install --upgrade pip wheel
             set -eo pipefail
             pip install dash-package/dash-package.tar.gz[dev,testing]
-            pip uninstall orjson -y
             pip list | grep dash | xargs pip show
             echo $(python -V 2>&1) | grep 3.
             TESTFILES=$(circleci tests glob "tests/integration/**/test_*.py" | circleci tests split --split-by=timings)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
           password: $DASH_PAT_DOCKERHUB
         environment:
           PYVERSION: python39
+          PERCY_ENABLE: 0
     steps:
       - checkout
       - run: echo $PYVERSION > ver.txt
@@ -34,6 +35,7 @@ jobs:
         environment:
           PYLINTRC: .pylintrc39
           PYVERSION: python39
+          PERCY_ENABLE: 0
 
     steps:
       - checkout
@@ -65,6 +67,7 @@ jobs:
         environment:
           PYLINTRC: .pylintrc39
           PYVERSION: python39
+          PERCY_ENABLE: 0
 
     steps:
       - checkout
@@ -106,78 +109,7 @@ jobs:
         environment:
           PYLINTRC: .pylintrc
           PYVERSION: python36
-
-  build-core-39: &build-core
-    working_directory: ~/dash
-    docker:
-      - image: circleci/python:3.9.2-buster-node-browsers
-        auth:
-          username: dashautomation
-          password: $DASH_PAT_DOCKERHUB
-        environment:
-          PYVERSION: python39
-    steps:
-      - checkout
-      - run: echo $PYVERSION > ver.txt
-      - restore_cache:
-          key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "requires-dev.txt" }}-{{ checksum "requires-install.txt" }}-{{ checksum "requires-testing.txt" }}
-      - run:
-          name: ️🏗️ pip dev requirements
-          command: |
-            python -m venv venv && . venv/bin/activate
-            pip install --upgrade pip wheel
-            sed -i '/dash-/d' requires-install.txt
-            pip install -e . --no-cache-dir -r requires-install.txt -r requires-dev.txt -r requires-testing.txt --progress-bar off
-      - save_cache:
-          key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "requires-dev.txt" }}-{{ checksum "requires-install.txt" }}-{{ checksum "requires-testing.txt" }}
-          paths:
-            - venv
-
-  build-core-36:
-    <<: *build-core
-    docker:
-      - image: circleci/python:3.6.13-stretch-node-browsers
-        auth:
-          username: dashautomation
-          password: $DASH_PAT_DOCKERHUB
-        environment:
-          PYVERSION: python36
-
-  build-misc-39: &build-misc
-    working_directory: ~/dash
-    docker:
-      - image: circleci/python:3.9.2-buster-node-browsers
-        auth:
-          username: dashautomation
-          password: $DASH_PAT_DOCKERHUB
-        environment:
-          PYVERSION: python39
-
-    steps:
-      - checkout
-      - run: echo $PYVERSION > ver.txt
-      - restore_cache:
-          key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "requires-dev.txt" }}-{{ checksum "requires-install.txt" }}-{{ checksum "requires-testing.txt" }}
-      - run:
-          name: ️️🏗️ pip dev requirements
-          command: |
-            python -m venv venv && . venv/bin/activate
-            pip install --upgrade pip wheel
-            pip install -e . --no-cache-dir -r requires-install.txt -r requires-dev.txt -r requires-testing.txt --progress-bar off
-      - save_cache:
-          key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "requires-dev.txt" }}-{{ checksum "requires-install.txt" }}-{{ checksum "requires-testing.txt" }}
-          paths:
-            - venv
-
-  build-misc-36:
-    <<: *build-misc
-    docker:
-      - image: circleci/python:3.6.13-stretch-node-browsers
-        auth:
-          username: dashautomation
-          password: $DASH_PAT_DOCKERHUB
-        environment:
-          PYVERSION: python36
+          PERCY_ENABLE: 0
 
   build-windows-39:
     working_directory: ~/dash
@@ -186,6 +118,7 @@ jobs:
       shell: bash.exe
     environment:
       PYVERSION: python39
+      PERCY_ENABLE: 0
     steps:
       - checkout
       - run: echo $PYVERSION > ver.txt
@@ -247,11 +180,12 @@ jobs:
           password: $DASH_PAT_DOCKERHUB
         environment:
           PERCY_ENABLE: 0
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: True
           PYVERSION: python36
           REDIS_URL: redis://localhost:6379
       - image: circleci/redis
 
-  dcc-lint-unit-39: &lint-unit
+  dcc-lint-unit-39: &dcc-lint-unit
     working_directory: ~/dash/components/dash-core-components
     docker:
       - image: circleci/python:3.9.2-buster-node-browsers
@@ -260,9 +194,10 @@ jobs:
           password: $DASH_PAT_DOCKERHUB
         environment:
           PYTHON_VERSION: py39
+          PERCY_ENABLE: 0
     steps:
       - checkout:
-            path: ~/dash
+          path: ~/dash
       - run: echo $PYTHON_VERSION > ver.txt
       - restore_cache:
           key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "dev-requirements.txt" }}
@@ -278,7 +213,7 @@ jobs:
       - save_cache:
           key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "dev-requirements.txt" }}
           paths:
-              - venv
+            - venv
       - run:
           name: 🌸 Lint
           command: |
@@ -288,7 +223,7 @@ jobs:
             npm run lint
 
   dcc-lint-unit-36:
-    <<: *lint-unit
+    <<: *dcc-lint-unit
     docker:
       - image: circleci/python:3.6.13-stretch-node-browsers
         auth:
@@ -296,8 +231,9 @@ jobs:
           password: $DASH_PAT_DOCKERHUB
         environment:
           PYTHON_VERSION: py36
+          PERCY_ENABLE: 0
 
-  dcc-build-dash-39: &build-dash
+  dcc-build-dash-39: &dcc-build-dash
     working_directory: ~/dash/components/dash-core-components
     docker:
       - image: circleci/python:3.9.2-buster-node-browsers
@@ -305,10 +241,11 @@ jobs:
           username: dashautomation
           password: $DASH_PAT_DOCKERHUB
         environment:
-            PYTHON_VERSION: py39
+          PYTHON_VERSION: py39
+          PERCY_ENABLE: 0
     steps:
       - checkout:
-            path: ~/dash
+          path: ~/dash
       - run: echo $PYTHON_VERSION > ver.txt
       - restore_cache:
           key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "dev-requirements.txt" }}
@@ -322,7 +259,7 @@ jobs:
       - save_cache:
           key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "dev-requirements.txt" }}
           paths:
-              - venv
+            - venv
       - attach_workspace:
           at: ~/dash/components/dash-core-components
       - run:
@@ -334,7 +271,7 @@ jobs:
             pip install dash-package/dash-package.tar.gz[dev,testing]
 
   dcc-build-dash-36:
-    <<: *build-dash
+    <<: *dcc-build-dash
     docker:
       - image: circleci/python:3.6.13-stretch-node-browsers
         auth:
@@ -342,8 +279,9 @@ jobs:
           password: $DASH_PAT_DOCKERHUB
         environment:
           PYTHON_VERSION: py36
+          PERCY_ENABLE: 0
 
-  dcc-test-39: &test
+  dcc-test-39: &dcc-test
     working_directory: ~/dash/components/dash-core-components
     docker:
       - image: circleci/python:3.9.2-buster-node-browsers
@@ -351,13 +289,13 @@ jobs:
           username: dashautomation
           password: $DASH_PAT_DOCKERHUB
         environment:
-            PYTHON_VERSION: py39
-            PERCY_PARALLEL_TOTAL: -1
-            PERCY_ENABLE: 1
+          PYTHON_VERSION: py39
+          PERCY_PARALLEL_TOTAL: -1
+          PERCY_ENABLE: 1
     parallelism: 3
     steps:
       - checkout:
-            path: ~/dash
+          path: ~/dash
       - run: echo $PYTHON_VERSION > ver.txt
       - restore_cache:
           key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "dev-requirements.txt" }}
@@ -382,7 +320,7 @@ jobs:
           path: /tmp/dash_artifacts
 
   dcc-test-36:
-    <<: *test
+    <<: *dcc-test
     docker:
       - image: circleci/python:3.6.13-stretch-node-browsers
         auth:
@@ -392,62 +330,8 @@ jobs:
           PYTHON_VERSION: py36
           PERCY_ENABLE: 0
 
-  html-python-36: &test-template
+  html-python-39: &html-test
     working_directory: ~/dash/components/dash-html-components
-    docker:
-      - image: circleci/python:3.6.13-stretch-node-browsers
-        auth:
-          username: dashautomation
-          password: $DASH_PAT_DOCKERHUB
-        environment:
-          PYTHON_VERSION: py36
-          PERCY_ENABLE: 0
-
-    steps:
-      - checkout:
-            path: ~/dash
-
-      - attach_workspace:
-          at: ~/dash/components/dash-html-components
-
-      - run:
-          name: ✍️ Write job name
-          command: echo $CIRCLE_JOB > circlejob.txt
-
-      - run:
-          name: 🏗️ Install dependencies
-          command: |
-              python -m venv venv
-              . venv/bin/activate
-              pip install --upgrade pip wheel
-              pip install dash-package/dash-package.tar.gz[dev,testing]
-              pip install -r dev-requirements.txt
-              npm ci
-
-      - run:
-          name: 🧰 Build
-          command: |
-              . venv/bin/activate
-              python --version
-              npm run clean
-              npm run build
-
-      - run:
-          name: 🧪 Run tests
-          command: |
-              . venv/bin/activate
-              python --version
-              npm run test
-
-      - store_artifacts:
-          path: ~/dash/components/dash-html-components/test-reports
-      - store_test_results:
-          path: ~/dash/components/dash-html-components/test-reports
-      - store_artifacts:
-          path: /tmp/dash_artifacts
-
-  html-python-39:
-    <<: *test-template
     docker:
       - image: circleci/python:3.9.2-buster-node-browsers
         auth:
@@ -458,191 +342,241 @@ jobs:
           PERCY_ENABLE: 1
           PERCY_PARALLEL_TOTAL: -1
 
+    steps:
+      - checkout:
+          path: ~/dash
+
+      - attach_workspace:
+          at: ~/dash/components/dash-html-components
+
+      - run:
+          name: 🏗️ Install dependencies
+          command: |
+            python -m venv venv
+            . venv/bin/activate
+            pip install --upgrade pip wheel
+            pip install dash-package/dash-package.tar.gz[dev,testing]
+            pip install -r dev-requirements.txt
+            npm ci
+
+      - run:
+          name: 🧰 Build
+          command: |
+            . venv/bin/activate
+            python --version
+            npm run clean
+            npm run build
+
+      - run:
+          name: 🧪 Run tests
+          command: |
+            . venv/bin/activate
+            python --version
+            npm run test
+
+      - store_artifacts:
+          path: ~/dash/components/dash-html-components/test-reports
+      - store_test_results:
+          path: ~/dash/components/dash-html-components/test-reports
+      - store_artifacts:
+          path: /tmp/dash_artifacts
+
+  html-python-36:
+    <<: *html-test
+    docker:
+      - image: circleci/python:3.6.13-stretch-node-browsers
+        auth:
+          username: dashautomation
+          password: $DASH_PAT_DOCKERHUB
+        environment:
+          PYTHON_VERSION: py36
+          PERCY_ENABLE: 0
+
   table-server-test:
-      working_directory: ~/dash/components/dash-table
-      docker:
-          - image: circleci/python:3.9.2-buster-node-browsers
-            environment:
-              PERCY_ENABLE: 1
-              PERCY_PARALLEL_TOTAL: -1
+    working_directory: ~/dash/components/dash-table
+    docker:
+      - image: circleci/python:3.9.2-buster-node-browsers
+        environment:
+          PERCY_ENABLE: 1
+          PERCY_PARALLEL_TOTAL: -1
 
-      parallelism: 4
+    parallelism: 4
 
-      steps:
-          - checkout:
-                  path: ~/dash
-          - run:
-              name: Inject Percy Environment variables
-              command: |
-                echo 'export PERCY_TOKEN="$PERCY_TOKEN"' >> $BASH_ENV
-          - restore_cache:
-              key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
-          - attach_workspace:
-              at: ~/dash/components/dash-table
-          - run:
-              name: Install npm packages
-              command: npm ci
-          - save_cache:
-              key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
-              paths:
-                  - node_modules
-          - run:
-              name: Install requirements
-              command: |
-                  python -m venv venv
-                  . venv/bin/activate
-                  pip install -r dev-requirements.txt --quiet
-                  pip install -r python-requirements.txt --quiet
-                  pip install dash-package/dash-package.tar.gz[dev,testing]
-          - run:
-              name: Build
-              command: |
-                  . venv/bin/activate
-                  npm run private::build:js-test
-                  npm run private::build:backends
-          - run:
-              name: Run tests
-              command: |
-                  . venv/bin/activate
-                  TESTFILES=$(circleci tests glob "tests/selenium/**/test_*.py" | circleci tests split --split-by=timings)
-                  pytest --nopercyfinalize --junitxml=test-reports/junit_intg.xml ${TESTFILES}
-          - store_artifacts:
-              path: ~/dash/components/dash-table/test-reports
-          - store_test_results:
-              path: ~/dash/components/dash-table/test-reports
-          - store_artifacts:
-              path: /tmp/dash_artifacts
+    steps:
+      - checkout:
+          path: ~/dash
+      - run:
+          name: Inject Percy Environment variables
+          command: |
+            echo 'export PERCY_TOKEN="$PERCY_TOKEN"' >> $BASH_ENV
+      - restore_cache:
+          key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
+      - attach_workspace:
+          at: ~/dash/components/dash-table
+      - run:
+          name: Install npm packages
+          command: npm ci
+      - save_cache:
+          key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
+          paths:
+            - node_modules
+      - run:
+          name: Install requirements
+          command: |
+            python -m venv venv
+            . venv/bin/activate
+            pip install -r dev-requirements.txt --quiet
+            pip install -r python-requirements.txt --quiet
+            pip install dash-package/dash-package.tar.gz[dev,testing]
+      - run:
+          name: Build
+          command: |
+            . venv/bin/activate
+            npm run private::build:js-test
+            npm run private::build:backends
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            TESTFILES=$(circleci tests glob "tests/selenium/**/test_*.py" | circleci tests split --split-by=timings)
+            pytest --nopercyfinalize --junitxml=test-reports/junit_intg.xml ${TESTFILES}
+      - store_artifacts:
+          path: ~/dash/components/dash-table/test-reports
+      - store_test_results:
+          path: ~/dash/components/dash-table/test-reports
+      - store_artifacts:
+          path: /tmp/dash_artifacts
 
   table-unit-test:
-      working_directory: ~/dash/components/dash-table
-      docker:
-          - image: circleci/python:3.9.2-buster-node-browsers
-      steps:
-          - checkout:
-                  path: ~/dash
-          - restore_cache:
-              key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
-          - run:
-              name: Install npm packages
-              command: npm ci
-          - save_cache:
-              key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
-              paths:
-                  - node_modules
-          - attach_workspace:
-              at: ~/dash/components/dash-table
-          - run:
-              name: Install requirements
-              command: |
-                  python -m venv venv
-                  . venv/bin/activate
-                  pip install -r dev-requirements.txt --quiet
-                  pip install dash-package/dash-package.tar.gz[dev,testing]
-          - run:
-              name: Run tests
-              command: |
-                  . venv/bin/activate
-                  npm run test.unit
+    working_directory: ~/dash/components/dash-table
+    docker:
+      - image: circleci/python:3.9.2-buster-node-browsers
+        environment:
+          PERCY_ENABLE: 0
+    steps:
+      - checkout:
+          path: ~/dash
+      - restore_cache:
+          key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
+      - run:
+          name: Install npm packages
+          command: npm ci
+      - save_cache:
+          key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}-{{ checksum ".circleci/config.yml" }}
+          paths:
+            - node_modules
+      - attach_workspace:
+          at: ~/dash/components/dash-table
+      - run:
+          name: Install requirements
+          command: |
+            python -m venv venv
+            . venv/bin/activate
+            pip install -r dev-requirements.txt --quiet
+            pip install dash-package/dash-package.tar.gz[dev,testing]
+      - run:
+          name: Run tests
+          command: |
+            . venv/bin/activate
+            npm run test.unit
 
   table-visual-test:
-      working_directory: ~/dash/components/dash-table
-      docker:
-          - image: circleci/node:14-browsers
-            environment:
-              PERCY_TOKEN: $PERCY_TOKEN_TABLE
+    working_directory: ~/dash/components/dash-table
+    docker:
+      - image: circleci/node:14-browsers
+        environment:
+          PERCY_TOKEN: $PERCY_TOKEN_TABLE
 
-      steps:
-          - checkout:
-                  path: ~/dash
-          - restore_cache:
-              key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}
-          - run:
-              name: Install package.json
-              command: npm ci
-          - save_cache:
-              key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}
-              paths:
-                  - node_modules
-          - run:
-              name: Run build:js
-              command: npm run private::build:js
-          - run:
-              name: Run visual tests
-              command: PERCY_TOKEN=$PERCY_TOKEN_TABLE npm run test.visual
-          - store_artifacts:
-              path: storybook-static
+    steps:
+      - checkout:
+          path: ~/dash
+      - restore_cache:
+          key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}
+      - run:
+          name: Install package.json
+          command: npm ci
+      - save_cache:
+          key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - run:
+          name: Run build:js
+          command: npm run private::build:js
+      - run:
+          name: Run visual tests
+          command: PERCY_TOKEN=$PERCY_TOKEN_TABLE npm run test.visual
+      - store_artifacts:
+          path: storybook-static
 
   table-node:
-      working_directory: ~/dash/components/dash-table
-      docker:
-          - image: circleci/python:3.9.2-node
-      steps:
-          - checkout:
-                  path: ~/dash
-          - run:
-                name: Create virtual env
-                command: python -m venv venv
-          - restore_cache:
-              key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}
-          - run:
-              name: Install package.json
-              command: npm ci
-          - save_cache:
-              key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}
-              paths:
-                  - node_modules
-          - attach_workspace:
-              at: ~/dash/components/dash-table
-          - run:
-              name: Install requirements
-              command: |
-                  . venv/bin/activate
-                  pip install -r dev-requirements.txt --quiet
-                  pip install dash-package/dash-package.tar.gz[dev,testing]
+    working_directory: ~/dash/components/dash-table
+    docker:
+      - image: circleci/python:3.9.2-node
+        environment:
+          PERCY_ENABLE: 0
+    steps:
+      - checkout:
+          path: ~/dash
+      - run:
+          name: Create virtual env
+          command: python -m venv venv
+      - restore_cache:
+          key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}
+      - run:
+          name: Install package.json
+          command: npm ci
+      - save_cache:
+          key: dep-{{ .Branch }}-{{ checksum "package-lock.json" }}-{{ checksum "package.json" }}
+          paths:
+            - node_modules
+      - attach_workspace:
+          at: ~/dash/components/dash-table
+      - run:
+          name: Install requirements
+          command: |
+            . venv/bin/activate
+            pip install -r dev-requirements.txt --quiet
+            pip install dash-package/dash-package.tar.gz[dev,testing]
 
-          - run:
-              name: Run eslint
-              command: |
-                  . venv/bin/activate
-                  npm run lint
-              when: always
+      - run:
+          name: Run eslint
+          command: |
+            . venv/bin/activate
+            npm run lint
+          when: always
 
 workflows:
   version: 2
-  dash-python3.9:
+  tests:
     jobs:
       - install-dependencies
-      - lint-unit-39
-      - build-core-39
+
       - build-windows-39
-      - build-misc-39
 
-
-  dash-python3.6:
-    jobs:
-      - install-dependencies
+      - lint-unit-39
       - lint-unit-36
-      - build-core-36
-      - build-misc-36
+
+      - test-39:
+          requires:
+            - install-dependencies
       - test-36:
           requires:
             - install-dependencies
-            - build-core-36
-            - build-misc-36
 
-  dcc-python3.9:
-    jobs:
-      - install-dependencies
       - dcc-lint-unit-39:
           requires:
             - install-dependencies
-
-  dcc-python3.6:
-    jobs:
-      - install-dependencies
       - dcc-lint-unit-36:
           requires:
             - install-dependencies
+
+      - dcc-build-dash-39:
+          requires:
+            - install-dependencies
+      - dcc-test-39:
+          requires:
+            - install-dependencies
+            - dcc-build-dash-39
       - dcc-build-dash-36:
           requires:
             - install-dependencies
@@ -651,58 +585,37 @@ workflows:
             - install-dependencies
             - dcc-build-dash-36
 
-  html-build:
-    jobs:
-      - install-dependencies
+      - html-python-39:
+          requires:
+            - install-dependencies
       - html-python-36:
           requires:
             - install-dependencies
 
+      - table-node:
+          requires:
+            - install-dependencies
+      - table-unit-test:
+          requires:
+            - install-dependencies
+      - table-visual-test
+      - table-server-test:
+          requires:
+            - install-dependencies
 
-  table-build:
-      jobs:
-          - install-dependencies
-          - table-node:
-              requires:
-                - install-dependencies
-          - table-unit-test:
-              requires:
-                - install-dependencies
-          - table-visual-test
-
-  percy-tests:
-      jobs:
-          - install-dependencies
-          - percy/finalize_all:
-              requires:
-                - test-39
-                - dcc-test-39
-                - html-python-39
-                - table-server-test
-          - artifacts:
-              requires:
-                - percy/finalize_all
-              filters:
-                branches:
-                  only:
-                    - master
-                    - dev
-                tags:
-                  only: /v*/
-          - test-39:
-              requires:
-                - install-dependencies
-
-          - table-server-test:
-              requires:
-                - install-dependencies
-          - html-python-39:
-              requires:
-                - install-dependencies
-          - dcc-build-dash-39:
-              requires:
-                - install-dependencies
-          - dcc-test-39:
-              requires:
-                - install-dependencies
-                - dcc-build-dash-39
+      - percy/finalize_all:
+          requires:
+            - test-39
+            - dcc-test-39
+            - html-python-39
+            - table-server-test
+      - artifacts:
+          requires:
+            - percy/finalize_all
+          filters:
+            branches:
+              only:
+                - master
+                - dev
+            tags:
+              only: /v*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ jobs:
       - run:
           name: 🏁 Build Component Packages & Update Dependencies/Artifacts
           command: |
-            sudo pip install virtualenv --upgrade
             python -m venv venv && . venv/bin/activate
+            pip install --upgrade pip wheel
             set -eo pipefail
             pip install -e .[testing,dev] --progress-bar off && pip list | grep dash
             npm i
@@ -74,8 +74,8 @@ jobs:
       - run:
           name: ️️🏗️ pip dev requirements
           command: |
-            sudo pip install --upgrade virtualenv --progress-bar off
-            python -m venv venv || virtualenv venv && . venv/bin/activate
+            python -m venv venv && . venv/bin/activate
+            pip install --upgrade pip wheel
             pip install -e . --no-cache-dir -r requires-install.txt -r requires-dev.txt -r requires-testing.txt --progress-bar off
       - save_cache:
           key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "requires-dev.txt" }}-{{ checksum "requires-install.txt" }}-{{ checksum "requires-testing.txt" }}
@@ -124,8 +124,8 @@ jobs:
       - run:
           name: ️🏗️ pip dev requirements
           command: |
-            sudo pip install --upgrade virtualenv
-            python -m venv venv || virtualenv venv && . venv/bin/activate
+            python -m venv venv && . venv/bin/activate
+            pip install --upgrade pip wheel
             sed -i '/dash-/d' requires-install.txt
             pip install -e . --no-cache-dir -r requires-install.txt -r requires-dev.txt -r requires-testing.txt --progress-bar off
       - save_cache:
@@ -161,8 +161,8 @@ jobs:
       - run:
           name: ️️🏗️ pip dev requirements
           command: |
-            sudo pip install --upgrade virtualenv --quiet
-            python -m venv venv || virtualenv venv && . venv/bin/activate
+            python -m venv venv && . venv/bin/activate
+            pip install --upgrade pip wheel
             pip install -e . --no-cache-dir -r requires-install.txt -r requires-dev.txt -r requires-testing.txt --progress-bar off
       - save_cache:
           key: dep-{{ checksum ".circleci/config.yml" }}-{{ checksum "ver.txt" }}-{{ checksum "requires-dev.txt" }}-{{ checksum "requires-install.txt" }}-{{ checksum "requires-testing.txt" }}
@@ -271,8 +271,8 @@ jobs:
       - run:
           name: 🐍 pip dev requirements
           command: |
-            sudo pip install virtualenv --upgrade
-            python -m venv venv || virtualenv venv && . venv/bin/activate
+            python -m venv venv && . venv/bin/activate
+            pip install --upgrade pip wheel
             pip install dash-package/dash-package.tar.gz[dev,testing]
             pip install --progress-bar off --no-cache-dir -r dev-requirements.txt
       - save_cache:
@@ -315,8 +315,8 @@ jobs:
       - run:
           name: 🐍 pip dev requirements
           command: |
-            sudo pip install virtualenv --upgrade
-            python -m venv venv || virtualenv venv && . venv/bin/activate
+            python -m venv venv && . venv/bin/activate
+            pip install --upgrade pip wheel
             set -eo pipefail
             pip install --progress-bar off --no-cache-dir -r dev-requirements.txt
       - save_cache:
@@ -417,9 +417,9 @@ jobs:
       - run:
           name: 🏗️ Install dependencies
           command: |
-              sudo pip install virtualenv --upgrade
-              python -m venv venv || virtualenv venv
+              python -m venv venv
               . venv/bin/activate
+              pip install --upgrade pip wheel
               pip install dash-package/dash-package.tar.gz[dev,testing]
               pip install -r dev-requirements.txt
               npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- [#1779](https://github.com/plotly/dash/pull/1779):
+    - Clean up our handling of serialization problems, including fixing `orjson` for Python 3.6
+    - Added the ability for `dash.testing` `percy_snapshot` methods to choose widths to generate.
+
 - [#1763](https://github.com/plotly/dash/pull/1763):
     ## Dash and Dash Renderer
 
@@ -29,7 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     @dash.callback(Output(my_output, 'children'), Input(my_input, 'value'))
     def update(value):
       return f'You have entered {value}'
-      
+
     ```
     ## Dash Core Components
 
@@ -138,7 +142,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     ```python
     dcc.Checklist(inline=True)
     ```
-  
+
 ## [2.0.0] - 2021-08-03
 
 ## Dash and Dash Renderer

--- a/components/dash-table/package.json
+++ b/components/dash-table/package.json
@@ -34,7 +34,7 @@
     "lint": "run-s private::lint.*",
     "test.server": "pytest --nopercyfinalize tests/selenium",
     "test.unit": "run-s private::test.python private::test.unit",
-    "test.visual": "build-storybook && percy-storybook",
+    "test.visual": "build-storybook && percy-storybook --widths=1280",
     "test.visual-local": "build-storybook"
   },
   "author": "Chris Parmer <chris@plotly.com>",

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -106,6 +106,7 @@ class Browser(DashPageMixin):
         convert_canvases=False,
         assert_check=True,
         stay_on_page=False,
+        widths=None,
     ):
         try:
             path = resource_path.lstrip("/")
@@ -119,6 +120,7 @@ class Browser(DashPageMixin):
                 path,
                 wait_for_callbacks=wait_for_callbacks,
                 convert_canvases=convert_canvases,
+                widths=widths,
             )
             if assert_check:
                 assert not self.driver.find_elements_by_css_selector(
@@ -130,10 +132,26 @@ class Browser(DashPageMixin):
             logger.exception("snapshot at resource %s error", path)
             raise e
 
-    def percy_snapshot(self, name="", wait_for_callbacks=False, convert_canvases=False):
+    def percy_snapshot(
+        self, name="", wait_for_callbacks=False, convert_canvases=False, widths=None
+    ):
         """percy_snapshot - visual test api shortcut to `percy_runner.snapshot`.
-        It also combines the snapshot `name` with the Python version.
+        It also combines the snapshot `name` with the Python version,
+        args:
+        - name: combined with the python version to give the final snapshot name
+        - wait_for_callbacks: default False, whether to wait for Dash callbacks,
+            after an extra second to ensure that any relevant callbacks have
+            been initiated
+        - convert_canvases: default False, whether to convert all canvas elements
+            in the DOM into static images for percy to see. They will be restored
+            after the snapshot is complete.
+        - widths: a list of pixel widths for percy to render the page with. Note
+            that this does not change the browser in which the DOM is constructed,
+            so the width will only affect CSS, not JS-driven layout.
+            Defaults to [375, 1280]
         """
+        if widths is None:
+            widths = [375, 1280]
         snapshot_name = "{} - py{}.{}".format(
             name, sys.version_info.major, sys.version_info.minor
         )
@@ -172,7 +190,7 @@ class Browser(DashPageMixin):
             """
             )
 
-            self.percy_runner.snapshot(name=snapshot_name)
+            self.percy_runner.snapshot(name=snapshot_name, widths=widths)
 
             self.driver.execute_script(
                 """
@@ -189,7 +207,7 @@ class Browser(DashPageMixin):
             )
 
         else:
-            self.percy_runner.snapshot(name=snapshot_name)
+            self.percy_runner.snapshot(name=snapshot_name, widths=widths)
 
     def take_snapshot(self, name):
         """Hook method to take snapshot when a selenium test fails. The

--- a/requires-dev.txt
+++ b/requires-dev.txt
@@ -9,5 +9,5 @@ black==21.6b0
 fire==0.4.0
 coloredlogs==15.0.1
 flask-talisman==0.8.1
-orjson==3.3.1;python_version<"3.7"
-orjson==3.6.1;python_version>="3.7"
+orjson==3.5.4;python_version<"3.7"
+orjson==3.6.3;python_version>="3.7"

--- a/tests/unit/dash/test_validate.py
+++ b/tests/unit/dash/test_validate.py
@@ -1,0 +1,38 @@
+import pytest
+
+from dash import Output
+from dash.html import Div
+from dash.exceptions import InvalidCallbackReturnValue
+from dash._validate import fail_callback_output
+
+
+@pytest.mark.parametrize(
+    "val",
+    [
+        {0},
+        [{1}, 1],
+        [1, {2}],
+        Div({3}),
+        Div([{4}]),
+        Div(style={5}),
+        Div([1, {6}]),
+        Div([1, Div({7})]),
+        [Div({8}), 1],
+        [1, Div({9})],
+        [Div(Div({10}))],
+        [Div(Div({11})), 1],
+        [1, Div(Div({12}))],
+        {"a": {13}},
+        Div(style={"a": {14}}),
+        Div(style=[{15}]),
+        [1, Div(style=[{16}])],
+    ],
+)
+def test_ddvl001_fail_handler_fails_correctly(val):
+    if isinstance(val, list):
+        outputs = [Output(f"id{i}", "children") for i in range(len(val))]
+    else:
+        outputs = Output("id", "children")
+
+    with pytest.raises(InvalidCallbackReturnValue):
+        fail_callback_output(val, outputs)


### PR DESCRIPTION
Fixing some issues discovered in updating DDK
- The version of `orjson` we were including in `[dev]` in Py3.6 has problems with numpy string (dtype=object) arrays. Not sure why we pinned this version, but bumping to the latest for each Python minor fixes this.
- Cleaned up our error handling of serialization problems
- Fixed our percy builds, so we only get one per project: one in dash, one in dash-table-test. Along the way I refactored the circleci config into one big workflow and removed some unnecessary jobs.
- Reduced the number of percy snapshots we take for the table (only one width - we do so much in JS that there's no point having multiple widths on Percy's side), and added the ability for `dash.testing` `percy_snapshot` methods to choose widths to generate.

- [x] I have added entry in the `CHANGELOG.md`
