### PR TITLE
Adds ability to redirect "/" when using pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2109](https://github.com/plotly/dash/pull/2109) Add `maxHeight` to Dropdown options menu.
 
 ### Fixed
+- [#2126](https://github.com/plotly/dash/pull/2126) Fix bug where it was not possible to redirect from root when using pages.
 - [#2114](https://github.com/plotly/dash/pull/2114) Fix bug [#1978](https://github.com/plotly/dash/issues/1978) where text could not be copied from cells in tables with `cell_selectable=False`.
 - [#2102](https://github.com/plotly/dash/pull/2102) Fix bug as reported in [dash-labs #113](https://github.com/plotly/dash-labs/issues/113) where files starting with `.` were not excluded when building `dash.page_registry`.
 - [#2098](https://github.com/plotly/dash/pull/2098) Accept HTTP code 400 as well as 401 for JWT expiry

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -556,7 +556,8 @@ class Dash:
         self._add_url("_dash-update-component", self.dispatch, ["POST"])
         self._add_url("_reload-hash", self.serve_reload_hash)
         self._add_url("_favicon.ico", self._serve_default_favicon)
-        self._add_url("", self.index)
+        if not self.use_pages:
+            self._add_url("", self.index)
 
         # catch-all for front-end routes, used by dcc.Location
         self._add_url("<path:path>", self.index)
@@ -2114,6 +2115,11 @@ class Dash:
                             fullname,
                             create_redirect_function(page["relative_path"]),
                         )
+            # set "/" if not redirected
+            try:
+                self._add_url("", self.index)
+            except AssertionError:
+                pass
 
     def run_server(self, *args, **kwargs):
         """`run_server` is a deprecated alias of `run` and may be removed in a

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -415,3 +415,7 @@ def test_inin027_multi_page_without_pages_folder(dash_duo):
         assert dash_duo.driver.title == page["title"], "check that page title updates"
 
     assert not dash_duo.get_logs()
+
+    # clean up after this test, so it does not affect other pages tests
+    del dash.page_registry["multi_layout1"]
+    del dash.page_registry["multi_layout2"]

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -415,7 +415,3 @@ def test_inin027_multi_page_without_pages_folder(dash_duo):
         assert dash_duo.driver.title == page["title"], "check that page title updates"
 
     assert not dash_duo.get_logs()
-
-    # clean up after this test, so it does not affect other pages tests
-    del dash.page_registry["multi_layout1"]
-    del dash.page_registry["multi_layout2"]

--- a/tests/integration/test_pages_redirect_home.py
+++ b/tests/integration/test_pages_redirect_home.py
@@ -5,7 +5,11 @@ def test_pare001_redirect_home(dash_duo):
 
     app = dash.Dash(__name__, use_pages=True, pages_folder="")
 
-    dash.register_page("home", path="/", layout="Home")
+    dash.register_page(
+        "multi_layout1",
+        layout=dash.html.Div("text for multi_layout1", id="text_multi_layout1"),
+        path="/",
+    )
 
     dash.register_page(
         "redirect_home",
@@ -23,5 +27,4 @@ def test_pare001_redirect_home(dash_duo):
     assert dash_duo.get_logs() == [], "browser console should contain no error"
 
     # clean up after this test, so this redirect does not affect other pages tests
-    del dash.page_registry["home"]
     del dash.page_registry["redirect_home"]

--- a/tests/integration/test_pages_redirect_home.py
+++ b/tests/integration/test_pages_redirect_home.py
@@ -1,0 +1,27 @@
+import dash
+
+
+def test_pare001_redirect_home(dash_duo):
+
+    app = dash.Dash(__name__, use_pages=True, pages_folder="")
+
+    dash.register_page("home", path="/", layout="Home")
+
+    dash.register_page(
+        "redirect_home",
+        redirect_from=["/"],
+        layout=dash.html.Div("Redirect", id="redirect"),
+    )
+
+    app.layout = dash.page_container
+
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_page(url=f"http://localhost:{dash_duo.server.port}/redirect-home")
+    dash_duo.wait_for_text_to_equal("#redirect", "Redirect")
+
+    assert dash_duo.get_logs() == [], "browser console should contain no error"
+
+    # clean up after this test, so this redirect does not affect other pages tests
+    del dash.page_registry["home"]
+    del dash.page_registry["redirect_home"]


### PR DESCRIPTION
This PR fixes the bug noted in the [dash 2.5 announcement](https://community.plotly.com/t/dash-2-5-released-easier-multi-page-apps-component-properties/64925/6?u=annmariew), where it's not possible to redirect from the root page `"/"`

## Contributor Checklist


- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows    
    -  [ ] here is the show and tell thread in Plotly Dash community
