### PR TITLE
Skip check on whether a component is passed as a non-children property.

### DIFF
--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -139,14 +139,6 @@ class Component(metaclass=ComponentMeta):
                     )
                 )
 
-            if k != "children" and isinstance(v, Component):
-                raise TypeError(
-                    error_string_prefix
-                    + " detected a Component for a prop other than `children`\n"
-                    + "Did you forget to wrap multiple `children` in an array?\n"
-                    + "Prop {} has value {}\n".format(k, repr(v))
-                )
-
             if k == "id":
                 if isinstance(v, dict):
                     for id_key, id_val in v.items():


### PR DESCRIPTION
Officially, Dash only supports passing other Dash components via the `children` prop. And for that reason (I guess), a check is being performed in the Python layer (in `base_component.py`) to catch if people try to do it,

```
if k != "children" and isinstance(v, Component):
    raise TypeError(...)
```

However, it _is_ possible to render components passed via non-children properties - in fact I have developed some JS code (available in [dash-extensions-js](https://github.com/thedirtyfew/dash-extensions-js/))  that makes it possible to do it in [a single line of code](https://github.com/snehilvj/dash-mantine-components/blob/9f8c67a369ffc22bf1a79dc8eaf1319f807e2dc6/src/lib/components/Button.react.js#L25). This option dramatiacally improves the development experience and the flexibility of the resulting Dash components allowing stuff like,

```
import dash
import dash_mantine_components as dmc
from dash_iconify import DashIconify as Iconify

app = dash.Dash()
app.layout = dmc.Button(
    "Send Mail", leftIcon=[Iconify(icon="fluent:folder-mail-16-filled")]  # dash component passed as non-children property
)

if __name__ == "__main__":
    app.run_server()
```

![image](https://user-images.githubusercontent.com/1623542/153496935-b61712cb-15ae-486b-856f-f4e3fba80a2e.png)

This code already works with the current version of dash, but **only** because the list wrapping of the `Iconify` component cheats the check listed above. Hence the following code will **not** work with the current version of Dash,

```
import dash
import dash_mantine_components as dmc
from dash_iconify import DashIconify as Iconify

app = dash.Dash()
app.layout = dmc.Button(
    "Send Mail", leftIcon=Iconify(icon="fluent:folder-mail-16-filled")  # dash component passed as non-children property
)

if __name__ == "__main__":
    app.run_server()
```

since the check will be hit. In this PR, I am proposing to remove the check so that the above code will work too.

The main limitation of this approach is that components rendered this way are now known by the dash renderer, so they _cannot be targeted by callbacks_.