### PR TITLE
Lock flask version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2508](https://github.com/plotly/dash/pull/2508) Fix error message, when callback output has different length than spec
 - [#2207](https://github.com/plotly/dash/pull/2207) Fix object of components support.
 
+## Changed
+
+- [#2516](https://github.com/plotly/dash/pull/2516) Lock Flask/Werkzeug version to 2.2.2 for Python>=3.7 and 2.0.3 for Python < 3.7.
+
 ## [2.9.3] - 2023-04-13
 
 ## Fixed

--- a/requires-install.txt
+++ b/requires-install.txt
@@ -1,4 +1,7 @@
-Flask>=1.0.4
+Flask==2.2.2;python_version>="3.7"
+Werkzeug==2.2.2;python_version>="3.7"
+Flask==2.0.3;python_version<"3.7"
+Werkzeug==2.0.3;python_version<"3.7"
 plotly>=5.0.0
 dash_html_components==2.0.0
 dash_core_components==2.0.0


### PR DESCRIPTION
Recent versions of flask/werkzeug have introduced breaking bugs in dash. This PR lock the versions of flask/werkzeug installed in order to prevent further breakage.