### PR TITLE
Remove event listeners for Location on unmount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Fixed
 
+- [#2489](https://github.com/plotly/dash/pull/2489) Fix location change event handling when `Location` objects are removed from the layout. Event handlers would not be removed and eventually change props of a random DOM element, fix [#1346](https://github.com/plotly/dash/issues/1346)
 - [#2491](https://github.com/plotly/dash/pull/2491) Fix clientside inline function name not found, fix [#2488](https://github.com/plotly/dash/issues/2488)
 
 ## [2.9.2] - 2023-03-29

--- a/components/dash-core-components/src/components/Location.react.js
+++ b/components/dash-core-components/src/components/Location.react.js
@@ -121,6 +121,14 @@ export default class Location extends Component {
         this.updateLocation(this.props);
     }
 
+    componentWillUnmount() {
+        window.onpopstate = () => {};
+        window.removeEventListener(
+            '_dashprivate_pushstate',
+            this.onLocationChange
+        );
+    }
+
     UNSAFE_componentWillReceiveProps(nextProps) {
         this.updateLocation(nextProps);
     }


### PR DESCRIPTION
Currently, if the `Location` component is not mounted anymore after it had been mounted (e.g. because it is on a different page), the component will have it's event handler for the custom `_dashprivate_pushstate` event registered.

When changing pages, this triggers the `onLocationChange` callback which changes its props via `this.props.setProps` with the itempath (from `_dashprivate_path`) in the DOM. The object, however, is not on the DOM and the path may lead to some other DOM element which is assigned the changed props for `href` and `pathname`. This leads to the error described in #1346 and breaks subsequent navigation with Links because of the error in the event handler.

The PR deregisters the event listeners if the component is unmounted. They will be added again via `componentDidMount` anyways if the component is mounted again.

In https://github.com/plotly/dash/pull/2068#issue-1251287697 one of the limitations of using the pages feature is that none of the pages can contain a `Location` component. This limitation is lifted with the PR.

Fixes https://github.com/plotly/dash/issues/1346 (all the way at the bottom)

## Contributor Checklist

- [X] I have broken down my PR scope into the following TODO tasks
   -  [X] Remove event listeners for Location component if unmounted
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
