### PR TITLE
Fix split by timings for pytest parallelization

### DIFF
--- a/components/dash-core-components/pytest.ini
+++ b/components/dash-core-components/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+junit_family = xunit1
 testpaths = tests/
 addopts = -rsxX -vv
 log_format = %(asctime)s | %(levelname)s | %(name)s:%(lineno)d | %(message)s

--- a/components/dash-core-components/pytest.ini
+++ b/components/dash-core-components/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 junit_family = xunit1
+
 testpaths = tests/
 addopts = -rsxX -vv
 log_format = %(asctime)s | %(levelname)s | %(name)s:%(lineno)d | %(message)s

--- a/components/dash-table/pytest.ini
+++ b/components/dash-table/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+junit_family = xunit1
 testpaths = tests/
 addopts = -rsxX -vv
 log_format = %(asctime)s | %(levelname)s | %(name)s:%(lineno)d | %(message)s

--- a/components/dash-table/pytest.ini
+++ b/components/dash-table/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 junit_family = xunit1
+
 testpaths = tests/
 addopts = -rsxX -vv
 log_format = %(asctime)s | %(levelname)s | %(name)s:%(lineno)d | %(message)s

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
+junit_family = xunit1
 testpaths = tests/
 addopts = -rsxX -vv
 log_format = %(asctime)s | %(levelname)s | %(name)s:%(lineno)d | %(message)s

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,6 @@
 [pytest]
 junit_family = xunit1
+
 testpaths = tests/
 addopts = -rsxX -vv
 log_format = %(asctime)s | %(levelname)s | %(name)s:%(lineno)d | %(message)s


### PR DESCRIPTION
Currently on `dev` branch split by timing of parallelized tests is broken:
https://app.circleci.com/pipelines/github/plotly/dash/3084/workflows/f0ae2fb1-1ad0-4d19-8313-e709c10ee72c/jobs/51326

![timing-split](https://user-images.githubusercontent.com/33888540/154360028-7435c9ea-bb04-4938-986a-5f37f7f0ec03.png)

As a result tests e.g. `table-server-test` take too much time to complete.
This PR addresses this problem thanks to https://discuss.circleci.com/t/pytest-parallelization-timings/42716 and https://stackoverflow.com/questions/64796476/pytest-junit-xml-report-doesnt-have-file-field

@alexcjohnson 
 