### PR TITLE
Fix callback crashing if getPath returns undefined

### DIFF
--- a/dash/dash-renderer/src/observers/executedCallbacks.ts
+++ b/dash/dash-renderer/src/observers/executedCallbacks.ts
@@ -127,6 +127,9 @@ const observer: IStoreObserverDefinition<IStoreState> = {
                     );
 
                     const basePath = getPath(oldPaths, parsedId);
+                    if (!basePath) {
+                        return;
+                    }
                     const oldObj = path(getPath(oldPaths, parsedId), oldLayout);
 
                     const childrenProps = pathOr(

--- a/dash/dash-renderer/src/observers/executedCallbacks.ts
+++ b/dash/dash-renderer/src/observers/executedCallbacks.ts
@@ -130,7 +130,7 @@ const observer: IStoreObserverDefinition<IStoreState> = {
                     if (!basePath) {
                         return;
                     }
-                    const oldObj = path(getPath(oldPaths, parsedId), oldLayout);
+                    const oldObj = path(basePath, oldLayout);
 
                     const childrenProps = pathOr(
                         'defaultValue',


### PR DESCRIPTION
Fixes a crash which results in a hanging page which was caused by an `Uncaught (in promise) TypeError: paths is undefined` exception raised by `ramda.path`.

*Start with a description of this PR. Then edit the list below to the items that make sense for your PR scope, and check off the boxes as you go!*

## Contributor Checklist

- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
