### PR TITLE
Fix markdown mathjax in html

### DIFF
--- a/components/dash-core-components/src/fragments/Markdown.react.js
+++ b/components/dash-core-components/src/fragments/Markdown.react.js
@@ -108,6 +108,20 @@ export default class DashMarkdown extends Component {
                     )}
                 />
             ),
+            dashMathjax: props => (
+                <Math tex={props.value} inline={props.inline} />
+            ),
+        };
+
+        const regexMath = value => {
+            const newValue = value.replace(
+                /(\${1,2})((?:\\.|[^$])+)\1/g,
+                function (m, tag, src) {
+                    const inline = tag.length === 1 || src.indexOf('\n') === -1;
+                    return `<dashMathjax value='${src}' inline='${inline}'/>`;
+                }
+            );
+            return newValue;
         };
 
         return (
@@ -151,7 +165,11 @@ export default class DashMarkdown extends Component {
                                 props.value
                             ) : (
                                 <JsxParser
-                                    jsx={props.value}
+                                    jsx={
+                                        mathjax
+                                            ? regexMath(props.value)
+                                            : props.value
+                                    }
                                     components={componentTransforms}
                                     renderInWrapper={false}
                                 />

--- a/components/dash-core-components/tests/integration/markdown/test_markdown.py
+++ b/components/dash-core-components/tests/integration/markdown/test_markdown.py
@@ -388,3 +388,20 @@ def test_mkdw009_target_blank_links(dash_dcc):
     dash_dcc.find_element("a").click()
 
     until(lambda: len(dash_dcc.driver.window_handles) == 2, timeout=1)
+
+
+def test_mkdw010_mathjax_with_html(dash_dcc):
+
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        dcc.Markdown(
+            "<p>Some paragraph with $E = mc^2$  inline math</p>",
+            dangerously_allow_html=True,
+            mathjax=True,
+        )
+    )
+
+    dash_dcc.start_server(app)
+
+    dash_dcc.wait_for_element(".MathJax")


### PR DESCRIPTION
As described in issue #2003, `dangerously_allow_html=True` + `mathjax=True` works in some cases, and in some cases not.
The problem is that the [markdown-parse](https://github.com/remarkjs/remark/tree/main/packages/remark-parse) recognizes whole string as the html object and stops further parsing. This PR fixes the processing of the mathjax in html.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] fix issue
   -  [x] add test
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
