### PR TITLE
Fixed viewport meta-tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Fixed
+- []() In dash 2.5.0, a default viewport meta tag was added as recommended for mobile-optimized sites by [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag)
+This feature can be disabled by providing an empty viewport meta tag.  e.g. `app = Dash(meta_tags=[{"name": "viewport"}])`
+
 ## [2.5.0] - 2022-06-07
 
 ### Added

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -843,7 +843,7 @@ class Dash:
             x.get("http-equiv", "") == "X-UA-Compatible" for x in meta_tags
         )
         has_charset = any("charset" in x for x in meta_tags)
-        has_viewport = any("viewport" in x for x in meta_tags)
+        has_viewport = any(x.get("name") == "viewport" for x in meta_tags)
 
         tags = []
         if not has_ie_compat:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -133,6 +133,29 @@ def test_inin007_meta_tags(dash_duo):
         assert meta_tag.get_attribute("content") == meta_info["content"]
 
 
+def test_inin007b_change_viewport_meta_tag(dash_duo):
+    """
+    As of dash 2.5 the default viewport meta tag is:
+        [{"name": "viewport", "content": "width=device-width, initial-scale=1"}]
+    Test verifies that this feature can be disabled by using an empty viewport tag.
+    """
+
+    app = Dash(meta_tags=[{"name": "viewport"}])
+
+    app.layout = html.Div(id="content")
+
+    dash_duo.start_server(app)
+
+    meta = dash_duo.find_elements("meta")
+
+    # -3 for the meta charset, http-equiv and viewport.
+    assert len(meta) == 3, "Should have 3 meta tags"
+
+    viewport_meta = meta[2]
+    assert viewport_meta.get_attribute("name") == "viewport"
+    assert viewport_meta.get_attribute("content") == ""
+
+
 def test_inin008_index_customization(dash_duo):
     app = Dash()
 


### PR DESCRIPTION

In dash 2.5.0, a default viewport meta tag was added as recommended for mobile-optimized sites by [mdn.](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag)
This PR makes it so that this feature can be disabled by providing an empty viewport meta tag. 
 e.g. `app = Dash(meta_tags=[{"name": "viewport"}])`

## Contributor Checklist
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
- [x] I have added entry in the `CHANGELOG.md`
