### PR TITLE
Move flask_compress dependency to extras require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2265](https://github.com/plotly/dash/pull/2265) Removed deprecated `before_first_request` as reported in [#2177](https://github.com/plotly/dash/issues/2177).
 - [#2257](https://github.com/plotly/dash/pull/2257) Fix tuple types in the TypeScript component generator.
 
+### Changed
+
+- [#2291](https://github.com/plotly/dash/pull/2291) Move `flask-compress` dependency to new extras requires `dash[compress]`
+
 ## [2.6.2] - 2022-09-23
 
 ### Fixed

--- a/requires-compress.txt
+++ b/requires-compress.txt
@@ -1,0 +1,1 @@
+flask-compress

--- a/requires-install.txt
+++ b/requires-install.txt
@@ -1,5 +1,4 @@
 Flask>=1.0.4
-flask-compress
 plotly>=5.0.0
 dash_html_components==2.0.0
 dash_core_components==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "testing": read_req_file("testing"),
         "celery": read_req_file("celery"),
         "diskcache": read_req_file("diskcache"),
+        "compress": read_req_file("compress"),
     },
     entry_points={
         "console_scripts": [

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -482,3 +482,8 @@ def test_debug_mode_enable_dev_tools(empty_environ, debug_env, debug, expected):
     app = Dash()
     app.enable_dev_tools(debug=debug)
     assert app._dev_tools.ui == expected
+
+
+def test_missing_flask_compress_raises():
+    with pytest.raises(ImportError):
+        Dash(compress=True)


### PR DESCRIPTION
Following discussion from https://github.com/plotly/dash/issues/2286#issuecomment-1293717772, this change the flask_compress dependency to an extra requires installed with `dash[compress]`. This new requirement is needed when using the `compress` argument of Dash.