### PR TITLE
`get_relative_path, strip_relative_path, get_asset_url`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,7 +111,7 @@ jobs:
             . venv/bin/activate
             set -eo pipefail
             pip install -e . --progress-bar off && pip list | grep dash
-            npm install --production && npm run initialize
+            npm install npm run initialize
             npm run build
             npm run lint
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added 
+- [#1923](https://github.com/plotly/dash/pull/1923):
+- `dash.get_relative_path`
+- `dash.strip_relative_path`
+- `dash.get_asset_url`
+This is similar to `dash.callback` where you don't need the `app` object. It makes it possible to use these
+functions in the `pages` folder of a multi-page app without running into the circular `app` imports issue.
+
+## [2.1.0] - 2022-01-22
+
 ### Changed
 - [#1876](https://github.com/plotly/dash/pull/1876) Delays finalizing `Dash.config` attributes not used in the constructor until `init_app()`.
 - [#1869](https://github.com/plotly/dash/pull/1869), [#1873](https://github.com/plotly/dash/pull/1873) Upgrade Plotly.js to v2.8.3. This includes:

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -21,8 +21,8 @@ from . import dash_table  # noqa: F401,E402
 from .version import __version__  # noqa: F401,E402
 from ._callback_context import callback_context  # noqa: F401,E402
 from ._callback import callback, clientside_callback  # noqa: F401,E402
-from ._get_paths import (
+from ._get_paths import (  # noqa: F401,E402
     get_asset_url,
     get_relative_path,
     strip_relative_path,
-)  # noqa: F401,E402
+)

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -21,3 +21,8 @@ from . import dash_table  # noqa: F401,E402
 from .version import __version__  # noqa: F401,E402
 from ._callback_context import callback_context  # noqa: F401,E402
 from ._callback import callback, clientside_callback  # noqa: F401,E402
+from ._get_paths import (
+    get_asset_url,
+    get_relative_path,
+    strip_relative_path,
+)  # noqa: F401,E402

--- a/dash/_get_paths.py
+++ b/dash/_get_paths.py
@@ -5,10 +5,10 @@ CONFIG = AttributeDict()
 
 
 def get_asset_url(path):
-    return real_get_asset_url(CONFIG, path)
+    return app_get_asset_url(CONFIG, path)
 
 
-def real_get_asset_url(config, path):
+def app_get_asset_url(config, path):
     if config.assets_external_path:
         prefix = config.assets_external_path
     else:
@@ -60,10 +60,10 @@ def get_relative_path(path):
             return chapters.page_2
     ```
     """
-    return real_get_relative_path(CONFIG.requests_pathname_prefix, path)
+    return app_get_relative_path(CONFIG.requests_pathname_prefix, path)
 
 
-def real_get_relative_path(requests_pathname, path):
+def app_get_relative_path(requests_pathname, path):
     if requests_pathname == "/" and path == "":
         return "/"
     if requests_pathname != "/" and path == "":
@@ -127,10 +127,10 @@ def strip_relative_path(path):
     `page-1/sub-page-1`
     ```
     """
-    return real_strip_relative_path(CONFIG.requests_pathname_prefix, path)
+    return app_strip_relative_path(CONFIG.requests_pathname_prefix, path)
 
 
-def real_strip_relative_path(requests_pathname, path):
+def app_strip_relative_path(requests_pathname, path):
     if path is None:
         return None
     if (

--- a/dash/_get_paths.py
+++ b/dash/_get_paths.py
@@ -5,10 +5,10 @@ CONFIG = AttributeDict()
 
 
 def get_asset_url(path):
-    return real_get_assets_url(CONFIG, path)
+    return real_get_asset_url(CONFIG, path)
 
 
-def real_get_assets_url(config, path):
+def real_get_asset_url(config, path):
     if config.assets_external_path:
         prefix = config.assets_external_path
     else:
@@ -60,11 +60,10 @@ def get_relative_path(path):
             return chapters.page_2
     ```
     """
-    return real_get_relative_path(CONFIG, path)
+    return real_get_relative_path(CONFIG.requests_pathname_prefix, path)
 
 
-def real_get_relative_path(config, path):
-    requests_pathname = config.requests_pathname_prefix
+def real_get_relative_path(requests_pathname, path):
     if requests_pathname == "/" and path == "":
         return "/"
     if requests_pathname != "/" and path == "":
@@ -128,11 +127,10 @@ def strip_relative_path(path):
     `page-1/sub-page-1`
     ```
     """
-    return real_strip_relative_path(CONFIG, path)
+    return real_strip_relative_path(CONFIG.requests_pathname_prefix, path)
 
 
-def real_strip_relative_path(config, path):
-    requests_pathname = config.requests_pathname_prefix
+def real_strip_relative_path(requests_pathname, path):
     if path is None:
         return None
     if (

--- a/dash/_get_paths.py
+++ b/dash/_get_paths.py
@@ -1,0 +1,157 @@
+from ._utils import AttributeDict
+from . import exceptions
+
+CONFIG = AttributeDict()
+
+
+def get_asset_url(path):
+    return real_get_assets_url(CONFIG, path)
+
+
+def real_get_assets_url(config, path):
+    if config.assets_external_path:
+        prefix = config.assets_external_path
+    else:
+        prefix = config.requests_pathname_prefix
+    return "/".join(
+        [
+            # Only take the first part of the pathname
+            prefix.rstrip("/"),
+            config.assets_url_path.lstrip("/"),
+            path,
+        ]
+    )
+
+
+def get_relative_path(path):
+    """
+    Return a path with `requests_pathname_prefix` prefixed before it.
+    Use this function when specifying local URL paths that will work
+    in environments regardless of what `requests_pathname_prefix` is.
+    In some deployment environments, like Dash Enterprise,
+    `requests_pathname_prefix` is set to the application name,
+    e.g. `my-dash-app`.
+    When working locally, `requests_pathname_prefix` might be unset and
+    so a relative URL like `/page-2` can just be `/page-2`.
+    However, when the app is deployed to a URL like `/my-dash-app`, then
+    `app.get_relative_path('/page-2')` will return `/my-dash-app/page-2`.
+    This can be used as an alternative to `get_asset_url` as well with
+    `app.get_relative_path('/assets/logo.png')`
+
+    Use this function with `app.strip_relative_path` in callbacks that
+    deal with `dcc.Location` `pathname` routing.
+    That is, your usage may look like:
+    ```
+    app.layout = html.Div([
+        dcc.Location(id='url'),
+        html.Div(id='content')
+    ])
+    @app.callback(Output('content', 'children'), [Input('url', 'pathname')])
+    def display_content(path):
+        page_name = app.strip_relative_path(path)
+        if not page_name:  # None or ''
+            return html.Div([
+                dcc.Link(href=app.get_relative_path('/page-1')),
+                dcc.Link(href=app.get_relative_path('/page-2')),
+            ])
+        elif page_name == 'page-1':
+            return chapters.page_1
+        if page_name == "page-2":
+            return chapters.page_2
+    ```
+    """
+    return real_get_relative_path(CONFIG, path)
+
+
+def real_get_relative_path(config, path):
+    requests_pathname = config.requests_pathname_prefix
+    if requests_pathname == "/" and path == "":
+        return "/"
+    if requests_pathname != "/" and path == "":
+        return requests_pathname
+    if not path.startswith("/"):
+        raise exceptions.UnsupportedRelativePath(
+            """
+            Paths that aren't prefixed with a leading / are not supported.
+            You supplied: {}
+            """.format(
+                path
+            )
+        )
+    return "/".join([requests_pathname.rstrip("/"), path.lstrip("/")])
+
+
+def strip_relative_path(path):
+    """
+    Return a path with `requests_pathname_prefix` and leading and trailing
+    slashes stripped from it. Also, if None is passed in, None is returned.
+    Use this function with `get_relative_path` in callbacks that deal
+    with `dcc.Location` `pathname` routing.
+    That is, your usage may look like:
+    ```
+    app.layout = html.Div([
+        dcc.Location(id='url'),
+        html.Div(id='content')
+    ])
+    @app.callback(Output('content', 'children'), [Input('url', 'pathname')])
+    def display_content(path):
+        page_name = app.strip_relative_path(path)
+        if not page_name:  # None or ''
+            return html.Div([
+                dcc.Link(href=app.get_relative_path('/page-1')),
+                dcc.Link(href=app.get_relative_path('/page-2')),
+            ])
+        elif page_name == 'page-1':
+            return chapters.page_1
+        if page_name == "page-2":
+            return chapters.page_2
+    ```
+    Note that `chapters.page_1` will be served if the user visits `/page-1`
+    _or_ `/page-1/` since `strip_relative_path` removes the trailing slash.
+
+    Also note that `strip_relative_path` is compatible with
+    `get_relative_path` in environments where `requests_pathname_prefix` set.
+    In some deployment environments, like Dash Enterprise,
+    `requests_pathname_prefix` is set to the application name, e.g. `my-dash-app`.
+    When working locally, `requests_pathname_prefix` might be unset and
+    so a relative URL like `/page-2` can just be `/page-2`.
+    However, when the app is deployed to a URL like `/my-dash-app`, then
+    `app.get_relative_path('/page-2')` will return `/my-dash-app/page-2`
+
+    The `pathname` property of `dcc.Location` will return '`/my-dash-app/page-2`'
+    to the callback.
+    In this case, `app.strip_relative_path('/my-dash-app/page-2')`
+    will return `'page-2'`
+
+    For nested URLs, slashes are still included:
+    `app.strip_relative_path('/page-1/sub-page-1/')` will return
+    `page-1/sub-page-1`
+    ```
+    """
+    return real_strip_relative_path(CONFIG, path)
+
+
+def real_strip_relative_path(config, path):
+    requests_pathname = config.requests_pathname_prefix
+    if path is None:
+        return None
+    if (
+        requests_pathname != "/" and not path.startswith(requests_pathname.rstrip("/"))
+    ) or (requests_pathname == "/" and not path.startswith("/")):
+        raise exceptions.UnsupportedRelativePath(
+            """
+            Paths that aren't prefixed with requests_pathname_prefix are not supported.
+            You supplied: {} and requests_pathname_prefix was {}
+            """.format(
+                path, requests_pathname
+            )
+        )
+    if requests_pathname != "/" and path.startswith(requests_pathname.rstrip("/")):
+        path = path.replace(
+            # handle the case where the path might be `/my-dash-app`
+            # but the requests_pathname_prefix is `/my-dash-app/`
+            requests_pathname.rstrip("/"),
+            "",
+            1,
+        )
+    return path.strip("/")

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -9,7 +9,6 @@ import logging
 import io
 import json
 from functools import wraps
-from . import exceptions
 
 logger = logging.getLogger()
 
@@ -45,60 +44,6 @@ def format_tag(tag_name, attributes, inner="", closed=False, opened=False):
 
 def generate_hash():
     return str(uuid.uuid4().hex).strip("-")
-
-
-def get_asset_path(requests_pathname, asset_path, asset_url_path):
-
-    return "/".join(
-        [
-            # Only take the first part of the pathname
-            requests_pathname.rstrip("/"),
-            asset_url_path,
-            asset_path,
-        ]
-    )
-
-
-def get_relative_path(requests_pathname, path):
-    if requests_pathname == "/" and path == "":
-        return "/"
-    if requests_pathname != "/" and path == "":
-        return requests_pathname
-    if not path.startswith("/"):
-        raise exceptions.UnsupportedRelativePath(
-            """
-            Paths that aren't prefixed with a leading / are not supported.
-            You supplied: {}
-            """.format(
-                path
-            )
-        )
-    return "/".join([requests_pathname.rstrip("/"), path.lstrip("/")])
-
-
-def strip_relative_path(requests_pathname, path):
-    if path is None:
-        return None
-    if (
-        requests_pathname != "/" and not path.startswith(requests_pathname.rstrip("/"))
-    ) or (requests_pathname == "/" and not path.startswith("/")):
-        raise exceptions.UnsupportedRelativePath(
-            """
-            Paths that aren't prefixed with requests_pathname_prefix are not supported.
-            You supplied: {} and requests_pathname_prefix was {}
-            """.format(
-                path, requests_pathname
-            )
-        )
-    if requests_pathname != "/" and path.startswith(requests_pathname.rstrip("/")):
-        path = path.replace(
-            # handle the case where the path might be `/my-dash-app`
-            # but the requests_pathname_prefix is `/my-dash-app/`
-            requests_pathname.rstrip("/"),
-            "",
-            1,
-        )
-    return path.strip("/")
 
 
 # pylint: disable=no-member

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1473,7 +1473,7 @@ class Dash:
         ]
 
     def get_asset_url(self, path):
-        return _get_paths.real_get_assets_url(self.config, path)
+        return _get_paths.real_get_asset_url(self.config, path)
 
     def get_relative_path(self, path):
         """
@@ -1737,7 +1737,7 @@ class Dash:
                 if hasattr(package, "path") and "dash/dash" in os.path.dirname(
                     package.path
                 ):
-                    component_packages_dist[i: i + 1] = [
+                    component_packages_dist[i : i + 1] = [
                         os.path.join(os.path.dirname(package.path), x)
                         for x in ["dcc", "html", "dash_table"]
                     ]

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -424,9 +424,6 @@ class Dash:
 
         self.logger.setLevel(logging.INFO)
 
-    def _get_config(self):
-        return self.config
-
     def init_app(self, app=None, **kwargs):
         """Initialize the parts of Dash that require a flask app."""
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1473,7 +1473,7 @@ class Dash:
         ]
 
     def get_asset_url(self, path):
-        return _get_paths.real_get_asset_url(self.config, path)
+        return _get_paths.app_get_asset_url(self.config, path)
 
     def get_relative_path(self, path):
         """
@@ -1512,7 +1512,9 @@ class Dash:
                 return chapters.page_2
         ```
         """
-        return _get_paths.real_get_relative_path(self.config, path)
+        return _get_paths.app_get_relative_path(
+            self.config.requests_pathname_prefix, path
+        )
 
     def strip_relative_path(self, path):
         """
@@ -1561,7 +1563,9 @@ class Dash:
         `page-1/sub-page-1`
         ```
         """
-        return _get_paths.real_strip_relative_path(self.config, path)
+        return _get_paths.app_strip_relative_path(
+            self.config.requests_pathname_prefix, path
+        )
 
     def _setup_dev_tools(self, **kwargs):
         debug = kwargs.get("debug", False)

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -13,7 +13,13 @@ from dash._configs import (
     get_combined_config,
     load_dash_env_vars,
 )
-from dash import get_asset_path, get_relative_path, strip_relative_path
+
+from dash._utils import AttributeDict
+from dash._get_paths import (
+    real_get_asset_url,
+    real_get_relative_path,
+    real_strip_relative_path,
+)
 
 
 @pytest.fixture
@@ -101,7 +107,8 @@ def test_pathname_prefix_environ_requests(empty_environ):
     ],
 )
 def test_pathname_prefix_assets(empty_environ, req, expected):
-    path = get_asset_path(req, "reset.css", "assets")
+    config = AttributeDict(assets_external_path=req, assets_url_path="assets")
+    path = real_get_asset_url(config, "reset.css")
     assert path == expected
 
 
@@ -209,7 +216,7 @@ def test_app_name_server(empty_environ, name, server, expected):
     ],
 )
 def test_pathname_prefix_relative_url(prefix, partial_path, expected):
-    path = get_relative_path(prefix, partial_path)
+    path = real_get_relative_path(prefix, partial_path)
     assert path == expected
 
 
@@ -219,7 +226,7 @@ def test_pathname_prefix_relative_url(prefix, partial_path, expected):
 )
 def test_invalid_get_relative_path(prefix, partial_path):
     with pytest.raises(_exc.UnsupportedRelativePath):
-        get_relative_path(prefix, partial_path)
+        real_get_relative_path(prefix, partial_path)
 
 
 @pytest.mark.parametrize(
@@ -247,7 +254,7 @@ def test_invalid_get_relative_path(prefix, partial_path):
     ],
 )
 def test_strip_relative_path(prefix, partial_path, expected):
-    path = strip_relative_path(prefix, partial_path)
+    path = real_strip_relative_path(prefix, partial_path)
     assert path == expected
 
 
@@ -261,7 +268,7 @@ def test_strip_relative_path(prefix, partial_path, expected):
 )
 def test_invalid_strip_relative_path(prefix, partial_path):
     with pytest.raises(_exc.UnsupportedRelativePath):
-        strip_relative_path(prefix, partial_path)
+        real_strip_relative_path(prefix, partial_path)
 
 
 def test_port_env_fail_str(empty_environ):

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -13,7 +13,7 @@ from dash._configs import (
     get_combined_config,
     load_dash_env_vars,
 )
-from dash._utils import get_asset_path, get_relative_path, strip_relative_path
+from dash import get_asset_path, get_relative_path, strip_relative_path
 
 
 @pytest.fixture

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -16,9 +16,12 @@ from dash._configs import (
 
 from dash._utils import AttributeDict
 from dash._get_paths import (
-    real_get_asset_url,
-    real_get_relative_path,
-    real_strip_relative_path,
+    app_get_asset_url,
+    app_get_relative_path,
+    app_strip_relative_path,
+    get_asset_url,
+    get_relative_path,
+    strip_relative_path,
 )
 
 
@@ -108,7 +111,7 @@ def test_pathname_prefix_environ_requests(empty_environ):
 )
 def test_pathname_prefix_assets(empty_environ, req, expected):
     config = AttributeDict(assets_external_path=req, assets_url_path="assets")
-    path = real_get_asset_url(config, "reset.css")
+    path = app_get_asset_url(config, "reset.css")
     assert path == expected
 
 
@@ -142,8 +145,51 @@ def test_asset_url(
         assets_url_path=assets_url_path,
     )
 
-    path = app.get_asset_url("reset.css")
-    assert path == expected
+    app_path = app.get_asset_url("reset.css")
+    dash_path = get_asset_url("reset.css")
+    assert app_path == dash_path == expected
+
+
+@pytest.mark.parametrize(
+    "requests_pathname_prefix, expected",
+    [
+        (None, "/page2"),
+        ("/app/", "/app/page2"),
+    ],
+)
+def test_get_relative_path(
+    empty_environ,
+    requests_pathname_prefix,
+    expected,
+):
+    app = Dash(
+        "Dash",
+        requests_pathname_prefix=requests_pathname_prefix,
+    )
+    app_path = app.get_relative_path("/page2")
+    dash_path = get_relative_path("/page2")
+    assert app_path == dash_path == expected
+
+
+@pytest.mark.parametrize(
+    "requests_pathname_prefix, expected",
+    [
+        (None, "/app/page2"),
+        ("/app/", "/page2"),
+    ],
+)
+def test_strip_relative_path(
+    empty_environ,
+    requests_pathname_prefix,
+    expected,
+):
+    app = Dash(
+        "Dash",
+        requests_pathname_prefix=requests_pathname_prefix,
+    )
+    app_path = app.strip_relative_path("/app/page2")
+    dash_path = strip_relative_path("/app/page2")
+    assert app_path == dash_path == expected
 
 
 def test_get_combined_config_dev_tools_ui(empty_environ):
@@ -216,7 +262,7 @@ def test_app_name_server(empty_environ, name, server, expected):
     ],
 )
 def test_pathname_prefix_relative_url(prefix, partial_path, expected):
-    path = real_get_relative_path(prefix, partial_path)
+    path = app_get_relative_path(prefix, partial_path)
     assert path == expected
 
 
@@ -226,7 +272,7 @@ def test_pathname_prefix_relative_url(prefix, partial_path, expected):
 )
 def test_invalid_get_relative_path(prefix, partial_path):
     with pytest.raises(_exc.UnsupportedRelativePath):
-        real_get_relative_path(prefix, partial_path)
+        app_get_relative_path(prefix, partial_path)
 
 
 @pytest.mark.parametrize(
@@ -254,7 +300,7 @@ def test_invalid_get_relative_path(prefix, partial_path):
     ],
 )
 def test_strip_relative_path(prefix, partial_path, expected):
-    path = real_strip_relative_path(prefix, partial_path)
+    path = app_strip_relative_path(prefix, partial_path)
     assert path == expected
 
 
@@ -268,7 +314,7 @@ def test_strip_relative_path(prefix, partial_path, expected):
 )
 def test_invalid_strip_relative_path(prefix, partial_path):
     with pytest.raises(_exc.UnsupportedRelativePath):
-        real_strip_relative_path(prefix, partial_path)
+        app_strip_relative_path(prefix, partial_path)
 
 
 def test_port_env_fail_str(empty_environ):


### PR DESCRIPTION
Closes https://github.com/plotly/dash-labs/issues/65

This PR creates the following functions:
- `dash.get_relative_path`
- `dash.strip_relative_path`
- `dash.get_asset_url`

This is similar to `dash.callback` where you don't need the `app` object. It makes it possible to use these functions in the `pages` folder of a multi-page app without running into the circular `app` imports issue.

