### PR TITLE
Wait for class testing utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [#2003](https://github.com/plotly/dash/issues/2003) in which 
 `dangerously_allow_html=True` + `mathjax=True` works in some cases, and in some cases not.
 
-- [#2049](https://github.com/plotly/dash/pull/2043) Added `wait_for_class_to_equal` and `wait_for_contains_class` methods to `dash.testing`
+### Added
 
+- [#2049](https://github.com/plotly/dash/pull/2043) Added `wait_for_class_to_equal` and `wait_for_contains_class` methods to `dash.testing`
 
 ## [2.4.1] - 2022-05-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [#2003](https://github.com/plotly/dash/issues/2003) in which 
 `dangerously_allow_html=True` + `mathjax=True` works in some cases, and in some cases not.
 
+- [#2049](https://github.com/plotly/dash/pull/2043) Added `wait_for_class_to_equal` and `wait_for_contains_class` methods to `dash.testing`
+
+
 ## [2.4.1] - 2022-05-11
 
 ### Fixed

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -26,6 +26,7 @@ from dash.testing.wait import (
     style_to_equal,
     class_to_equal,
     contains_text,
+    contains_class,
     until,
 )
 from dash.testing.dash_page import DashPageMixin
@@ -341,6 +342,20 @@ class Browser(DashPageMixin):
             args=(selector, text),
             timeout=timeout,
             msg=f"text -> {text} not found within {timeout or self._wait_timeout}s",
+        )
+
+    def wait_for_contains_class(self, selector, classname, timeout=None):
+        """Explicit wait until the element's classes contains the expected `classname`.
+
+        timeout if not set, equals to the fixture's `wait_timeout`
+        shortcut to `WebDriverWait` with customized `contains_class`
+        condition.
+        """
+        return self._wait_for(
+            method=contains_class,
+            args=(selector, classname),
+            timeout=timeout,
+            msg=f"classname -> {classname} not found inside element within {timeout or self._wait_timeout}s",
         )
 
     def wait_for_contains_text(self, selector, text, timeout=None):

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -21,7 +21,13 @@ from selenium.common.exceptions import (
     MoveTargetOutOfBoundsException,
 )
 
-from dash.testing.wait import text_to_equal, style_to_equal, contains_text, until
+from dash.testing.wait import (
+    text_to_equal,
+    style_to_equal,
+    class_to_equal,
+    contains_text,
+    until,
+)
 from dash.testing.dash_page import DashPageMixin
 from dash.testing.errors import DashAppLoadingError, BrowserError, TestingTimeoutError
 from dash.testing.consts import SELENIUM_GRID_DEFAULT
@@ -299,6 +305,17 @@ class Browser(DashPageMixin):
             ((By.ID, element_id),),
             timeout,
             f"timeout {timeout or self._wait_timeout}s => waiting for element id {element_id}",
+        )
+
+    def wait_for_class_to_equal(self, selector, classname, timeout=None):
+        """Explicit wait until the element's class has expected `value` timeout
+        if not set, equals to the fixture's `wait_timeout` shortcut to
+        `WebDriverWait` with customized `class_to_equal` condition."""
+        return self._wait_for(
+            method=class_to_equal,
+            args=(selector, classname),
+            timeout=timeout,
+            msg=f"classname => {classname} not found within {timeout or self._wait_timeout}s",
         )
 
     def wait_for_style_to_equal(self, selector, style, val, timeout=None):

--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -68,6 +68,23 @@ class contains_text:
             return False
 
 
+class contains_class:
+    def __init__(self, selector, classname):
+        self.selector = selector
+        self.classname = classname
+
+    def __call__(self, driver):
+        try:
+            elem = driver.find_element(By.CSS_SELECTOR, self.selector)
+            classname = elem.get_attribute("class")
+            logger.debug(
+                "contains class {%s} => expected %s", classname, self.classname
+            )
+            return self.classname in str(classname)
+        except WebDriverException:
+            return False
+
+
 class text_to_equal:
     def __init__(self, selector, text):
         self.selector = selector

--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -99,3 +99,20 @@ class style_to_equal:
             return val == self.val
         except WebDriverException:
             return False
+
+
+class class_to_equal:
+    def __init__(self, selector, classname):
+        self.selector = selector
+        self.classname = classname
+
+    def __call__(self, driver):
+        try:
+            elem = driver.find_element(By.CSS_SELECTOR, self.selector)
+            classname = elem.get_attribute("class")
+            logger.debug(
+                "class to equal {%s} => expected %s", classname, self.classname
+            )
+            return str(classname) == self.classname
+        except WebDriverException:
+            return False

--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -80,7 +80,7 @@ class contains_class:
             logger.debug(
                 "contains class {%s} => expected %s", classname, self.classname
             )
-            return self.classname in str(classname)
+            return self.classname in str(classname).split(" ")
         except WebDriverException:
             return False
 


### PR DESCRIPTION
As more and more CSS libraries and frameworks are using utility classes, there is a growing need for people to check an elements class attribute contains or equals a value. I am currently in this circumstance building a set of custom AIO components utilising TailwindCSS and FontAwesome icons.

My reasoning for making this addition was to check a callback had successfully changed the icon within a div. FontAwesome uses the `::before` pseudo-element with a `content` css property to contain the unicode character of the icon. The process to access psuedo-elements within Selenium is not the most developer friendly method ([example here](https://stackoverflow.com/a/59706267)) but if they're being created by classes, why not just check and wait for those? 

The testing documentation ([located here](https://dash.plotly.com/testing)) would need to be updated to include these new options under Browser APIs.

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  [X] Add wait_for_class_to_equal
   -  [X] Add wait_for_contains_class
- [X] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added entry in the `CHANGELOG.md`
