### PR TITLE
clear unused resolve alias for `plotly.js` in webpack config

### DIFF
--- a/components/dash-core-components/webpack.config.js
+++ b/components/dash-core-components/webpack.config.js
@@ -110,11 +110,6 @@ module.exports = (env, argv) => {
                 },
             ],
         },
-        resolve: {
-            alias: {
-                'plotly.js': 'plotly.js-dist-min/plotly.min.js'
-            }
-        },
         optimization: {
             splitChunks: {
                 name: '[name].js',


### PR DESCRIPTION
Looks unused and rather confusing.
@alexcjohnson 