### PR TITLE
Bump plotly.js from v2.12.0 to v2.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,10 +47,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2027](https://github.com/plotly/dash/pull/1751) Improve the error message when a user doesn't wrap children in a list
 
 ### Updated
-- [#2016](https://github.com/plotly/dash/pull/2016) and [#2032](https://github.com/plotly/dash/pull/2032) Widespread dependency upgrades
-  - Upgrade Plotly.js to v2.12.0 (from v2.11.0).
+- [#2016](https://github.com/plotly/dash/pull/2016), [#2032](https://github.com/plotly/dash/pull/2032), and [#2042](https://github.com/plotly/dash/pull/2042) Widespread dependency upgrades
+  - Upgrade Plotly.js to v2.12.1 (from v2.11.0).
     - Feature release [2.12.0](https://github.com/plotly/plotly.js/releases/tag/v2.12.0) adds minor ticks and gridlines, as well as dashed gridlines.
     - Patch release [2.11.1](https://github.com/plotly/plotly.js/releases/tag/v2.11.1) fixes regl-based traces in strict CSP mode, however you must manually switch to the strict bundle to use this.
+    - Patch release [2.12.1](https://github.com/plotly/plotly.js/releases/tag/v2.12.1) fixes several bugs.
   - Upgrade `black` to v22.3.0 for Python 3.7+ - if you use `dash[ci]` and you call `black`, this may alter your code formatting slightly, including more consistently breaking Python 2 compatibility.
   - Many other mainly JS dependency upgrades to the internals of Dash renderer and components. These may patch bugs or improve performance.
 

--- a/components/dash-core-components/package-lock.json
+++ b/components/dash-core-components/package-lock.json
@@ -22,7 +22,7 @@
         "mathjax": "^3.2.0",
         "moment": "^2.29.3",
         "node-polyfill-webpack-plugin": "^1.1.4",
-        "plotly.js-dist-min": "2.12.0",
+        "plotly.js-dist-min": "2.12.1",
         "prop-types": "^15.8.1",
         "ramda": "^0.28.0",
         "rc-slider": "^9.7.5",
@@ -7002,9 +7002,9 @@
       }
     },
     "node_modules/plotly.js-dist-min": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.12.0.tgz",
-      "integrity": "sha512-B4q1o9TiyQFOKvggpAesI2k1G5ZY6ngZMFzuCcC5nN968mhVdqJHcgxlaKxXfYDYxKBqYPC06WQZD1hCmjA2PQ=="
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.12.1.tgz",
+      "integrity": "sha512-JFYDn/eKXlbaEr6touiiZsb745fHsd7cLhXDWSTVon4sdcx19pdPKf1f5jXf5xwZ8Dv5L28Lb5OPmxAkBp/6rw=="
     },
     "node_modules/postcss": {
       "version": "8.4.13",
@@ -14902,9 +14902,9 @@
       }
     },
     "plotly.js-dist-min": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.12.0.tgz",
-      "integrity": "sha512-B4q1o9TiyQFOKvggpAesI2k1G5ZY6ngZMFzuCcC5nN968mhVdqJHcgxlaKxXfYDYxKBqYPC06WQZD1hCmjA2PQ=="
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.12.1.tgz",
+      "integrity": "sha512-JFYDn/eKXlbaEr6touiiZsb745fHsd7cLhXDWSTVon4sdcx19pdPKf1f5jXf5xwZ8Dv5L28Lb5OPmxAkBp/6rw=="
     },
     "postcss": {
       "version": "8.4.13",

--- a/components/dash-core-components/package.json
+++ b/components/dash-core-components/package.json
@@ -49,7 +49,7 @@
     "mathjax": "^3.2.0",
     "moment": "^2.29.3",
     "node-polyfill-webpack-plugin": "^1.1.4",
-    "plotly.js-dist-min": "2.12.0",
+    "plotly.js-dist-min": "2.12.1",
     "prop-types": "^15.8.1",
     "ramda": "^0.28.0",
     "rc-slider": "^9.7.5",


### PR DESCRIPTION
Please note that #1157 is addressed by https://github.com/plotly/plotly.js/pull/6177.


