### PR TITLE
celery: pin importlib < 5 for py3.7

### DIFF
--- a/requires-celery.txt
+++ b/requires-celery.txt
@@ -1,3 +1,4 @@
 # Dependencies used by the CeleryLongCallbackManager
 redis>=3.5.3
 celery[redis]>=5.1.2
+importlib-metadata<5;python_version<"3.8"


### PR DESCRIPTION
Bringing the issue noted in https://github.com/plotly/dash-snapshots/issues/248 over to dash.
We don't test dash on Py3.7 specifically, and we already pin `importlib-metadata` for Py3.6 (https://github.com/plotly/dash/pull/1872), so I don't expect this issue to manifest in our tests unfortunately...
cc @T4rk1n 