### PR TITLE
 [WIP] Make Dash Pages & packages play nice & experimenting with clearing Pages registry

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -172,7 +172,13 @@ no_update = _callback.NoUpdate()  # pylint: disable=protected-access
 def init_dash_globals():
     """Ensure that all Dash global state is re-initialised."""
     _pages.PAGE_REGISTRY.clear()
-    _pages.CONFIG.clear()
+
+    # this line of thinking could be extended to potentially clear the following:
+    # _pages.CONFIG
+    # _get_paths.CONFIG
+    # _callback.GLOBAL_CALLBACK_MAP
+    # _callback.GLOBAL_CALLBACK_LIST
+    # _callback.GLOBAL_INLINE_SCRIPTS
 
 
 # pylint: disable=too-many-instance-attributes

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -169,6 +169,12 @@ def _get_traceback(secret, error: Exception):
 no_update = _callback.NoUpdate()  # pylint: disable=protected-access
 
 
+def init_dash_globals():
+    """Ensure that all Dash global state is re-initialised."""
+    _pages.PAGE_REGISTRY.clear()
+    _pages.CONFIG.clear()
+
+
 # pylint: disable=too-many-instance-attributes
 # pylint: disable=too-many-arguments, too-many-locals
 class Dash:
@@ -379,6 +385,8 @@ class Dash:
         base_prefix, routes_prefix, requests_prefix = pathname_configs(
             url_base_pathname, routes_pathname_prefix, requests_pathname_prefix
         )
+
+        init_dash_globals()
 
         self.config = AttributeDict(
             name=name,
@@ -2008,7 +2016,7 @@ class Dash:
                     self.pages_folder.replace("\\", "/").lstrip("/").replace("/", ".")
                 )
 
-                module_name = ".".join([pages_folder, page_filename])
+                module_name = ".".join([self.config.name, pages_folder, page_filename])
 
                 spec = importlib.util.spec_from_file_location(
                     module_name, os.path.join(root, file)

--- a/tests/integration/multi_page/test_pages_layout.py
+++ b/tests/integration/multi_page/test_pages_layout.py
@@ -173,12 +173,11 @@ def test_pala003_meta_tags_custom(dash_duo):
 
 
 def test_pala004_no_layout_exception():
-    error_msg = 'No layout found in module pages_error.no_layout_page\nA variable or a function named "layout" is required.'
+    error_msg = 'No layout found in module test_pages_layout.pages_error.no_layout_page\nA variable or a function named "layout" is required.'
 
     with pytest.raises(NoLayoutException) as err:
         Dash(__name__, use_pages=True, pages_folder="pages_error")
-
     # clean up after this test, so the broken entry doesn't affect other pages tests
-    del dash.page_registry["pages_error.no_layout_page"]
+    del dash.page_registry["test_pages_layout.pages_error.no_layout_page"]
 
     assert error_msg in err.value.args[0]

--- a/tests/integration/multi_page/test_pages_order.py
+++ b/tests/integration/multi_page/test_pages_order.py
@@ -48,14 +48,14 @@ def test_paor001_order(dash_duo):
         "multi_layout3",
         "multi_layout2",
         "multi_layout1",
-        "pages.defaults",
-        "pages.metas",
-        "pages.not_found_404",
-        "pages.page1",
-        "pages.page2",
-        "pages.path_variables",
-        "pages.query_string",
-        "pages.redirect",
+        "test_pages_order.pages.defaults",
+        "test_pages_order.pages.metas",
+        "test_pages_order.pages.not_found_404",
+        "test_pages_order.pages.page1",
+        "test_pages_order.pages.page2",
+        "test_pages_order.pages.path_variables",
+        "test_pages_order.pages.query_string",
+        "test_pages_order.pages.redirect",
     ]
 
     dash_duo.start_server(app)


### PR DESCRIPTION
_Please don't merge._ 

This is something of an experiment to try to address the problem of Dash Pages not playing nicely when used with a Dash app that's housed in a Python package, as discussed in #2263.

The solution I adopted was to prefix the modules programatically imported by Dash Pages (eg the contents of `pages/*.py`) with the `name` parameter of the `Dash` instance. All the user needs to do then is invokes their apps as `Dash(name=__package__)`. This largely worked (as far as I can tell) but broke some tests that made some assumptions about the contents of `_pages.PAGE_REGISTRY` across multiple `Dash` app instantiations.

The more experimental part of this PR is to clear the contents of the `_pages.PAGE_REGISTRY` on `__init__` of each `Dash` instance. 