### PR TITLE
Add license trove classifiers to component packages

### DIFF
--- a/components/dash-core-components/setup.py
+++ b/components/dash-core-components/setup.py
@@ -16,4 +16,7 @@ setup(
     license=package["license"],
     description=package.get("description", package_name),
     install_requires=[],
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+    ],
 )

--- a/components/dash-html-components/setup.py
+++ b/components/dash-html-components/setup.py
@@ -20,4 +20,7 @@ setup(
     long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     install_requires=[],
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+    ],
 )

--- a/components/dash-table/setup.py
+++ b/components/dash-table/setup.py
@@ -15,4 +15,7 @@ setup(
     license=package["license"],
     description=package["description"] if "description" in package else package_name,
     install_requires=[],
+    classifiers=[
+        "License :: OSI Approved :: MIT License",
+    ],
 )


### PR DESCRIPTION
Add proper license [Trove classifiers](https://pypi.org/classifiers/) for component packages.

This is used by tools such as [`pip-licenses`](https://github.com/raimon49/pip-licenses) to provide a license report for users.