### PR TITLE
exclude dirs in the pages folder that start with . or _

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2223](https://github.com/plotly/dash/pull/2223) Exclude hidden folders when building `dash.page_registry`.
 - [#2182](https://github.com/plotly/dash/pull/2182) Fix [#2172](https://github.com/plotly/dash/issues/2172)  Make it so that when using pages, if `suppress_callback_exceptions=True` the `validation_layout` is not set.
 - [#2152](https://github.com/plotly/dash/pull/2152) Fix bug [#2128](https://github.com/plotly/dash/issues/2128) preventing rendering of multiple components inside a dictionary.
 - [#2187](https://github.com/plotly/dash/pull/2187) Fix confusing error message when trying to use pytest fixtures but `dash[testing]` is not installed.

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1963,7 +1963,10 @@ class Dash:
     def _import_layouts_from_pages(self):
         walk_dir = self.config.pages_folder
 
-        for (root, _, files) in os.walk(walk_dir):
+        for (root, dirs, files) in os.walk(walk_dir):
+            dirs[:] = [
+                d for d in dirs if not d.startswith(".") and not d.startswith("_")
+            ]
             for file in files:
                 if (
                     file.startswith("_")

--- a/tests/integration/multi_page/pages/.no_import/no_import.py
+++ b/tests/integration/multi_page/pages/.no_import/no_import.py
@@ -1,0 +1,1 @@
+raise Exception("files in directories starting with . should not be imported")

--- a/tests/integration/multi_page/pages/.no_import/no_import.py
+++ b/tests/integration/multi_page/pages/.no_import/no_import.py
@@ -1,1 +1,3 @@
+from dash import register_page
+
 raise Exception("files in directories starting with . should not be imported")

--- a/tests/integration/multi_page/pages/.no_import/no_import.py
+++ b/tests/integration/multi_page/pages/.no_import/no_import.py
@@ -1,3 +1,5 @@
 from dash import register_page
 
+register_page(__name__)
+
 raise Exception("files in directories starting with . should not be imported")

--- a/tests/integration/multi_page/pages/_no_import.py
+++ b/tests/integration/multi_page/pages/_no_import.py
@@ -1,3 +1,5 @@
 from dash import register_page
 
+register_page(__name__)
+
 raise Exception("files starting with _ should not be imported")

--- a/tests/integration/multi_page/pages/_no_import.py
+++ b/tests/integration/multi_page/pages/_no_import.py
@@ -1,1 +1,3 @@
+from dash import register_page
+
 raise Exception("files starting with _ should not be imported")


### PR DESCRIPTION
Fixes bug as [reported on the forum](https://community.plotly.com/t/dash-pages-ignore-hidden-files-and-folders/67819) where hidden directories in the `pages` folder were being imported.