### PR TITLE
Fix Dropdown useMemo not detecting equal objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - [#2265](https://github.com/plotly/dash/pull/2265) Removed deprecated `before_first_request` as reported in [#2177](https://github.com/plotly/dash/issues/2177).
 - [#2257](https://github.com/plotly/dash/pull/2257) Fix tuple types in the TypeScript component generator.
+- [#2293](https://github.com/plotly/dash/pull/2293) Fix Dropdown useMemo not detecting equal objects
 
 ### Changed
 

--- a/components/dash-core-components/package-lock.json
+++ b/components/dash-core-components/package-lock.json
@@ -30,6 +30,7 @@
         "react-dates": "^21.8.0",
         "react-docgen": "^5.4.3",
         "react-dropzone": "^4.1.2",
+        "react-fast-compare": "^3.2.0",
         "react-markdown": "^4.3.1",
         "react-resize-detector": "^6.7.6",
         "react-select-fast-filter-options": "^0.2.3",
@@ -7048,6 +7049,11 @@
       "peerDependencies": {
         "react": ">=0.14.0"
       }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "node_modules/react-input-autosize": {
       "version": "2.2.2",
@@ -14301,6 +14307,11 @@
         "attr-accept": "^1.1.3",
         "prop-types": "^15.5.7"
       }
+    },
+    "react-fast-compare": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.0.tgz",
+      "integrity": "sha512-rtGImPZ0YyLrscKI9xTpV8psd6I8VAtjKCzQDlzyDvqJA8XOW78TXYQwNRNd8g8JZnDu8q9Fu/1v4HPAVwVdHA=="
     },
     "react-input-autosize": {
       "version": "2.2.2",

--- a/components/dash-core-components/package.json
+++ b/components/dash-core-components/package.json
@@ -57,6 +57,7 @@
     "react-dates": "^21.8.0",
     "react-docgen": "^5.4.3",
     "react-dropzone": "^4.1.2",
+    "react-fast-compare": "^3.2.0",
     "react-markdown": "^4.3.1",
     "react-resize-detector": "^6.7.6",
     "react-select-fast-filter-options": "^0.2.3",

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -8,7 +8,7 @@ import '../components/css/Dropdown.css';
 
 import {propTypes, defaultProps} from '../components/Dropdown.react';
 import {sanitizeOptions} from '../utils/optionTypes';
-import isEqual from "react-fast-compare";
+import isEqual from 'react-fast-compare';
 
 // Custom tokenizer, see https://github.com/bvaughn/js-search/issues/43
 // Split on spaces

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -83,7 +83,7 @@ const Dropdown = props => {
                 indexes,
             }),
         ];
-    }, [options]);
+    }, [JSON.stringify(options)]);
 
     const onChange = useCallback(
         selectedOption => {

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -1,5 +1,5 @@
 import {isNil, pluck, without, pick} from 'ramda';
-import React, {useState, useCallback, useEffect, useMemo} from 'react';
+import React, {useState, useCallback, useEffect, useMemo, useRef} from 'react';
 import ReactDropdown from 'react-virtualized-select';
 import createFilterOptions from 'react-select-fast-filter-options';
 import '../components/css/react-virtualized-select@3.1.0.css';
@@ -8,7 +8,7 @@ import '../components/css/Dropdown.css';
 
 import {propTypes, defaultProps} from '../components/Dropdown.react';
 import {sanitizeOptions} from '../utils/optionTypes';
-import * as util from "util";
+import isEqual from "react-fast-compare";
 
 // Custom tokenizer, see https://github.com/bvaughn/js-search/issues/43
 // Split on spaces
@@ -48,6 +48,12 @@ const Dropdown = props => {
         value,
     } = props;
     const [optionsCheck, setOptionsCheck] = useState(null);
+    const persistentOptions = useRef(null);
+
+    if (!persistentOptions || !isEqual(options, persistentOptions.current)) {
+        persistentOptions.current = options;
+    }
+
     const [sanitizedOptions, filterOptions] = useMemo(() => {
         let sanitized = sanitizeOptions(options);
 
@@ -84,7 +90,7 @@ const Dropdown = props => {
                 indexes,
             }),
         ];
-    }, [util.inspect(options, {depth: 3})]);
+    }, [persistentOptions.current]);
 
     const onChange = useCallback(
         selectedOption => {
@@ -147,7 +153,7 @@ const Dropdown = props => {
         >
             <ReactDropdown
                 filterOptions={filterOptions}
-                options={sanitizeOptions(options)}
+                options={sanitizedOptions}
                 value={value}
                 onChange={onChange}
                 onInputChange={onInputChange}

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -8,6 +8,7 @@ import '../components/css/Dropdown.css';
 
 import {propTypes, defaultProps} from '../components/Dropdown.react';
 import {sanitizeOptions} from '../utils/optionTypes';
+import * as util from "util";
 
 // Custom tokenizer, see https://github.com/bvaughn/js-search/issues/43
 // Split on spaces
@@ -83,7 +84,7 @@ const Dropdown = props => {
                 indexes,
             }),
         ];
-    }, [JSON.stringify(options)]);
+    }, [util.inspect(options, {depth: 3})]);
 
     const onChange = useCallback(
         selectedOption => {


### PR DESCRIPTION
This pull requests improves the performance of the dash core component dropdown.
The `useMemo` didn't recognize that the objects inside the `options` array of the dropdown stayed the same, so the `useMemo` got recalculated all the time.
Because of this Dropdowns with a lot of values inside (I have some with >1k) took a lot of time to render(>100ms).
Using the `useRef` the current `options`-object(and the address associated with that) are saved and compared with the new `options`-object is deep compared to that one using `isEqual` from react-fast-compare.
That way the `persistentOptions` is only changed when the options change, and that way the `useMemo` is only executed when needen.

## Contributor Checklist
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))


### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
