### PR TITLE
Fix args_grouping to handle "id" in the `id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
-- [#2087](https://github.com/plotly/dash/pull/2087) Fix bug [#2086](https://github.com/plotly/dash/issues/2086) in which using id as a key within a component's id breaks the new callback context's args_grouping function.
+- [#2087](https://github.com/plotly/dash/pull/2087) Fix bug [#2086](https://github.com/plotly/dash/issues/2086) in which using id as a key within a component's id breaks the new callback context's `args_grouping` function.
 - [#2084](https://github.com/plotly/dash/pull/2084) In dash 2.5.0, a default viewport meta tag was added as recommended for mobile-optimized sites by [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag)
 This feature can be disabled by providing an empty viewport meta tag.  e.g. `app = Dash(meta_tags=[{"name": "viewport"}])`
+
+### Removed
+
+- [#2087](https://github.com/plotly/dash/pull/2087) Removed the undocumented callback context `args_grouping_values` property which was incompatible with pattern-matching callbacks.
 
 ## [2.5.0] - 2022-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Unreleased
 
 ### Fixed
+
+- [#2087](https://github.com/plotly/dash/pull/2087) Fix bug [#2086](https://github.com/plotly/dash/issues/2086) in which using id as a key within a component's id breaks the new callback context's args_grouping function.
 - [#2084](https://github.com/plotly/dash/pull/2084) In dash 2.5.0, a default viewport meta tag was added as recommended for mobile-optimized sites by [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag)
 This feature can be disabled by providing an empty viewport meta tag.  e.g. `app = Dash(meta_tags=[{"name": "viewport"}])`
 

--- a/dash/_callback_context.py
+++ b/dash/_callback_context.py
@@ -152,7 +152,7 @@ class CallbackContext:
         grouping = getattr(flask.g, "args_grouping", {})
 
         def update_args_grouping(g):
-            if isinstance(g, dict) and "id" in g:
+            if isinstance(g, dict) and isinstance(g.get("id"), dict):
                 str_id = stringify_id(g["id"])
                 prop_id = f"{str_id}.{g['property']}"
 

--- a/dash/_callback_context.py
+++ b/dash/_callback_context.py
@@ -170,7 +170,8 @@ class CallbackContext:
             if isinstance(g, (tuple, list)):
                 for i in g:
                     update_args_grouping(i)
-                    recursive_update(i)
+                    if not isinstance(i.get("id"), dict):
+                        recursive_update(i)
             if isinstance(g, dict):
                 for i in g.values():
                     update_args_grouping(i)

--- a/dash/_callback_context.py
+++ b/dash/_callback_context.py
@@ -1,11 +1,10 @@
 import functools
 import warnings
 import json
-from copy import deepcopy
 import flask
 
 from . import exceptions
-from ._utils import stringify_id, AttributeDict
+from ._utils import AttributeDict
 
 
 def has_context(func):
@@ -147,60 +146,7 @@ class CallbackContext:
                return "No clicks yet"
 
         """
-        triggered = getattr(flask.g, "triggered_inputs", [])
-        triggered = [item["prop_id"] for item in triggered]
-        grouping = getattr(flask.g, "args_grouping", {})
-
-        def update_args_grouping(g):
-            if isinstance(g, dict) and "id" in g and "property" in g:
-                str_id = stringify_id(g["id"])
-                prop_id = f"{str_id}.{g['property']}"
-
-                new_values = {
-                    "value": g.get("value"),
-                    "str_id": str_id,
-                    "triggered": prop_id in triggered,
-                    "id": AttributeDict(g["id"])
-                    if isinstance(g["id"], dict)
-                    else g["id"],
-                }
-                g.update(new_values)
-
-        def recursive_update(g):
-            if isinstance(g, (tuple, list)):
-                for i in g:
-                    update_args_grouping(i)
-                    if not isinstance(i.get("id"), dict):
-                        recursive_update(i)
-            if isinstance(g, dict):
-                for i in g.values():
-                    update_args_grouping(i)
-                    recursive_update(i)
-
-        recursive_update(grouping)
-
-        return grouping
-
-    # todo not sure whether we need this, but it removes a level of nesting so
-    #  you don't need to use `.value` to get the value.
-    @property
-    @has_context
-    def args_grouping_values(self):
-        grouping = getattr(flask.g, "args_grouping", {})
-        grouping = deepcopy(grouping)
-
-        def recursive_update(g):
-            if isinstance(g, (tuple, list)):
-                for i in g:
-                    recursive_update(i)
-            if isinstance(g, dict):
-                for k, v in g.items():
-                    if isinstance(v, dict) and "id" in v:
-                        g[k] = v["value"]
-                    recursive_update(v)
-
-        recursive_update(grouping)
-        return grouping
+        return getattr(flask.g, "args_grouping", [])
 
     @property
     @has_context

--- a/dash/_callback_context.py
+++ b/dash/_callback_context.py
@@ -152,7 +152,7 @@ class CallbackContext:
         grouping = getattr(flask.g, "args_grouping", {})
 
         def update_args_grouping(g):
-            if isinstance(g, dict) and isinstance(g.get("id"), dict):
+            if isinstance(g, dict) and "id" in g and "property" in g:
                 str_id = stringify_id(g["id"])
                 prop_id = f"{str_id}.{g['property']}"
 

--- a/dash/_grouping.py
+++ b/dash/_grouping.py
@@ -14,7 +14,7 @@ structure
 
 """
 from dash.exceptions import InvalidCallbackReturnValue
-from ._utils import AttributeDict
+from ._utils import AttributeDict, stringify_id
 
 
 def flatten_grouping(grouping, schema=None):
@@ -222,3 +222,17 @@ def validate_grouping(grouping, schema, full_schema=None, path=()):
             )
     else:
         pass
+
+
+def update_args_group(g, triggered):
+    if isinstance(g, dict):
+        str_id = stringify_id(g["id"])
+        prop_id = f"{str_id}.{g['property']}"
+
+        new_values = {
+            "value": g.get("value"),
+            "str_id": str_id,
+            "triggered": prop_id in triggered,
+            "id": AttributeDict(g["id"]) if isinstance(g["id"], dict) else g["id"],
+        }
+        g.update(new_values)

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -61,11 +61,7 @@ from . import _validate
 from . import _watch
 from . import _get_app
 
-from ._grouping import (
-    flatten_grouping,
-    map_grouping,
-    grouping_len,
-)
+from ._grouping import flatten_grouping, map_grouping, grouping_len, update_args_group
 
 from . import _pages
 from ._pages import (
@@ -1430,6 +1426,14 @@ class Dash:
             inputs_state_indices = cb["inputs_state_indices"]
             inputs_state = inputs + state
             inputs_state = convert_to_AttributeDict(inputs_state)
+
+            # update args_grouping attributes
+            for g in inputs_state:
+                # check for pattern matching: list of inputs or state
+                if isinstance(g, list):
+                    for pattern_match_g in g:
+                        update_args_group(pattern_match_g, changed_props)
+                update_args_group(g, changed_props)
 
             args_grouping = map_grouping(
                 lambda ind: inputs_state[ind], inputs_state_indices

--- a/tests/assets/grouping_app.py
+++ b/tests/assets/grouping_app.py
@@ -39,7 +39,7 @@ def grouping_app():
         ),
         dict(
             items=dict(
-                all=State({"item": ALL}, "children"),
+                all=State({"id": ALL}, "children"),
                 new=State("new-item", "value"),
             ),
             triggers=[Input("add", "n_clicks"), Input("new-item", "n_submit")],
@@ -64,11 +64,11 @@ def grouping_app():
             html.Div(
                 [
                     dcc.Checklist(
-                        id={"item": i, "action": "done"},
+                        id={"id": i, "action": "done"},
                         options=[{"label": "", "value": "done"}],
                         style={"display": "inline"},
                     ),
-                    html.Div(text, id={"item": i}, style=style_todo),
+                    html.Div(text, id={"id": i}, style=style_todo),
                 ],
                 style={"clear": "both"},
             )

--- a/tests/assets/grouping_app.py
+++ b/tests/assets/grouping_app.py
@@ -64,7 +64,7 @@ def grouping_app():
             html.Div(
                 [
                     dcc.Checklist(
-                        id={"id": i, "action": "done"},
+                        id={"id": i, "property": "done"},
                         options=[{"label": "", "value": "done"}],
                         style={"display": "inline"},
                     ),

--- a/tests/integration/callbacks/test_wildcards.py
+++ b/tests/integration/callbacks/test_wildcards.py
@@ -421,10 +421,10 @@ def test_cbwc006_grouping_callbacks(dash_duo):
             items=dict(
                 all=[
                     {
-                        "id": {"item": i},
+                        "id": {"id": i},
                         "property": "children",
                         "value": text,
-                        "str_id": stringify_id({"item": i}),
+                        "str_id": stringify_id({"id": i}),
                         "triggered": False,
                     }
                     for i, text in enumerate(items_text[:-1])


### PR DESCRIPTION
fixes [#2086](https://github.com/plotly/dash/issues/2086) where using id as a key within a component's id breaks the new callback context's args_grouping function. 
## Contributor Checklist

- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
- [x] I have added entry in the `CHANGELOG.md`
