### PR TITLE
Fix: validate error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED]
+
+## Fixed
+
+- [#2508](https://github.com/plotly/dash/pull/2508) Fix error message, when callback output has different length than spec
+
 ## [2.9.3] - 2023-04-13
 
 ## Fixed

--- a/dash/_validate.py
+++ b/dash/_validate.py
@@ -161,49 +161,49 @@ def validate_and_group_input_args(flat_args, arg_index_grouping):
     return func_args, func_kwargs
 
 
-def validate_multi_return(outputs_list, output_value, callback_id):
-    if not isinstance(output_value, (list, tuple)):
+def validate_multi_return(output_lists, output_values, callback_id):
+    if not isinstance(output_values, (list, tuple)):
         raise exceptions.InvalidCallbackReturnValue(
             dedent(
                 f"""
                 The callback {callback_id} is a multi-output.
                 Expected the output type to be a list or tuple but got:
-                {output_value!r}.
+                {output_values!r}.
                 """
             )
         )
 
-    if len(output_value) != len(outputs_list):
+    if len(output_values) != len(output_lists):
         raise exceptions.InvalidCallbackReturnValue(
             f"""
             Invalid number of output values for {callback_id}.
-            Expected {len(outputs_list)}, got {len(output_value)}
+            Expected {len(output_lists)}, got {len(output_values)}
             """
         )
 
-    for i, outi in enumerate(outputs_list):
-        if isinstance(outi, list):
-            vi = output_value[i]
-            if not isinstance(vi, (list, tuple)):
+    for i, output_spec in enumerate(output_lists):
+        if isinstance(output_spec, list):
+            output_value = output_values[i]
+            if not isinstance(output_value, (list, tuple)):
                 raise exceptions.InvalidCallbackReturnValue(
                     dedent(
                         f"""
                         The callback {callback_id} output {i} is a wildcard multi-output.
                         Expected the output type to be a list or tuple but got:
-                        {vi!r}.
-                        output spec: {outi!r}
+                        {output_value!r}.
+                        output spec: {output_spec!r}
                         """
                     )
                 )
 
-            if len(vi) != len(outi):
+            if len(output_value) != len(output_spec):
                 raise exceptions.InvalidCallbackReturnValue(
                     dedent(
                         f"""
                         Invalid number of output values for {callback_id} item {i}.
-                        Expected {len(outi)}, got {len(vi)}
-                        output spec: {outi!r}
-                        output value: {vi!r}
+                        Expected {len(output_spec)}, got {len(output_value)}
+                        output spec: {output_spec!r}
+                        output value: {output_value!r}
                         """
                     )
                 )

--- a/dash/_validate.py
+++ b/dash/_validate.py
@@ -201,7 +201,7 @@ def validate_multi_return(outputs_list, output_value, callback_id):
                     dedent(
                         f"""
                         Invalid number of output values for {callback_id} item {i}.
-                        Expected {len(vi)}, got {len(outi)}
+                        Expected {len(outi)}, got {len(vi)}
                         output spec: {outi!r}
                         output value: {vi!r}
                         """


### PR DESCRIPTION
This PR fixes the error message, when the wrong number of outputs are present on a callback.

Currently
```
dash.exceptions.InvalidCallbackReturnValue: Invalid number of output values for {"index":["ALL"],"type":"output"}.children item 0.
Expected 5, got 4
output spec: [{'id': {'index': 0, 'type': 'output'}, 'property': 'children'}, {'id': {'index': 1, 'type': 'output'}, 'property': 'children'}, {'id': {'index': 2, 'type': 'output'}, 'property': 'children'}, {'id': {'index': 3, 'type': 'output'}, 'property': 'children'}]
output value: [['None'], ['None'], ['None'], ['None'], ['None']]
```

But the `Expected 5, got 4` is wrong should be the other way around (`Expected 4, got 5`)

<details><summary>Example code that throws the error</summary>
<p>

```py
import dash
from dash import dcc, html, Output, Input, ALL

app = dash.Dash(__name__)

app.layout = html.Div(
    [
        html.Div(
            id={"type": "output", "index": x},
            style={"border": "1px solid black", "width": "100px", "height": "100px"},
        ) for x in range(4)
    ] +
    [
        html.Div(dcc.Input(id="input", type="number"))
    ]
)


@app.callback(
    Output({"type": "output", "index": ALL}, "children"),
    Input("input", "value")
)
def display_output(value):
    return [[str(value)]] * 5


if __name__ == "__main__":
    app.run_server(debug=True)

```

</p>
</details> 

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
