### PR TITLE
use plotly.js-dist-min in webpack externals

### DIFF
--- a/components/dash-html-components/webpack.config.js
+++ b/components/dash-html-components/webpack.config.js
@@ -37,7 +37,6 @@ module.exports = (env, argv) => {
     const externals = ('externals' in overrides) ? overrides.externals : ({
         react: 'React',
         'react-dom': 'ReactDOM',
-        'plotly.js-dist-min': 'Plotly',
         'prop-types': 'PropTypes'
     });
 

--- a/components/dash-table/.config/webpack/base.js
+++ b/components/dash-table/.config/webpack/base.js
@@ -33,7 +33,6 @@ module.exports = (options = {}) => {
         externals: {
             react: 'React',
             'react-dom': 'ReactDOM',
-            'plotly.js-dist-min': 'Plotly'
         },
         module: {
             rules: [


### PR DESCRIPTION
Follow up of #1911.
Now that `plotly.js-dist-min` is the name of the package used instead of `plotly.js`.
@alexcjohnson 