### PR TITLE
Dropdown component label search

### DIFF
--- a/components/dash-core-components/src/components/Dropdown.react.js
+++ b/components/dash-core-components/src/components/Dropdown.react.js
@@ -80,6 +80,14 @@ Dropdown.propTypes = {
                  * see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/title
                  */
                 title: PropTypes.string,
+
+                /**
+                 * Optional search value for the option, to use if the label
+                 * is a component or provide a custom search value different
+                 * from the label. If no search value and the label is a
+                 * component, the `value` will be used for search.
+                 */
+                search: PropTypes.string,
             })
         ),
     ]),

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -1,4 +1,4 @@
-import {isNil, pluck, without, pick} from 'ramda';
+import {isNil, pluck, without, pick, head} from 'ramda';
 import React, {useState, useCallback, useEffect, useMemo} from 'react';
 import ReactDropdown from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
@@ -47,12 +47,26 @@ const Dropdown = props => {
     } = props;
     const [optionsCheck, setOptionsCheck] = useState(null);
     const [sanitizedOptions, filterOptions] = useMemo(() => {
-        const sanitized = sanitizeOptions(options);
+        let sanitized = sanitizeOptions(options);
+        const firstOption = head(sanitized);
+        let labelKey = 'label';
+        if (firstOption && firstOption.search) {
+            labelKey = 'search';
+        } else if (firstOption && React.isValidElement(firstOption.label)) {
+            // Auto put the value as search
+            labelKey = 'search';
+            sanitized = sanitized.map(option => ({
+                ...option,
+                search: `${option.value}`,
+            }));
+        }
+
         return [
             sanitized,
             createFilterOptions({
                 options: sanitized,
                 tokenizer: TOKENIZER,
+                labelKey,
             }),
         ];
     }, [options]);

--- a/components/dash-core-components/tests/integration/misc/test_dcc_components_as_props.py
+++ b/components/dash-core-components/tests/integration/misc/test_dcc_components_as_props.py
@@ -41,3 +41,10 @@ def test_mdcap001_dcc_components_as_props(dash_dcc):
     dash_dcc.find_element("#dropdown").click()
     dash_dcc.wait_for_text_to_equal("#dropdown h4", "h4")
     dash_dcc.wait_for_text_to_equal("#dropdown h6", "h6")
+
+    search_input = dash_dcc.find_element("#dropdown input")
+    search_input.send_keys("4")
+    options = dash_dcc.find_elements("#dropdown .VirtualizedSelectOption")
+
+    assert len(options) == 1
+    assert options[0].text == "h4"


### PR DESCRIPTION
Add `search` prop for the options of `dcc.Dropdown`. Fix #2108 

- Use if the `label` is a component or provide a custom search value different from the label.
- If no search value and the label is a component, the `value` will be used for search.