### PR TITLE
Fixing desired capabilities and find element deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [#2003](https://github.com/plotly/dash/issues/2003) in which 
 `dangerously_allow_html=True` + `mathjax=True` works in some cases, and in some cases not.
 
+### Changed
+
+- [#2050](https://github.com/plotly/dash/pull/2050) Changed `find_element` and `find_elements` to accept an `attribute` argument that aligns with Selenium's `By` class, allowing you to search elements by other attributes. Default value is `CSS_SELECTOR` to maintain backwards compatibility with previous `find_elements`.
+
 ## [2.4.1] - 2022-05-11
 
 ### Fixed

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -230,13 +230,23 @@ class Browser(DashPageMixin):
 
     def find_element(self, selector, attribute="CSS_SELECTOR"):
         """find_element returns the first found element by the attribute `selector`
-        shortcut to `driver.find_element(By.CSS_SELECTOR, ...)`."""
+        shortcut to `driver.find_element(By.CSS_SELECTOR, ...)`.
+        args:
+        - attribute: the attribute type to search for, aligns with the Selenium
+            API's `By` class. default "CSS_SELECTOR"
+            valid values: "CSS_SELECTOR", "ID", "NAME", "TAG_NAME",
+            "CLASS_NAME", "LINK_TEXT", "PARTIAL_LINK_TEXT", "XPATH"
+        """
         return self.driver.find_element(getattr(By, attribute.upper()), selector)
 
     def find_elements(self, selector, attribute="CSS_SELECTOR"):
         """find_elements returns a list of all elements matching the attribute
-        `selector`
-        shortcut to `driver.find_elements(By.CSS_SELECTOR, ...)`.
+        `selector`. Shortcut to `driver.find_elements(By.CSS_SELECTOR, ...)`.
+        args:
+        - attribute: the attribute type to search for, aligns with the Selenium
+            API's `By` class. default "CSS_SELECTOR"
+            valid values: "CSS_SELECTOR", "ID", "NAME", "TAG_NAME",
+            "CLASS_NAME", "LINK_TEXT", "PARTIAL_LINK_TEXT", "XPATH"
         """
         return self.driver.find_elements(getattr(By, attribute.upper()), selector)
 
@@ -450,10 +460,7 @@ class Browser(DashPageMixin):
         options.add_argument("--remote-debugging-port=9222")
 
         chrome = (
-            webdriver.Remote(
-                command_executor=self._remote_url,
-                options=options
-            )
+            webdriver.Remote(command_executor=self._remote_url, options=options)
             if self._remote
             else webdriver.Chrome(options=options)
         )

--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -12,7 +12,6 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 from selenium.webdriver.common.action_chains import ActionChains
 
 from selenium.common.exceptions import (
@@ -229,18 +228,17 @@ class Browser(DashPageMixin):
 
         self.driver.save_screenshot(f"{target}/{name}_{self.session_id}.png")
 
-    def find_element(self, selector):
-        """find_element returns the first found element by the css `selector`
+    def find_element(self, selector, attribute="CSS_SELECTOR"):
+        """find_element returns the first found element by the attribute `selector`
         shortcut to `driver.find_element(By.CSS_SELECTOR, ...)`."""
-        return self.driver.find_element(By.CSS_SELECTOR, selector)
+        return self.driver.find_element(getattr(By, attribute.upper()), selector)
 
-    def find_elements(self, selector):
-        """find_elements returns a list of all elements matching the css
-        `selector`.
-
+    def find_elements(self, selector, attribute="CSS_SELECTOR"):
+        """find_elements returns a list of all elements matching the attribute
+        `selector`
         shortcut to `driver.find_elements(By.CSS_SELECTOR, ...)`.
         """
-        return self.driver.find_elements(By.CSS_SELECTOR, selector)
+        return self.driver.find_elements(getattr(By, attribute.upper()), selector)
 
     def _get_element(self, elem_or_selector):
         if isinstance(elem_or_selector, str):
@@ -430,9 +428,8 @@ class Browser(DashPageMixin):
     def _get_chrome(self):
         options = self._get_wd_options()
 
-        capabilities = DesiredCapabilities.CHROME
-        capabilities["loggingPrefs"] = {"browser": "SEVERE"}
-        capabilities["goog:loggingPrefs"] = {"browser": "SEVERE"}
+        options.set_capability("loggingPrefs", {"browser": "SEVERE"})
+        options.set_capability("goog:loggingPrefs", {"browser": "SEVERE"})
 
         if "DASH_TEST_CHROMEPATH" in os.environ:
             options.binary_location = os.environ["DASH_TEST_CHROMEPATH"]
@@ -455,11 +452,10 @@ class Browser(DashPageMixin):
         chrome = (
             webdriver.Remote(
                 command_executor=self._remote_url,
-                options=options,
-                desired_capabilities=capabilities,
+                options=options
             )
             if self._remote
-            else webdriver.Chrome(options=options, desired_capabilities=capabilities)
+            else webdriver.Chrome(options=options)
         )
 
         # https://bugs.chromium.org/p/chromium/issues/detail?id=696481
@@ -482,15 +478,12 @@ class Browser(DashPageMixin):
     def _get_firefox(self):
         options = self._get_wd_options()
 
-        capabilities = DesiredCapabilities.FIREFOX
-        capabilities["loggingPrefs"] = {"browser": "SEVERE"}
-        capabilities["marionette"] = True
+        options.set_capability("loggingPrefs", {"browser": "SEVERE"})
+        options.set_capability("marionette", True)
 
-        # https://developer.mozilla.org/en-US/docs/Download_Manager_preferences
-        fp = webdriver.FirefoxProfile()
-        fp.set_preference("browser.download.dir", self.download_path)
-        fp.set_preference("browser.download.folderList", 2)
-        fp.set_preference(
+        options.set_preference("browser.download.dir", self.download_path)
+        options.set_preference("browser.download.folderList", 2)
+        options.set_preference(
             "browser.helperApps.neverAsk.saveToDisk",
             "application/octet-stream",  # this MIME is generic for binary
         )
@@ -498,12 +491,9 @@ class Browser(DashPageMixin):
             webdriver.Remote(
                 command_executor=self._remote_url,
                 options=options,
-                desired_capabilities=capabilities,
             )
             if self._remote
-            else webdriver.Firefox(
-                firefox_profile=fp, options=options, capabilities=capabilities
-            )
+            else webdriver.Firefox(options=options)
         )
 
     @staticmethod

--- a/tests/integration/dash_assets/test_dash_assets.py
+++ b/tests/integration/dash_assets/test_dash_assets.py
@@ -114,7 +114,7 @@ def test_dada002_external_files_init(dash_duo):
         (("//script[@src='{}']", x) for x in js_urls),
         (("//link[@href='{}']", x) for x in css_urls),
     ):
-        dash_duo.driver.find_element_by_xpath(fmt.format(url))
+        dash_duo.find_element(fmt.format(url), attribute="XPATH")
 
     assert (
         dash_duo.find_element("#btn").value_of_css_property("height") == "18px"

--- a/tests/integration/devtools/test_devtools_ui.py
+++ b/tests/integration/devtools/test_devtools_ui.py
@@ -256,4 +256,4 @@ def test_dvui007_other_before_request_func(dash_thread_server, dash_br):
     )
 
     driver.get(dash_thread_server.url)
-    dash_br.find_element("alternative_id", attribute="ID")
+    dash_br.find_element("#alternative_id")

--- a/tests/integration/devtools/test_devtools_ui.py
+++ b/tests/integration/devtools/test_devtools_ui.py
@@ -256,4 +256,4 @@ def test_dvui007_other_before_request_func(dash_thread_server, dash_br):
     )
 
     driver.get(dash_thread_server.url)
-    driver.find_element_by_id("alternative_id")
+    dash_br.find_element("alternative_id", attribute="ID")


### PR DESCRIPTION
This PR closes #1870 

When running the tests, `DeprecationWarning: desired_capabilities has been deprecated, please pass in a Service object` is shown.

There was also another similar message that has been dealt with in this PR: `DeprecationWarning: find_element_by_* commands are deprecated. Please use find_element() instead`. This has been solved by `find_element` and `find_elements` now taking an attribute keyword, as a string, for the type of selector that is being used. default is set to `CSS_SELECTOR` as that's what historically `find_element` was solely for.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Fix `desired_capabilities` deprecation warning
   -  [x] Fix `find_element_by_*` deprecation warning
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added entry in the `CHANGELOG.md`
