### PR TITLE
Graph edit queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2237](https://github.com/plotly/dash/pull/2237) Ensure calls to `plotly.js` from `dcc.Graph` are properly sequenced even if React initiates multiple render cycles in quick succession.
 - [#2218](https://github.com/plotly/dash/pull/2218) Fix bug [#1348](https://github.com/plotly/dash/issues/1348) Validate children prop (required or not).
 - [#2223](https://github.com/plotly/dash/pull/2223) Exclude hidden folders when building `dash.page_registry`.
 - [#2182](https://github.com/plotly/dash/pull/2182) Fix [#2172](https://github.com/plotly/dash/issues/2172)  Make it so that when using pages, if `suppress_callback_exceptions=True` the `validation_layout` is not set.

--- a/dash/development/_py_components_generation.py
+++ b/dash/development/_py_components_generation.py
@@ -85,7 +85,7 @@ def generate_class_string(
         prop_reorder_exceptions=prop_reorder_exceptions,
     ).replace("\r\n", "\n")
     required_args = required_props(filtered_props)
-    is_children_required = 'children' in required_args
+    is_children_required = "children" in required_args
     required_args = [arg for arg in required_args if arg != "children"]
 
     prohibit_events(props)

--- a/dash/long_callback/managers/diskcache_manager.py
+++ b/dash/long_callback/managers/diskcache_manager.py
@@ -119,7 +119,9 @@ DiskcacheLongCallbackManager requires extra dependencies which can be installed 
         from multiprocess import Process
 
         # pylint: disable-next=not-callable
-        proc = Process(target=job_fn, args=(key, self._make_progress_key(key), args, context))
+        proc = Process(
+            target=job_fn, args=(key, self._make_progress_key(key), args, context)
+        )
         proc.start()
         return proc.pid
 

--- a/tests/integration/test_generation.py
+++ b/tests/integration/test_generation.py
@@ -106,4 +106,4 @@ def test_gene004_required_children_prop():
     with pytest.raises(TypeError):
         RequiredChildrenComponent()
 
-    RequiredChildrenComponent(children='worked')
+    RequiredChildrenComponent(children="worked")

--- a/tests/unit/development/test_base_component.py
+++ b/tests/unit/development/test_base_component.py
@@ -538,4 +538,4 @@ def test_debc029_random_id_errors():
 
 def test_debc030_invalid_children_args():
     with pytest.raises(TypeError):
-        dcc.Input(children='invalid children')
+        dcc.Input(children="invalid children")


### PR DESCRIPTION
Plotly.js rendering in `dcc.Graph` can be async - more so now that we support MathJax in Dash, though there were always some async things like loading geojson. Anyway this hasn't caused any problems in core dash that I'm aware of, but in [dash-design-kit](https://plotly.com/dash/design-kit/), which wraps `dcc.Graph` and passes some information back and forth for theming purposes, `extendData` and `prependData` could cause two `render` cycles to overlap and drop the new data. This ensures the `plotly.js` method calls are sequenced properly, even if they end up delayed relative to the React renders. In my testing the changes here fix DDK (separate PR coming there) and it may fix some as-yet-undiscovered bugs in core DCC.

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added entry in the `CHANGELOG.md`