### PR TITLE
added disable_n_clicks to page_container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+
+## Unreleased
+
+## Fixed
+
+- [#2400](https://github.com/plotly/dash/pull/2400) Added `disable_n_clicks=True` to the `html.Div` components in `page_container`.
+
 ## [2.8.0] - 2023-01-24
 
 ### Added

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -120,9 +120,9 @@ try:
     page_container = html.Div(
         [
             dcc.Location(id=_ID_LOCATION),
-            html.Div(id=_ID_CONTENT),
+            html.Div(id=_ID_CONTENT, disable_n_clicks=True),
             dcc.Store(id=_ID_STORE),
-            html.Div(id=_ID_DUMMY),
+            html.Div(id=_ID_DUMMY, disable_n_clicks=True),
         ]
     )
 except AttributeError:


### PR DESCRIPTION
As [reported on the forum](https://community.plotly.com/t/using-dash-table-on-multipage-app-leads-to-warning/71054/10?u=annmariew), need to set `disable_n_clicks=True` in `html.Div`s included in  `dash.page_container`