### PR TITLE
added page_current to persisted_props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     - `dash[ci]`: mainly for internal use, these are additional requirements for the Dash CI tests, exposed for other component libraries to use a matching configuration.
 
 ### Added
+- [#1883](https://github.com/plotly/dash/pull/1883) in DataTable added `page_current` to `persisted_props` as requested in [#1860](https://github.com/plotly/dash/issues/1860)
+
+
 
 - [#1763](https://github.com/plotly/dash/pull/1763):
     ## Dash and Dash Renderer
@@ -183,6 +186,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#1779](https://github.com/plotly/dash/pull/1779):
     - Clean up our handling of serialization problems, including fixing `orjson` for Python 3.6
     - Added the ability for `dash.testing` `percy_snapshot` methods to choose widths to generate.
+  
+- [#1778](https://github.com/plotly/dash/pull/1778) DataTable: Fix React warnings stating
+  that each child in a list should have a unique "key" prop
 
 ## [2.0.0] - 2021-08-03
 

--- a/components/dash-core-components/CHANGELOG.md
+++ b/components/dash-core-components/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for dash-core-components
 ### NOTE: as of v2.0, changes in dash-core-component are all being recorded in the main dash changelog.
-###This file is kept only for historical purposes.
+### This file is kept only for historical purposes.
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 

--- a/components/dash-core-components/CHANGELOG.md
+++ b/components/dash-core-components/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log for dash-core-components
+### NOTE: as of v2.0, changes in dash-core-component are all being recorded in the main dash changelog.
+###This file is kept only for historical purposes.
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 

--- a/components/dash-html-components/CHANGELOG.md
+++ b/components/dash-html-components/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Change Log for dash-html-components
+### NOTE: as of v2.0, changes in dash-html-components are all being recorded in the main dash changelog.
+###This file is kept only for historical purposes.
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 

--- a/components/dash-html-components/CHANGELOG.md
+++ b/components/dash-html-components/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log for dash-html-components
 ### NOTE: as of v2.0, changes in dash-html-components are all being recorded in the main dash changelog.
-###This file is kept only for historical purposes.
+### This file is kept only for historical purposes.
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 

--- a/components/dash-table/CHANGELOG.md
+++ b/components/dash-table/CHANGELOG.md
@@ -1,15 +1,9 @@
 # Change Log for dash-table
+### NOTE: as of v2.0, changes in dash-table are all being recorded in the main dash changelog.
+### This file is kept only for historical purposes.
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
-
-### Added
-- [#1883](https://github.com/plotly/dash/pull/1883) Add `page_current` to `persisted_props` as requested in [#1860](https://github.com/plotly/dash/issues/1860)
-
-### Fixed
-- [#1778](https://github.com/plotly/dash/pull/1778) Fix React warnings stating
-  that each child in a list should have a unique "key" prop
 
 ## [4.12.0] - 2021-07-09
 ### Fixed

--- a/components/dash-table/CHANGELOG.md
+++ b/components/dash-table/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+
+### Added
+- [#1883](https://github.com/plotly/dash/pull/1883) Add `page_current` to `persisted_props` as requested in [#1860](https://github.com/plotly/dash/issues/1860)
+
 ### Fixed
 - [#1778](https://github.com/plotly/dash/pull/1778) Fix React warnings stating
   that each child in a list should have a unique "key" prop

--- a/components/dash-table/src/dash-table/dash/DataTable.js
+++ b/components/dash-table/src/dash-table/dash/DataTable.js
@@ -101,6 +101,7 @@ export const defaultProps = {
         'columns.name',
         'filter_query',
         'hidden_columns',
+        'page_current',
         'selected_columns',
         'selected_rows',
         'sort_by'
@@ -1537,6 +1538,7 @@ export const propTypes = {
             'data',
             'filter_query',
             'hidden_columns',
+            'page_current',
             'selected_columns',
             'selected_rows',
             'sort_by'


### PR DESCRIPTION
closes #1860 

Adds the `page_current` to the `persisted_props` as requested in #1860