### PR TITLE
Fix Dropdown with a value but no options.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [#2003](https://github.com/plotly/dash/issues/2003) in which 
 `dangerously_allow_html=True` + `mathjax=True` works in some cases, and in some cases not.
 - [#2047](https://github.com/plotly/dash/pull/2047) Fix bug [#1979](https://github.com/plotly/dash/issues/1979) in which `DASH_DEBUG` as enviroment variable gets ignored.
+- [#2065](https://github.com/plotly/dash/pull/2065) Fix bug [#2064](https://github.com/plotly/dash/issues/2064) rendering of `dcc.Dropdown` with a value but no options.
 
 ### Changed
 

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -85,7 +85,11 @@ const Dropdown = props => {
     );
 
     useEffect(() => {
-        if (optionsCheck !== sanitizedOptions && !isNil(value)) {
+        if (
+            !isNil(sanitizedOptions) &&
+            optionsCheck !== sanitizedOptions &&
+            !isNil(value)
+        ) {
             const values = sanitizedOptions.map(option => option.value);
             if (multi && Array.isArray(value)) {
                 const invalids = value.filter(v => !values.includes(v));

--- a/components/dash-core-components/tests/integration/dropdown/test_dynamic_options.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_dynamic_options.py
@@ -67,3 +67,17 @@ def test_dddo002_array_comma_value(dash_dcc):
     dash_dcc.wait_for_text_to_equal("#react-select-2--value-0", "San Francisco, CA\n ")
 
     assert dash_dcc.get_logs() == []
+
+
+def test_dddo003_value_no_options(dash_dcc):
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(value="foobar", id="dropdown"),
+        ]
+    )
+
+    dash_dcc.start_server(app)
+    assert dash_dcc.get_logs() == []
+    dash_dcc.wait_for_element("#dropdown")


### PR DESCRIPTION
Fix Dropdown rendering error when a value is provided but no options. `dcc.Dropdown(value="option")`. Fix #2064 

## Contributor Checklist

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
