### PR TITLE
Fix missing newline for split html debugger.

### DIFF
--- a/dash/dash-renderer/src/components/error/FrontEnd/FrontEndError.react.js
+++ b/dash/dash-renderer/src/components/error/FrontEnd/FrontEndError.react.js
@@ -110,9 +110,8 @@ function UnconnectedErrorContent({error, base}) {
             )}
             {/* Backend Error */}
             {typeof error.html !== 'string' ? null : error.html
-                  .split()[0]
-                  .toLowerCase()
-                  .startsWith('<!doctype') ? (
+                  .substring(0, '<!doctype'.length)
+                  .toLowerCase() === '<!doctype' ? (
                 <div className='dash-be-error__st'>
                     <div className='dash-backend-error'>
                         {/* Embed werkzeug debugger in an iframe to prevent


### PR DESCRIPTION
Think I missed something when I tested the fix for the html debugger with newer version of werkzeug.