### PR TITLE
webpack-dash-dynamic-import: Don't add JS to chunks created by mini-css-extract-plugin

### DIFF
--- a/@plotly/webpack-dash-dynamic-import/package.json
+++ b/@plotly/webpack-dash-dynamic-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@plotly/webpack-dash-dynamic-import",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Webpack Plugin for Dynamic Import in Dash",
   "repository": {
     "type": "git",

--- a/@plotly/webpack-dash-dynamic-import/src/index.js
+++ b/@plotly/webpack-dash-dynamic-import/src/index.js
@@ -78,6 +78,10 @@ class WebpackDashDynamicImport {
     apply(compiler) {
         compiler.hooks.compilation.tap('WebpackDashDynamicImport', compilation => {
             compilation.mainTemplate.hooks.requireExtensions.tap('WebpackDashDynamicImport > RequireExtensions', (source, chunk, hash) => {
+                // Prevent CSS chunks from having JS appended to them
+                if (chunk.name === 'mini-css-extract-plugin') {
+                    return source;
+                }
                 return source + resolveImportSource();
             });
         });

--- a/@plotly/webpack-dash-dynamic-import/src/index.js
+++ b/@plotly/webpack-dash-dynamic-import/src/index.js
@@ -78,7 +78,7 @@ class WebpackDashDynamicImport {
     apply(compiler) {
         compiler.hooks.compilation.tap('WebpackDashDynamicImport', compilation => {
             compilation.mainTemplate.hooks.requireExtensions.tap('WebpackDashDynamicImport > RequireExtensions', (source, chunk, hash) => {
-                // Prevent CSS chunks from having JS appended to them
+                // Prevent CSS chunks having JS appended
                 if (chunk.name === 'mini-css-extract-plugin') {
                     return source;
                 }


### PR DESCRIPTION
While using the dash-component-boilerplate I was trying to extract my CSS in a separate file but was facing issues as this plugin adds additional content.

The plugin assumes that all chunks are JS chunks but when using mini-css-extract-plugin this isn't the case.

Fortunately mini-css-extract-plugin always names it's chunks the same so this if allowed me to avoid adding that content for this case. There are more involved ways to check the type of the import though so no worries if this doesn't pass muster with you all.

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  Add if condition to check where mini-css-extract-plugin is the chunk name and skip adding content
   -  Increment package.json version
- [] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
  - [] Are there existing tests for this?
