### PR TITLE
Delayed App Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Changed
+- [#1876](https://github.com/plotly/dash/pull/1876) Delays finalizing `Dash.config` attributes not used in the constructor until `init_app()`.
 - [#1869](https://github.com/plotly/dash/pull/1869), [#1873](https://github.com/plotly/dash/pull/1873) Upgrade Plotly.js to v2.8.3. This includes:
   - [Feature release 2.5.0](https://github.com/plotly/plotly.js/releases/tag/v2.5.0):
     - 3D traces are now compatible with `no-unsafe-eval` CSP rules.

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -446,7 +446,6 @@ class Dash:
             config.routes_pathname_prefix.replace("/", "_"), "dash_assets"
         )
 
-        print(assets_blueprint_name)
         self.server.register_blueprint(
             flask.Blueprint(
                 assets_blueprint_name,

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -361,6 +361,10 @@ class Dash:
             ],
             "Read-only: can only be set in the Dash constructor",
         )
+        self.config.finalize(
+            "Invalid config key. Some settings are only available "
+            "via the Dash constructor"
+        )
 
         # keep title as a class property for backwards compatibility
         self.title = title
@@ -433,10 +437,6 @@ class Dash:
             "Read-only: can only be set in the Dash constructor or during init_app()",
         )
 
-        self.config.finalize(
-            "Invalid config key. Some settings are only available "
-            "via the Dash constructor"
-        )
         config = self.config
 
         if app is not None:

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -356,17 +356,10 @@ class Dash:
                 "assets_folder",
                 "assets_url_path",
                 "eager_loading",
-                "url_base_pathname",
-                "routes_pathname_prefix",
-                "requests_pathname_prefix",
                 "serve_locally",
                 "compress",
             ],
             "Read-only: can only be set in the Dash constructor",
-        )
-        self.config.finalize(
-            "Invalid config key. Some settings are only available "
-            "via the Dash constructor"
         )
 
         # keep title as a class property for backwards compatibility
@@ -427,8 +420,23 @@ class Dash:
 
         self.logger.setLevel(logging.INFO)
 
-    def init_app(self, app=None):
+    def init_app(self, app=None, **kwargs):
         """Initialize the parts of Dash that require a flask app."""
+
+        self.config.update(kwargs)
+        self.config.set_read_only(
+            [
+                "url_base_pathname",
+                "routes_pathname_prefix",
+                "requests_pathname_prefix",
+            ],
+            "Read-only: can only be set in the Dash constructor or during init_app()",
+        )
+
+        self.config.finalize(
+            "Invalid config key. Some settings are only available "
+            "via the Dash constructor"
+        )
         config = self.config
 
         if app is not None:
@@ -438,6 +446,7 @@ class Dash:
             config.routes_pathname_prefix.replace("/", "_"), "dash_assets"
         )
 
+        print(assets_blueprint_name)
         self.server.register_blueprint(
             flask.Blueprint(
                 assets_blueprint_name,

--- a/tests/unit/dash/test_utils.py
+++ b/tests/unit/dash/test_utils.py
@@ -24,12 +24,13 @@ def test_ddut001_attribute_dict():
     assert a.k == 2
     assert a["k"] == 2
 
-    a.set_read_only(["k", "q"], "boo")
+    a.set_read_only(["k"], "boo")
 
     with pytest.raises(AttributeError) as err:
         a.k = 3
     assert err.value.args == ("boo", "k")
     assert a.k == 2
+    assert a._read_only == {"k": "boo"}
 
     with pytest.raises(AttributeError) as err:
         a["k"] = 3
@@ -38,13 +39,11 @@ def test_ddut001_attribute_dict():
 
     a.set_read_only(["q"])
 
-    a.k = 3
-    assert a.k == 3
-
     with pytest.raises(AttributeError) as err:
         a.q = 3
     assert err.value.args == ("Attribute is read-only", "q")
     assert "q" not in a
+    assert a._read_only == {"k": "boo", "q": "Attribute is read-only"}
 
     a.finalize("nope")
 

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -370,3 +370,19 @@ def test_title():
     assert "<title>Hello World</title>" in app.index()
     app = Dash(title="Custom Title")
     assert "<title>Custom Title</title>" in app.index()
+
+
+def test_app_delayed_config():
+    app = Dash(server=False)
+    app.init_app(app=Flask("test"), requests_pathname_prefix="/dash/")
+
+    assert app.config.requests_pathname_prefix == "/dash/"
+
+    with pytest.raises(AttributeError):
+        app.config.name = "cannot update me"
+
+
+def test_app_invalid_delayed_config():
+    app = Dash(server=False)
+    with pytest.raises(AttributeError):
+        app.init_app(app=Flask("test"), name="too late 2 update")


### PR DESCRIPTION
Adds the ability to set/update `Dash.config` attributes via `**kwargs` passed to `Dash.init_app()`.

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  [X] Make AttributeDict additive
   -  [X] Update `Dash.__init__()` and `Dash.init_app()`
- [X] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [X] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

## Alternative Multi-Page App Example

The delayed app config allows app routes to be decoupled from `Dash.__init__()` when `server=False` 

```python
from dash import Dash, html
from flask import Flask

server = Flask(__name__)

app1 = Dash(name='app1', server=False)
app1.layout = html.Div('This is App1')

app2 = Dash(name='app2', server=False)
app2.layout = html.Div('This is App2')

routes = {
    '/dash-app1/': app1,
    '/dash-app2/': app2,
}

for route, app in routes.items():
    app.init_app(server, routes_pathname_prefix=route, requests_pathname_prefix=route)


@server.route('/')
def index():
    return "<p>Hello, World!</p>"

server.run()

```



