### PR TITLE
Fix pages meta tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - [#2538](https://github.com/plotly/dash/pull/2538) Add an upper bound to Flask and Werkzeug versions at `<2.2.3` because we expect the Dash ecosystem to be incompatible with the next minor release of Flask (this excludes the current latest Flask release 2.3.x). We will raise the upper bound to `<2.4` after we fix incompatibilities elsewhere in the Dash ecosystem.
 
+## Added
+
+- [#2540](https://github.com/plotly/dash/pull/2540) Add `include_pages_meta=True` to `Dash._init__`, fix [#2536](https://github.com/plotly/dash/issues/2536).
+
 ## Fixed
 
 - [#2508](https://github.com/plotly/dash/pull/2508) Fix error message, when callback output has different length than spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Added
 
-- [#2540](https://github.com/plotly/dash/pull/2540) Add `include_pages_meta=True` to `Dash._init__`, fix [#2536](https://github.com/plotly/dash/issues/2536).
+- [#2540](https://github.com/plotly/dash/pull/2540) Add `include_pages_meta=True` to `Dash` constructor, and fix a security issue in pages meta tags [#2536](https://github.com/plotly/dash/issues/2536).
 
 ## Fixed
 

--- a/dash/_pages.py
+++ b/dash/_pages.py
@@ -5,7 +5,6 @@ import sys
 from fnmatch import fnmatch
 from pathlib import Path
 from os.path import isfile, join
-from textwrap import dedent
 from urllib.parse import parse_qs
 
 import flask
@@ -397,19 +396,14 @@ def _page_meta_tags(app):
     if callable(description):
         description = description(**path_variables) if path_variables else description()
 
-    return dedent(
-        f"""
-        <meta name="description" content="{description}" />
-        <!-- Twitter Card data -->
-        <meta property="twitter:card" content="summary_large_image">
-        <meta property="twitter:url" content="{flask.request.url}">
-        <meta property="twitter:title" content="{title}">
-        <meta property="twitter:description" content="{description}">
-        <meta property="twitter:image" content="{image_url}">
-        <!-- Open Graph data -->
-        <meta property="og:title" content="{title}" />
-        <meta property="og:type" content="website" />
-        <meta property="og:description" content="{description}" />
-        <meta property="og:image" content="{image_url}">
-        """
-    )
+    return [
+        {"name": "description", "content": description},
+        {"property": "twitter:card", "content": "summary_large_image"},
+        {"property": "twitter:url", "content": flask.request.url},
+        {"property": "twitter:title", "content": title},
+        {"property": "twitter:description", "content": description},
+        {"property": "twitter:image", "content": image_url},
+        {"property": "og:title", "content": title},
+        {"property": "og:description", "content": description},
+        {"property": "og:image_url", "content": image_url},
+    ]

--- a/dash/_pages.py
+++ b/dash/_pages.py
@@ -407,7 +407,7 @@ def _page_meta_tags(app):
         {"property": "og:title", "content": title},
         {"property": "og:type", "content": "website"},
         {"property": "og:description", "content": description},
-        {"property": "og:image_url", "content": image_url or ""},
+        {"property": "og:image", "content": image_url or ""},
     ]
 
 

--- a/dash/_pages.py
+++ b/dash/_pages.py
@@ -405,6 +405,7 @@ def _page_meta_tags(app):
         {"property": "twitter:description", "content": description},
         {"property": "twitter:image", "content": image_url or ""},
         {"property": "og:title", "content": title},
+        {"property": "og:type", "content": "website"},
         {"property": "og:description", "content": description},
         {"property": "og:image_url", "content": image_url or ""},
     ]

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -10,6 +10,7 @@ import io
 import json
 import secrets
 import string
+from html import escape
 from functools import wraps
 
 logger = logging.getLogger()
@@ -30,8 +31,12 @@ def interpolate_str(template, **data):
     return s
 
 
-def format_tag(tag_name, attributes, inner="", closed=False, opened=False):
-    attributes = " ".join([f'{k}="{v}"' for k, v in attributes.items()])
+def format_tag(
+    tag_name, attributes, inner="", closed=False, opened=False, sanitize=False
+):
+    attributes = " ".join(
+        [f'{k}="{escape(v) if sanitize else v}"' for k, v in attributes.items()]
+    )
     tag = f"<{tag_name} {attributes}"
     if closed:
         tag += "/>"

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -862,10 +862,10 @@ class Dash:
     def _generate_meta(self):
         meta_tags = []
         has_ie_compat = any(
-            x.get("http-equiv", "") == "X-UA-Compatible" for x in meta_tags
+            x.get("http-equiv", "") == "X-UA-Compatible" for x in self.config.meta_tags
         )
-        has_charset = any("charset" in x for x in meta_tags)
-        has_viewport = any(x.get("name") == "viewport" for x in meta_tags)
+        has_charset = any("charset" in x for x in self.config.meta_tags)
+        has_viewport = any(x.get("name") == "viewport" for x in self.config.meta_tags)
 
         if not has_ie_compat:
             meta_tags.append({"http-equiv": "X-UA-Compatible", "content": "IE=edge"})

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -928,7 +928,7 @@ class Dash:
         title = self.title
 
         if self.use_pages and self.config.include_pages_meta:
-            metas += _page_meta_tags(self)
+            metas = _page_meta_tags(self) + metas
 
         if self._favicon:
             favicon_mod_time = os.path.getmtime(

--- a/tests/integration/security/test_injection.py
+++ b/tests/integration/security/test_injection.py
@@ -1,0 +1,29 @@
+import requests
+
+from dash import Dash, html, register_page
+
+injection_script = "<scRipt>console.error(0x000F45)</scRipt>"
+
+
+def test_sinj001_url_injection(dash_duo):
+    app = Dash(__name__, use_pages=True, pages_folder="")
+
+    register_page(
+        "injected",
+        layout=html.Div("Regular page"),
+        title="Title",
+        description="desc",
+        name="injected",
+        path="/injected",
+    )
+
+    dash_duo.start_server(app)
+
+    url = f"{dash_duo.server_url}/?'\"--></style></scRipt>{injection_script}"
+    dash_duo.server_url = url
+
+    assert dash_duo.get_logs() == []
+
+    ret = requests.get(url)
+
+    assert injection_script not in ret.text


### PR DESCRIPTION
- Add `include_pages_meta=True` to `Dash.__init__`
- Escape meta tags values
- Refactor some pages methods on Dash to `_pages.py`

Fix #2536
