### PR TITLE
Update duplicate callback outputs error

### DIFF
--- a/dash/dash-renderer/src/actions/dependencies.js
+++ b/dash/dash-renderer/src/actions/dependencies.js
@@ -323,8 +323,7 @@ function findDuplicateOutputs(outputs, head, dispatchError, outStrs, outObjs) {
             if (newOutputStrs[idProp]) {
                 dispatchError('Duplicate callback Outputs', [
                     head,
-                    `Output ${i} (${idProp}) is already used by this callback.`,
-                    'To resolve this, set `allow_duplicate=True` on this output.'
+                    `Output ${i} (${idProp}) is already used by this callback.`
                 ]);
             } else if (outStrs[idProp]) {
                 dispatchError('Duplicate callback outputs', [

--- a/dash/dash-renderer/src/actions/dependencies.js
+++ b/dash/dash-renderer/src/actions/dependencies.js
@@ -323,14 +323,15 @@ function findDuplicateOutputs(outputs, head, dispatchError, outStrs, outObjs) {
             if (newOutputStrs[idProp]) {
                 dispatchError('Duplicate callback Outputs', [
                     head,
-                    `Output ${i} (${idProp}) is already used by this callback.`
+                    `Output ${i} (${idProp}) is already used by this callback.`,
+                    'To resolve this, set `allow_duplicate=True` on this output.'
                 ]);
             } else if (outStrs[idProp]) {
                 dispatchError('Duplicate callback outputs', [
                     head,
                     `Output ${i} (${idProp}) is already in use.`,
-                    'Any given output can only have one callback that sets it.',
-                    'To resolve this situation, try combining these into',
+                    'To resolve this, set `allow_duplicate=True` on',
+                    'duplicate outputs, or combine the outputs into',
                     'one callback function, distinguishing the trigger',
                     'by using `dash.callback_context` if necessary.'
                 ]);


### PR DESCRIPTION
This PR updates the error message for duplicate callback outputs so the user knows they can use `allow_duplicate`

## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
