### PR TITLE
Fixed bug that prevented env DASH_DEBUG to work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2043](https://github.com/plotly/dash/pull/2043) Fix bug 
 [#2003](https://github.com/plotly/dash/issues/2003) in which 
 `dangerously_allow_html=True` + `mathjax=True` works in some cases, and in some cases not.
+- [#2047](https://github.com/plotly/dash/pull/2047) Fix bug [#1979](https://github.com/plotly/dash/issues/1979) in which `DASH_DEBUG` as enviroment variable gets ignored.
 
 ## [2.4.1] - 2022-05-11
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1989,7 +1989,7 @@ class Dash:
         """
         if debug is None:
             debug = get_combined_config("debug", None, False)
-        
+
         debug = self.enable_dev_tools(
             debug,
             dev_tools_ui,

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1702,7 +1702,7 @@ class Dash:
         :return: debug
         """
         if debug is None:
-            debug = get_combined_config("debug", None, False)
+            debug = get_combined_config("debug", None, True)
 
         dev_tools = self._setup_dev_tools(
             debug=debug,
@@ -1987,6 +1987,9 @@ class Dash:
 
         :return:
         """
+        if debug is None:
+            debug = get_combined_config("debug", None, False)
+        
         debug = self.enable_dev_tools(
             debug,
             dev_tools_ui,

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1702,7 +1702,7 @@ class Dash:
         :return: debug
         """
         if debug is None:
-            debug = get_combined_config("debug", None, True)
+            debug = get_combined_config("debug", None, False)
 
         dev_tools = self._setup_dev_tools(
             debug=debug,
@@ -1896,7 +1896,7 @@ class Dash:
         host=os.getenv("HOST", "127.0.0.1"),
         port=os.getenv("PORT", "8050"),
         proxy=os.getenv("DASH_PROXY", None),
-        debug=False,
+        debug=None,
         dev_tools_ui=None,
         dev_tools_props_check=None,
         dev_tools_serve_dev_bundles=None,

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -480,6 +480,5 @@ def test_debug_mode_enable_dev_tools(empty_environ, debug_env, debug, expected):
     if debug_env:
         os.environ['DASH_DEBUG'] = debug_env
     app = Dash()
-    # with pytest.raises(AssertionError):
     app.enable_dev_tools(debug=debug)
     assert app._dev_tools.ui == expected

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -437,3 +437,49 @@ def test_app_invalid_delayed_config():
     app = Dash(server=False)
     with pytest.raises(AttributeError):
         app.init_app(app=Flask("test"), name="too late 2 update")
+
+
+@pytest.mark.parametrize(
+    "debug_env, debug, expected",
+    [
+        (None, None, False),
+        (None, True, True),
+        (None, False, False),
+        ('True', None, True),
+        ('True', True, True),
+        ('True', False, False),
+        ('False', None, False),
+        ('False', True, True),
+        ('False', False, False),
+    ],
+)
+def test_debug_mode_run(empty_environ, debug_env, debug, expected):
+    if debug_env:
+        os.environ['DASH_DEBUG'] = debug_env
+    app = Dash()
+    with pytest.raises(AssertionError):
+        app.run(debug=debug, port=-1)
+    assert app._dev_tools.ui == expected
+
+@pytest.mark.parametrize(
+    "debug_env, debug, expected",
+    [
+        (None, None, True),
+        (None, True, True),
+        (None, False, False),
+        ('True', None, True),
+        ('True', True, True),
+        ('True', False, False),
+        ('False', None, False),
+        ('False', True, True),
+        ('False', False, False),
+    ],
+)
+def test_debug_mode_enable_dev_tools(empty_environ, debug_env, debug, expected):
+    if debug_env:
+        os.environ['DASH_DEBUG'] = debug_env
+    app = Dash()
+    # with pytest.raises(AssertionError):
+    app.enable_dev_tools(debug=debug)
+    assert app._dev_tools.ui == expected
+

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -461,6 +461,7 @@ def test_debug_mode_run(empty_environ, debug_env, debug, expected):
         app.run(debug=debug, port=-1)
     assert app._dev_tools.ui == expected
 
+
 @pytest.mark.parametrize(
     "debug_env, debug, expected",
     [
@@ -482,4 +483,3 @@ def test_debug_mode_enable_dev_tools(empty_environ, debug_env, debug, expected):
     # with pytest.raises(AssertionError):
     app.enable_dev_tools(debug=debug)
     assert app._dev_tools.ui == expected
-


### PR DESCRIPTION
Hey,
setting the debug value with the environment variable `DASH_DEBUG=true`, didn't work.
The default, if no debug value is given, is still false. Everything else works as intended.
This also fixes #1979 .

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Changing the default debug value for `app.run` to `None`
   -   [x] Changing the default debug value to `False` in `enable_dev_tools`
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

