### PR TITLE
Fixes AIO Callback testing with Dash-Duo

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1400,10 +1400,9 @@ class Dash:
                     "assigned with `app.callback`."
                 )
 
-            self.callback_map[k] = _callback.GLOBAL_CALLBACK_MAP.pop(k)
+            self.callback_map[k] = _callback.GLOBAL_CALLBACK_MAP[k]
 
         self._callback_list.extend(_callback.GLOBAL_CALLBACK_LIST)
-        _callback.GLOBAL_CALLBACK_LIST.clear()
 
     def _add_assets_resource(self, url_path, file_path):
         res = {"asset_path": url_path, "filepath": file_path}


### PR DESCRIPTION
This PR fixes #1933. The AIO components are unable to be tested using Pytest and the Dash-Duo object. The callbacks set via `dash.callback` (rather than `app.callback`) are added to a global map that is cleared after the first instance of `dash.Dash._setup_server`.

To get around this, I'm currently exploring whether it is possible to leave the `GLOBAL_CALLBACK_MAP` and `GLOBAL_CALLBACK_LIST` populated rather than clearing them on setup.

## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] Explore whether it is as simple as allowing the MAP and LIST to remain populated
   -  [ ] If not, explore whether we can have another MAP as suggested by @T4rk1n in #1933 
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
