### PR TITLE
Enable copying text to clipboard for tables with `cell_selectable=False`

### DIFF
--- a/components/dash-table/src/dash-table/components/ControlledTable/index.tsx
+++ b/components/dash-table/src/dash-table/components/ControlledTable/index.tsx
@@ -794,14 +794,17 @@ export default class ControlledTable extends PureComponent<ControlledTableProps>
             include_headers_on_copy_paste
         } = this.props;
 
-        TableClipboardHelper.toClipboard(
-            e,
-            selected_cells,
-            columns,
-            visibleColumns,
-            viewport.data,
-            include_headers_on_copy_paste
-        );
+        // if no cells are selected, fall back to the browser's default copy event handling
+        if (selected_cells.length) {
+            TableClipboardHelper.toClipboard(
+                e,
+                selected_cells,
+                columns,
+                visibleColumns,
+                viewport.data,
+                include_headers_on_copy_paste
+            );
+        }
         this.$el.focus();
     };
 

--- a/components/dash-table/src/dash-table/components/Table/Table.less
+++ b/components/dash-table/src/dash-table/components/Table/Table.less
@@ -427,10 +427,6 @@
                     height: 100%;
                     width: 100%;
 
-                    &.unfocused::selection {
-                        background-color: transparent;
-                    }
-
                     &.unfocused {
                         caret-color: transparent;
                     }


### PR DESCRIPTION
This PR makes sure that for DataTables with `cell_selectable=False`, the _text content_ of a cell can be selected and copied to the clipboard as is normally handled by the browser.

It fixes issue https://github.com/plotly/dash/issues/1978.

## Contributor Checklist

- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`

