### PR TITLE
fixed dropdown bug #1908

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 - [#1953](https://github.com/plotly/dash/pull/1953) Fix bug [#1783](https://github.com/plotly/dash/issues/1783) in which a failed hot reloader blocks the UI with alerts.
 
+
+## Dash Core Components
+
+### Fixed
+- [#1958](https://github.com/plotly/dash/pull/1958) Fix dropdown bug [#1908](https://github.com/plotly/dash/issues/1908) where the value didn't display in the input box if it contained a comma.
+
+
 ## [2.2.0] - 2022-02-18
 
 ### Added
@@ -92,7 +99,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   [#1894](https://github.com/plotly/dash/pull/1894) restricted this feature so auto-generated IDs are not allowed if the app uses `dash_snapshots` (a Dash Enterprise package) or if the component uses `persistence`, as this can create confusing errors. Callback definitions can still reference components in these cases, but those components must have explicit IDs.
 
     ## Dash Core Components
-
+    
     ### Rearranged Keyword Arguments & Flexible Types
     **`Dropdown`, `RadioItem`, and `Checklist`**
     - Rearranged Keyword Arguments - `options` & `value` are now the first two keywords which means they can be supplied as positional arguments without the keyword. Supplying the keywords (`options=` and `value=`) is still supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 
 ### Fixed
+
+### Fixed
+- [#1958](https://github.com/plotly/dash/pull/1958) Fix dropdown bug [#1908](https://github.com/plotly/dash/issues/1908) where the value didn't display in the input box if it contained a comma.
 - [#1915](https://github.com/plotly/dash/pull/1915) Fix bug [#1474](https://github.com/plotly/dash/issues/1474) when both dcc.Graph and go.Figure have animation, and when the second animation in Figure is executed, the Frames from the first animation are played instead of the second one.
 
 - [#1953](https://github.com/plotly/dash/pull/1953) Fix bug [#1783](https://github.com/plotly/dash/issues/1783) in which a failed hot reloader blocks the UI with alerts.

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -1,4 +1,4 @@
-import {isNil, pluck, omit, type} from 'ramda';
+import {isNil, pluck, omit} from 'ramda';
 import React, {Component} from 'react';
 import ReactDropdown from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
@@ -21,7 +21,6 @@ const TOKENIZER = {
     },
 };
 
-const DELIMITER = ',';
 
 export default class Dropdown extends Component {
     constructor(props) {
@@ -57,12 +56,6 @@ export default class Dropdown extends Component {
             value,
         } = this.props;
         const {filterOptions} = this.state;
-        let selectedValue;
-        if (type(value) === 'Array') {
-            selectedValue = value.join(DELIMITER);
-        } else {
-            selectedValue = value;
-        }
         return (
             <div
                 id={id}
@@ -75,7 +68,7 @@ export default class Dropdown extends Component {
                 <ReactDropdown
                     filterOptions={filterOptions}
                     options={sanitizeOptions(options)}
-                    value={selectedValue}
+                    value={value}
                     onChange={selectedOption => {
                         if (multi) {
                             let value;

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -21,7 +21,6 @@ const TOKENIZER = {
     },
 };
 
-
 export default class Dropdown extends Component {
     constructor(props) {
         super(props);

--- a/components/dash-core-components/tests/integration/dropdown/test_dynamic_options.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_dynamic_options.py
@@ -1,4 +1,4 @@
-from dash import Dash, Input, Output, dcc, html
+from dash import Dash, Input, Output, dcc
 from dash.exceptions import PreventUpdate
 
 
@@ -49,28 +49,5 @@ def test_dddo001_dynamic_options(dash_dcc):
     assert len(options) == 1
     print(options)
     assert options[0].text == "Montreal"
-
-    assert dash_dcc.get_logs() == []
-
-
-def test_dddo002_array_value(dash_dcc):
-    dropdown_options = [
-        {"label": "New York City", "value": "New,York,City"},
-        {"label": "Montreal", "value": "Montreal"},
-        {"label": "San Francisco", "value": "San,Francisco"},
-    ]
-
-    app = Dash(__name__)
-    arrayValue = ["San", "Francisco"]
-
-    dropdown = dcc.Dropdown(
-        options=dropdown_options,
-        value=arrayValue,
-    )
-    app.layout = html.Div([dropdown])
-
-    dash_dcc.start_server(app)
-
-    dash_dcc.wait_for_text_to_equal("#react-select-2--value-item", "San Francisco")
 
     assert dash_dcc.get_logs() == []

--- a/components/dash-core-components/tests/integration/dropdown/test_dynamic_options.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_dynamic_options.py
@@ -1,4 +1,4 @@
-from dash import Dash, Input, Output, dcc
+from dash import Dash, Input, Output, dcc, html
 from dash.exceptions import PreventUpdate
 
 
@@ -49,5 +49,23 @@ def test_dddo001_dynamic_options(dash_dcc):
     assert len(options) == 1
     print(options)
     assert options[0].text == "Montreal"
+
+    assert dash_dcc.get_logs() == []
+
+
+def test_dddo002_array_value(dash_dcc):
+
+    app = Dash(__name__)
+
+    dropdown = dcc.Dropdown(
+        options=["New York, NY", "Montreal, QC", "San Francisco, CA"],
+        value=["San Francisco, CA"],
+        multi=True,
+    )
+    app.layout = html.Div(dropdown)
+
+    dash_dcc.start_server(app)
+
+    dash_dcc.wait_for_text_to_equal("#react-select-2--value-0", "San Francisco, CA\n ")
 
     assert dash_dcc.get_logs() == []


### PR DESCRIPTION
Fixes #1908 Dropdown: Selected options not showing when the value contains a comma

As [reported on the forum](https://community.plotly.com/t/dcc-dropdown-bug-suspected-please-confirm-or-correct-me/60585) by Marcus

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))

- [x] I have added entry in the `CHANGELOG.md`