### PR TITLE
fix unrelenting alert when hot reload fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- [#1953](https://github.com/plotly/dash/pull/1953) Fix bug [#1783](https://github.com/plotly/dash/issues/1783) in which a failed hot reloader blocks the UI with alerts.
+
 ## [2.2.0] - 2022-02-18
 
 ### Added

--- a/dash/dash-renderer/src/components/core/Reloader.react.js
+++ b/dash/dash-renderer/src/components/core/Reloader.react.js
@@ -154,15 +154,16 @@ class Reloader extends React.Component {
                 // Backend code changed - can do a soft reload in place
                 dispatch({type: 'RELOAD'});
             }
-        } else if (reloadRequest.status === 500) {
+        } else if (
+            this.state.intervalId !== null &&
+            reloadRequest.status === 500
+        ) {
             if (this._retry > this.state.max_retry) {
                 this.clearInterval();
                 // Integrate with dev tools ui?!
                 window.alert(
-                    `
-                    Reloader failed after ${this._retry} times.
-                    Please check your application for errors.
-                    `
+                    `Hot reloading is disabled after failing ${this._retry} times. ` +
+                        'Please check your application for errors, then refresh the page.'
                 );
             }
             this._retry++;


### PR DESCRIPTION
Fixes #1783 

This really only gets triggered in workspaces - must be because the app is behind a proxy there. When you're pointed directly at the server a failure manifests as a refused connection, which the devtools detect as "the server stopped." But in workspaces the server appears present, just responding with a 500 error. To test this locally I temporarily threw an exception [here](https://github.com/plotly/dash/blob/97470a0a8aabd93c480f5dff64009baa88906cc6/dash/dash.py#L604).

Not intending to add a test for this, it would be awfully cumbersome and unclear that it would actually be representative of the real condition.

- [x] I have added entry in the `CHANGELOG.md`
