### PR TITLE
Delete redundancy in pattern-matching callback resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     ```
 
 ### Fixed
+- [#1879](https://github.com/plotly/dash/pull/1879) Delete redundancy in pattern-matching callback implementation, specifically when `ALL` and `MATCH` wildcards are used together. This patch was submitted by an anonymous Dash Enterprise customer. Many thanks!
+
 - [#1858](https://github.com/plotly/dash/pull/1858) Support `mini-css-extract-plugin` Webpack plugin with `@plotly/webpack-dash-dynamic-import` node package - used by components to support dash async chunks. Updated dependencies of other `@plotly` node packages.
 
 - [#1836](https://github.com/plotly/dash/pull/1836) Fix `__all__` in dcc and table for extras: dcc download helpers and table format helpers. This also restores this functionality to the obsolete top-level packages `dash_core_components` and `dash_table`.
@@ -187,7 +189,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#1779](https://github.com/plotly/dash/pull/1779):
     - Clean up our handling of serialization problems, including fixing `orjson` for Python 3.6
     - Added the ability for `dash.testing` `percy_snapshot` methods to choose widths to generate.
-  
+
 - [#1778](https://github.com/plotly/dash/pull/1778) DataTable: Fix React warnings stating
   that each child in a list should have a unique "key" prop
 

--- a/dash/dash-renderer/src/actions/dependencies.js
+++ b/dash/dash-renderer/src/actions/dependencies.js
@@ -1036,15 +1036,19 @@ function getCallbackByOutput(graphs, paths, id, prop) {
 function addResolvedFromOutputs(callback, outPattern, outs, matches) {
     const out0Keys = Object.keys(outPattern.id).sort();
     const out0PatternVals = props(out0Keys, outPattern.id);
+    const foundCbIds = {};
     outs.forEach(({id: outId}) => {
         const outVals = props(out0Keys, outId);
-        matches.push(
-            makeResolvedCallback(
-                callback,
-                resolveDeps(out0Keys, outVals, out0PatternVals),
-                getAnyVals(out0PatternVals, outVals)
-            )
+        const resolved = makeResolvedCallback(
+            callback,
+            resolveDeps(out0Keys, outVals, out0PatternVals),
+            getAnyVals(out0PatternVals, outVals)
         );
+        const {resolvedId} = resolved;
+        if (!foundCbIds[resolvedId]) {
+            matches.push(resolved);
+            foundCbIds[resolvedId] = true;
+        }
     });
 }
 

--- a/dash/dash-renderer/src/actions/dependencies_ts.ts
+++ b/dash/dash-renderer/src/actions/dependencies_ts.ts
@@ -102,20 +102,23 @@ export function getPriority(
     callback: ICallback
 ): string {
     let callbacks: ICallback[] = [callback];
-    let touchedOutputs: {[key: string]: boolean} = {};
+    const touchedOutputs: {[key: string]: boolean} = {};
+    const touchedCbIds: {[key: string]: boolean} = {};
     const priority: number[] = [];
 
     while (callbacks.length) {
+        callbacks = filter(c => {
+            const touched = touchedCbIds[c.resolvedId];
+            touchedCbIds[c.resolvedId] = true;
+            return touched;
+        }, callbacks);
+
         const outputs = filter(
             o => !touchedOutputs[combineIdAndProp(o)],
             flatten(map(cb => flatten(cb.getOutputs(paths)), callbacks))
         );
 
-        touchedOutputs = reduce(
-            (touched, o) => assoc(combineIdAndProp(o), true, touched),
-            touchedOutputs,
-            outputs
-        );
+        outputs.forEach(o => (touchedOutputs[combineIdAndProp(o)] = true));
 
         callbacks = flatten(
             map(


### PR DESCRIPTION
As noticed by a customer (including the proposed fix in this PR 🙇 ) PMCs bog down unreasonably when `ALL` and `MATCH` are used together. Preliminary testing looks good, and unfortunately I don't see any obvious external symptoms to test - maybe just a large enough instance of this type of PMC that we know it would crash the browser without this patch?

My suspicion is that part of the behavior being fixed here has been present since the beginning of PMCs, but I bet it was made worse when we refactored it and changed part to TypeScript.

- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
- [x] I have added entry in the `CHANGELOG.md`
