### PR TITLE
bump plotly.js v2.13.1

### DIFF
--- a/components/dash-core-components/package-lock.json
+++ b/components/dash-core-components/package-lock.json
@@ -22,7 +22,7 @@
         "mathjax": "^3.2.0",
         "moment": "^2.29.3",
         "node-polyfill-webpack-plugin": "^1.1.4",
-        "plotly.js-dist-min": "2.12.1",
+        "plotly.js-dist-min": "2.13.1",
         "prop-types": "^15.8.1",
         "ramda": "^0.28.0",
         "rc-slider": "^9.7.5",
@@ -6949,9 +6949,9 @@
       }
     },
     "node_modules/plotly.js-dist-min": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.12.1.tgz",
-      "integrity": "sha512-JFYDn/eKXlbaEr6touiiZsb745fHsd7cLhXDWSTVon4sdcx19pdPKf1f5jXf5xwZ8Dv5L28Lb5OPmxAkBp/6rw=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.13.1.tgz",
+      "integrity": "sha512-IBIp1TMUrpM5ILYYcyaC478UsonM31iFMrU9XgS9aJCUGlWjrr7PpsVARd2YTnA/GEtYvPOOyM9+n9f1txze7Q=="
     },
     "node_modules/postcss": {
       "version": "8.4.13",
@@ -14812,9 +14812,9 @@
       }
     },
     "plotly.js-dist-min": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.12.1.tgz",
-      "integrity": "sha512-JFYDn/eKXlbaEr6touiiZsb745fHsd7cLhXDWSTVon4sdcx19pdPKf1f5jXf5xwZ8Dv5L28Lb5OPmxAkBp/6rw=="
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/plotly.js-dist-min/-/plotly.js-dist-min-2.13.1.tgz",
+      "integrity": "sha512-IBIp1TMUrpM5ILYYcyaC478UsonM31iFMrU9XgS9aJCUGlWjrr7PpsVARd2YTnA/GEtYvPOOyM9+n9f1txze7Q=="
     },
     "postcss": {
       "version": "8.4.13",

--- a/components/dash-core-components/package.json
+++ b/components/dash-core-components/package.json
@@ -49,7 +49,7 @@
     "mathjax": "^3.2.0",
     "moment": "^2.29.3",
     "node-polyfill-webpack-plugin": "^1.1.4",
-    "plotly.js-dist-min": "2.12.1",
+    "plotly.js-dist-min": "2.13.1",
     "prop-types": "^15.8.1",
     "ramda": "^0.28.0",
     "rc-slider": "^9.7.5",


### PR DESCRIPTION
plotly.js release notes: 
https://github.com/plotly/plotly.js/releases/tag/v2.13.0
https://github.com/plotly/plotly.js/releases/tag/v2.13.1