### PR TITLE
Wrapper function to avoid polluting global namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   - `custom_spinner`  enables using a custom component for loading messages instead of built-in spinners
   - `display`  overrides the loading status with options for "show," "hide," or "auto"
 
+## Fixed
+
+- [#2362](https://github.com/plotly/dash/pull/2362) Global namespace not polluted any more when loading clientside callbacks.
+
 ## [2.16.1] - 2024-03-06
 
 ## Fixed

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -502,9 +502,11 @@ def register_callback(  # pylint: disable=R0914
 
 
 _inline_clientside_template = """
-var clientside = window.dash_clientside = window.dash_clientside || {{}};
-var ns = clientside["{namespace}"] = clientside["{namespace}"] || {{}};
-ns["{function_name}"] = {clientside_function};
+(function() {{
+    var clientside = window.dash_clientside = window.dash_clientside || {{}};
+    var ns = clientside["{namespace}"] = clientside["{namespace}"] || {{}};
+    ns["{function_name}"] = {clientside_function};
+}})();
 """
 
 

--- a/tests/integration/clientside/test_clientside.py
+++ b/tests/integration/clientside/test_clientside.py
@@ -35,6 +35,10 @@ def test_clsd001_simple_clientside_serverside_callback(dash_duo):
     dash_duo.wait_for_text_to_equal("#output-serverside", 'Server says "hello world"')
     dash_duo.wait_for_text_to_equal("#output-clientside", 'Client says "hello world"')
 
+    assert dash_duo.driver.execute_script("return 'dash_clientside' in window")
+    assert dash_duo.driver.execute_script("return !('clientside' in window)")
+    assert dash_duo.driver.execute_script("return !('ns' in window)")
+
 
 def test_clsd002_chained_serverside_clientside_callbacks(dash_duo):
     app = Dash(__name__, assets_folder="assets")


### PR DESCRIPTION
Wrapped the clientside template JS code in an anonymous function. This prevents `clientside` and `ns` vars from polluting the global namespace.


## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] 🦗 
   -  [ ] 🦗🦗 
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
