### PR TITLE
Fix #1871

### DIFF
--- a/requires-install.txt
+++ b/requires-install.txt
@@ -4,3 +4,4 @@ plotly>=5.0.0
 dash_html_components==2.0.0
 dash_core_components==2.0.0
 dash_table==5.0.0
+importlib-metadata==4.8.3;python_version<"3.7"


### PR DESCRIPTION
For some reason Py3.6.4 fails to install dash without explicitly pinning importlib-metadata. Hopefully this will help.

Thanks @gfrair for finding this issue!