### PR TITLE
fix custom 404 page error in multi page application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- [#2292](https://github.com/plotly/dash/pull/2292) Pages: find the 404 page even if `pages_folder` is nested, or the 404 page is nested inside `pages_folder`.
 - [#2265](https://github.com/plotly/dash/pull/2265) Removed deprecated `before_first_request` as reported in [#2177](https://github.com/plotly/dash/issues/2177).
 - [#2257](https://github.com/plotly/dash/pull/2257) Fix tuple types in the TypeScript component generator.
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -2063,22 +2063,11 @@ class Dash:
 
                 # get layout
                 if page == {}:
-                    module_404 = (
-                        ".".join(
-                            [
-                                self.pages_folder.replace("\\", "/")
-                                .lstrip("/")
-                                .replace("/", "."),
-                                "not_found_404",
-                            ]
-                        )
-                        if self.pages_folder
-                        else "not_found_404"
-                    )
-                    not_found_404 = _pages.PAGE_REGISTRY.get(module_404)
-                    if not_found_404:
-                        layout = not_found_404["layout"]
-                        title = not_found_404["title"]
+                    for module, page in _pages.PAGE_REGISTRY.items():
+                        if module.split(".")[-1] == "not_found_404":
+                            layout = page["layout"]
+                            title = page["title"]
+                            break
                     else:
                         layout = html.H1("404 - Page not found")
                         title = self.title

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -2064,7 +2064,14 @@ class Dash:
                 # get layout
                 if page == {}:
                     module_404 = (
-                        ".".join([self.pages_folder, "not_found_404"])
+                        ".".join(
+                            [
+                                self.pages_folder.replace("\\", "/")
+                                .lstrip("/")
+                                .replace("/", "."),
+                                "not_found_404",
+                            ]
+                        )
                         if self.pages_folder
                         else "not_found_404"
                     )


### PR DESCRIPTION
*Start with a description of this PR. Then edit the list below to the items that make sense for your PR scope, and check off the boxes as you go!*

## Problem Faced
The issue comes up when trying to set up a custom not_found_404 page in a multi-page setup where the pages folder is not a direct subdirectory in the application root folder. In the example below, the dash will not use `not_found_404.py` as the custom 404 page.

### Example 
The file structure is as follows
```
.
|-- application.py
|-- requirements.txt
`-- src
    |-- __init__.py
    |-- assets
    |   |-- favicon.ico
    |-- pages
    |   |-- callbacks
    |   |   `-- sample_callback.py
    |   |-- layouts
    |   |   `-- sample_layout.py
    |   |-- not_found_404.py
    |   `-- procs
    |       `-- sample_proc
    |           `-- sample_proc.py
```
> application.py
```python
app = dash.Dash(
    __name__,
    server=server,
    use_pages=True,
    pages_folder='src/pages',
    assets_folder='src/assets',
    suppress_callback_exceptions=True,
)
```

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] task 1 - fix custom 404 page error in multi page application
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
