### PR TITLE
revert 2126 until fixed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [UNRELEASED]
 
 - [#2146](https://github.com/plotly/dash/pull/2146) Remove leftover debug console.log statement.
+- [#2168](https://github.com/plotly/dash/pull/2168)  Reverts [#2126](https://github.com/plotly/dash/pull/2126) until the new bugs introduced by that PR are fixed.
 
 ## [2.6.0] - 2022-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [UNRELEASED]
 
 - [#2146](https://github.com/plotly/dash/pull/2146) Remove leftover debug console.log statement.
-- [#2168](https://github.com/plotly/dash/pull/2168)  Reverts [#2126](https://github.com/plotly/dash/pull/2126) until the new bugs introduced by that PR are fixed.
+- [#2168](https://github.com/plotly/dash/pull/2168)  Reverts [#2126](https://github.com/plotly/dash/pull/2126) (supporting redirect from root when using pages) until the new bugs introduced by that PR are fixed.
 
 ## [2.6.0] - 2022-07-14
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -556,8 +556,7 @@ class Dash:
         self._add_url("_dash-update-component", self.dispatch, ["POST"])
         self._add_url("_reload-hash", self.serve_reload_hash)
         self._add_url("_favicon.ico", self._serve_default_favicon)
-        if not self.use_pages:
-            self._add_url("", self.index)
+        self._add_url("", self.index)
 
         # catch-all for front-end routes, used by dcc.Location
         self._add_url("<path:path>", self.index)
@@ -2119,11 +2118,6 @@ class Dash:
                             fullname,
                             create_redirect_function(page["relative_path"]),
                         )
-            # set "/" if not redirected
-            try:
-                self._add_url("", self.index)
-            except AssertionError:
-                pass
 
     def run_server(self, *args, **kwargs):
         """`run_server` is a deprecated alias of `run` and may be removed in a

--- a/tests/integration/test_pages_redirect_home.py
+++ b/tests/integration/test_pages_redirect_home.py
@@ -1,7 +1,9 @@
 import dash
+import pytest
 
 
 def test_pare001_redirect_home(dash_duo):
+    pytest.skip("Revisit later")
 
     app = dash.Dash(__name__, use_pages=True, pages_folder="")
 


### PR DESCRIPTION
Two  new bugs were introduced in #2126 
 1) Breaks dash-auth as reported [here](https://community.plotly.com/t/basicauth-failing-with-dash-2-6/66170)
 2) At times, the app will not load initially until after the browser is refreshed.
![image](https://user-images.githubusercontent.com/72614349/180882367-53dcadc3-cec2-4d7b-9a70-78e9557b11c1.png)


This PR reverts 2126