### PR TITLE
new pytest doesn't require py workaround

### DIFF
--- a/requires-ci.txt
+++ b/requires-ci.txt
@@ -20,9 +20,7 @@ pyarrow<3;python_version<"3.7"
 pyarrow;python_version>="3.7"
 pylint==2.13.5
 pytest-mock
-pytest-sugar==0.9.5
-# py is temporary until https://github.com/Teemu/pytest-sugar/issues/241 is fixed
-py==1.11.0
+pytest-sugar==0.9.6
 xlrd>=2.0.1;python_version>="3.8"
 xlrd<2;python_version<"3.8"
 pytest-rerunfailures


### PR DESCRIPTION
undoing https://github.com/plotly/dash/pull/2287 now that https://github.com/Teemu/pytest-sugar/pull/242 has been published as `pytest-sugar@0.9.6`