### PR TITLE
Allow both 400 and 401 for JWT expiry responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2098](https://github.com/plotly/dash/pull/2098) Accept HTTP code 400 as well as 401 for JWT expiry
 - [#2097](https://github.com/plotly/dash/pull/2097) Fix bug [#2095](https://github.com/plotly/dash/issues/2095) with TypeScript compiler and `React.FC` empty valueDeclaration error & support empty props components.
 
 ## [2.5.1] - 2022-06-13
@@ -35,8 +36,8 @@ This feature can be disabled by providing an empty viewport meta tag.  e.g. `app
 
 ### Fixed
 
-- [#2043](https://github.com/plotly/dash/pull/2043) Fix bug 
-[#2003](https://github.com/plotly/dash/issues/2003) in which 
+- [#2043](https://github.com/plotly/dash/pull/2043) Fix bug
+[#2003](https://github.com/plotly/dash/issues/2003) in which
 `dangerously_allow_html=True` + `mathjax=True` works in some cases, and in some cases not.
 - [#2065](https://github.com/plotly/dash/pull/2065) Fix bug [#2064](https://github.com/plotly/dash/issues/2064) rendering of `dcc.Dropdown` with a value but no options.
 - [#2047](https://github.com/plotly/dash/pull/2047) Fix bug [#1979](https://github.com/plotly/dash/issues/1979) in which `DASH_DEBUG` as environment variable gets ignored.

--- a/dash/dash-renderer/src/actions/api.js
+++ b/dash/dash-renderer/src/actions/api.js
@@ -65,7 +65,10 @@ export default function apiThunk(endpoint, method, store, id, body) {
                     return;
                 }
 
-                if (res.status === STATUS.UNAUTHORIZED) {
+                if (
+                    res.status === STATUS.UNAUTHORIZED ||
+                    res.status === STATUS.BAD_REQUEST
+                ) {
                     if (hooks.request_refresh_jwt) {
                         const body = await res.text();
                         if (body.includes(JWT_EXPIRED_MESSAGE)) {

--- a/dash/dash-renderer/src/actions/callbacks.ts
+++ b/dash/dash-renderer/src/actions/callbacks.ts
@@ -536,7 +536,8 @@ export function executeCallback(
                         lastError = res;
                         if (
                             retry <= MAX_AUTH_RETRIES &&
-                            res.status === STATUS.UNAUTHORIZED
+                            (res.status === STATUS.UNAUTHORIZED ||
+                                res.status === STATUS.BAD_REQUEST)
                         ) {
                             const body = await res.text();
 

--- a/dash/dash-renderer/src/constants/constants.js
+++ b/dash/dash-renderer/src/constants/constants.js
@@ -5,6 +5,10 @@ export const JWT_EXPIRED_MESSAGE = 'JWT Expired';
 export const STATUS = {
     OK: 200,
     PREVENT_UPDATE: 204,
+    // We accept both 400 and 401 for JWT token expiry responses.
+    // Some servers use code 400 for expired tokens, because
+    // they reserve 401 for cases that require user action
+    BAD_REQUEST: 400,
     UNAUTHORIZED: 401,
     CLIENTSIDE_ERROR: 'CLIENTSIDE_ERROR',
     NO_RESPONSE: 'NO_RESPONSE'

--- a/dash/development/base_component.py
+++ b/dash/development/base_component.py
@@ -196,7 +196,7 @@ class Component(metaclass=ComponentMeta):
                 """
             )
 
-        v = str(uuid.UUID(int=rd.randint(0, 2 ** 128)))
+        v = str(uuid.UUID(int=rd.randint(0, 2**128)))
         setattr(self, "id", v)
         return v
 

--- a/tests/integration/renderer/test_request_hooks.py
+++ b/tests/integration/renderer/test_request_hooks.py
@@ -1,6 +1,7 @@
 import json
 import functools
 import flask
+import pytest
 
 from dash import Dash, Output, Input, html, dcc
 from werkzeug.exceptions import HTTPException
@@ -195,7 +196,8 @@ def test_rdrh002_with_custom_renderer_interpolated(dash_duo):
     assert dash_duo.get_logs() == []
 
 
-def test_rdrh003_refresh_jwt(dash_duo):
+@pytest.mark.parametrize("expiry_code", [401, 400])
+def test_rdrh003_refresh_jwt(expiry_code, dash_duo):
 
     app = Dash(__name__)
 
@@ -260,7 +262,7 @@ def test_rdrh003_refresh_jwt(dash_duo):
                 ):
                     # Read the data to prevent bug with base http server.
                     flask.request.get_json(silent=True)
-                    flask.abort(401, description="JWT Expired " + str(token))
+                    flask.abort(expiry_code, description="JWT Expired " + str(token))
             except HTTPException as e:
                 return e
             return func(*args, **kwargs)


### PR DESCRIPTION
As in my comment in the code: Some servers use code 400 for expired tokens, because they reserve 401 for cases that require user action.

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
- [x] I have added entry in the `CHANGELOG.md`