### PR TITLE
fix dropdown 'multi' argument

### DIFF
--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -58,7 +58,7 @@ export default class Dropdown extends Component {
         } = this.props;
         const {filterOptions} = this.state;
         let selectedValue;
-        if (type(value) === 'Array') {
+        if (type(value) === 'Array' && !multi) {
             selectedValue = value.join(DELIMITER);
         } else {
             selectedValue = value;

--- a/components/dash-core-components/tests/integration/dropdown/test_option_title_prop.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_option_title_prop.py
@@ -68,3 +68,25 @@ def test_ddot001_option_title(dash_dcc, multi):
     wait.until(lambda: dropdown_option_element.get_attribute("title") == "", 3)
 
     assert dash_dcc.get_logs() == []
+
+
+@pytest.mark.parametrize("multi", [True, False])
+def test_ddot002_multi_value(dash_dcc, multi):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(
+                id="dropdown",
+                options=["New York City, NY", "Montreal, QC", "San Francisco, CA"],
+                value=["Montreal, QC"],
+                multi=multi,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app)
+
+    dropdown_option_element = dash_dcc.wait_for_element(".Select-value-label")
+    assert "Montreal, QC" in dropdown_option_element.text
+
+    assert dash_dcc.get_logs() == []


### PR DESCRIPTION
As described in issue #1920 commas in the options are cause that the dropdown does not work.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] fix issue
   -  [x] make test
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
