### PR TITLE
Add key to wrapped children props in list.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED]
+
+### Fixed
+
+- [#2332](https://github.com/plotly/dash/pull/2332) Add key to wrapped children props in list.
+
 ## [2.7.0] - 2022-11-03
 
 ### Removed

--- a/dash/dash-renderer/src/TreeContainer.js
+++ b/dash/dash-renderer/src/TreeContainer.js
@@ -100,15 +100,16 @@ class BaseTreeContainer extends Component {
         this.setProps = this.setProps.bind(this);
     }
 
-    createContainer(props, component, path) {
+    createContainer(props, component, path, key = undefined) {
         return isSimpleComponent(component) ? (
             component
         ) : (
             <TreeContainer
                 key={
-                    component &&
-                    component.props &&
-                    stringifyId(component.props.id)
+                    (component &&
+                        component.props &&
+                        stringifyId(component.props.id)) ||
+                    key
                 }
                 _dashprivate_error={props._dashprivate_error}
                 _dashprivate_layout={component}
@@ -205,7 +206,8 @@ class BaseTreeContainer extends Component {
                               'props',
                               ...childrenProp,
                               i
-                          ])
+                          ]),
+                          i
                       )
                     : n
             );

--- a/dash/dash-renderer/src/TreeContainer.js
+++ b/dash/dash-renderer/src/TreeContainer.js
@@ -81,7 +81,7 @@ function isDryComponent(obj) {
     );
 }
 
-const TreeContainer = memo(props => (
+const DashWrapper = props => (
     <DashContext.Consumer>
         {context => (
             <BaseTreeContainer
@@ -91,7 +91,9 @@ const TreeContainer = memo(props => (
             />
         )}
     </DashContext.Consumer>
-));
+);
+
+const TreeContainer = memo(DashWrapper);
 
 class BaseTreeContainer extends Component {
     constructor(props) {

--- a/dash/dash-renderer/src/TreeContainer.js
+++ b/dash/dash-renderer/src/TreeContainer.js
@@ -1,4 +1,4 @@
-import React, {Component, memo} from 'react';
+import React, {Component, memo, useContext} from 'react';
 import PropTypes from 'prop-types';
 import Registry from './registry';
 import {propTypeErrorHandler} from './exceptions';
@@ -81,17 +81,16 @@ function isDryComponent(obj) {
     );
 }
 
-const DashWrapper = props => (
-    <DashContext.Consumer>
-        {context => (
-            <BaseTreeContainer
-                {...context.fn()}
-                {...props}
-                _dashprivate_path={JSON.parse(props._dashprivate_path)}
-            />
-        )}
-    </DashContext.Consumer>
-);
+const DashWrapper = props => {
+    const context = useContext(DashContext);
+    return (
+        <BaseTreeContainer
+            {...context.fn()}
+            {...props}
+            _dashprivate_path={JSON.parse(props._dashprivate_path)}
+        />
+    );
+};
 
 const TreeContainer = memo(DashWrapper);
 


### PR DESCRIPTION
- Automatically add a key to the wrapped components in a list if it doesn't have an id. Fix #2302 
- Extract memo TreeContainer component to DashWrapper for it to have a name in react dev tools.
- Refactor DashWrapper context consumer to useContext for one less component for each wrapped component.
