### PR TITLE
Terminate jobs in diskcache background callback tests teardown.

### DIFF
--- a/tests/integration/long_callback/utils.py
+++ b/tests/integration/long_callback/utils.py
@@ -1,5 +1,20 @@
 import os
 
+from dash.long_callback import DiskcacheManager
+
+manager = None
+
+
+class TestDiskCacheManager(DiskcacheManager):
+    def __init__(self, cache=None, cache_by=None, expire=None):
+        super().__init__(cache=cache, cache_by=cache_by, expire=expire)
+        self.running_jobs = []
+
+    def call_job_fn(self, key, job_fn, args, context):
+        pid = super().call_job_fn(key, job_fn, args, context)
+        self.running_jobs.append(pid)
+        return pid
+
 
 def get_long_callback_manager():
     """
@@ -19,16 +34,18 @@ def get_long_callback_manager():
         redis_conn = redis.Redis(host="localhost", port=6379, db=1)
         long_callback_manager.test_lock = redis_conn.lock("test-lock")
     elif os.environ.get("LONG_CALLBACK_MANAGER", None) == "diskcache":
-        from dash.long_callback import DiskcacheLongCallbackManager
         import diskcache
 
         cache = diskcache.Cache(os.environ.get("DISKCACHE_DIR"))
-        long_callback_manager = DiskcacheLongCallbackManager(cache)
+        long_callback_manager = TestDiskCacheManager(cache)
         long_callback_manager.test_lock = diskcache.Lock(cache, "test-lock")
     else:
         raise ValueError(
             "Invalid long callback manager specified as LONG_CALLBACK_MANAGER "
             "environment variable"
         )
+
+    global manager
+    manager = long_callback_manager
 
     return long_callback_manager


### PR DESCRIPTION
Auto terminate jobs that are still running/zombie at the end of diskcache background tests.

Build passed 10/11, there is still some flakiness with the dcc tests unrelated to background callbacks tests.