### PR TITLE
Deterministic duplicate outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Fixed
 
-- [#2479](https://github.com/plotly/dash/pull/2479) Fix KeyError when duplicate outputs id being different on restarts.
+- [#2479](https://github.com/plotly/dash/pull/2479) Fix `KeyError` "Callback function not found for output [...], , perhaps you forgot to prepend the '@'?" issue when using duplicate callbacks targeting the same output. This issue would occur when the app is restarted or when running with multiple `gunicorn` workers.
 
 ## [2.9.1] - 2023-03-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED
+
+## Fixed
+
+- [#2479](https://github.com/plotly/dash/pull/2479) Fix KeyError when duplicate outputs id being different on restarts.
+
 ## [2.9.1] - 2023-03-17
 
 ## Fixed

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -245,7 +245,7 @@ def insert_callback(
         output, prevent_initial_call, config_prevent_initial_callbacks
     )
 
-    callback_id = create_callback_id(output)
+    callback_id = create_callback_id(output, inputs)
     callback_spec = {
         "output": callback_id,
         "inputs": [c.to_dict() for c in inputs],

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -127,13 +127,16 @@ def create_callback_id(output, inputs):
     # A single dot within a dict id key or value is OK
     # but in case of multiple dots together escape each dot
     # with `\` so we don't mistake it for multi-outputs
-    hashed_inputs = hashlib.md5(
-        ".".join(str(x) for x in inputs).encode("utf-8")
-    ).hexdigest()
+    hashed_inputs = None
 
     def _concat(x):
+        nonlocal hashed_inputs
         _id = x.component_id_str().replace(".", "\\.") + "." + x.component_property
         if x.allow_duplicate:
+            if not hashed_inputs:
+                hashed_inputs = hashlib.md5(
+                    ".".join(str(x) for x in inputs).encode("utf-8")
+                ).hexdigest()
             # Actually adds on the property part.
             _id += f"@{hashed_inputs}"
         return _id

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -123,15 +123,19 @@ class AttributeDict(dict):
             return next(iter(self), {})
 
 
-def create_callback_id(output):
+def create_callback_id(output, inputs):
     # A single dot within a dict id key or value is OK
     # but in case of multiple dots together escape each dot
     # with `\` so we don't mistake it for multi-outputs
+    hashed_inputs = hashlib.md5(
+        ".".join(str(x) for x in inputs).encode("utf-8")
+    ).hexdigest()
+
     def _concat(x):
         _id = x.component_id_str().replace(".", "\\.") + "." + x.component_property
         if x.allow_duplicate:
             # Actually adds on the property part.
-            _id += f"@{uuid.uuid4().hex}"
+            _id += f"@{hashed_inputs}"
         return _id
 
     if isinstance(output, (list, tuple)):

--- a/dash/testing/composite.py
+++ b/dash/testing/composite.py
@@ -6,14 +6,15 @@ class DashComposite(Browser):
         super().__init__(**kwargs)
         self.server = server
 
-    def start_server(self, app, **kwargs):
+    def start_server(self, app, navigate=True, **kwargs):
         """Start the local server with app."""
 
         # start server with app and pass Dash arguments
         self.server(app, **kwargs)
 
-        # set the default server_url, it implicitly call wait_for_page
-        self.server_url = self.server.url
+        if navigate:
+            # set the default server_url, it implicitly call wait_for_page
+            self.server_url = self.server.url
 
 
 class DashRComposite(Browser):

--- a/tests/unit/library/test_grouped_callbacks.py
+++ b/tests/unit/library/test_grouped_callbacks.py
@@ -41,9 +41,9 @@ def check_output_for_grouping(grouping):
     mock_fn = mock.Mock()
     mock_fn.return_value = grouping
     if multi:
-        callback_id = create_callback_id(flatten_grouping(outputs))
+        callback_id = create_callback_id(flatten_grouping(outputs), [])
     else:
-        callback_id = create_callback_id(outputs)
+        callback_id = create_callback_id(outputs, [])
 
     app.callback(
         outputs,


### PR DESCRIPTION
Duplicate outputs we're inserted with a random uuid, when the server restarted or used with gunicorn multi workers it would have different values for callback ids resulting in KeyError for callbacks.

This PR change the behavior to be deterministic, creating md5 hash from the callback inputs to use in lieu of the uuid4.

Fix #2480
