### PR TITLE
Fix browser back button with multiple dcc.Location components in layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.10.3] - 2032-06-XX
+
+## Fixed
+
+- [#2555](https://github.com/plotly/dash/pull/2555) Fix browser back button when removing one of multiple location components from layout, fix [#1312](https://github.com/plotly/dash/issues/1312)
+
+
 ## [2.10.2] - 2023-05-31
 
 ## Changed

--- a/components/dash-core-components/src/components/Location.react.js
+++ b/components/dash-core-components/src/components/Location.react.js
@@ -112,7 +112,7 @@ export default class Location extends Component {
     }
 
     componentDidMount() {
-        window.onpopstate = this.onLocationChange;
+        window.addEventListener('popstate', this.onLocationChange);
 
         window.addEventListener(
             '_dashprivate_pushstate',
@@ -122,7 +122,7 @@ export default class Location extends Component {
     }
 
     componentWillUnmount() {
-        window.onpopstate = () => {};
+        window.removeEventListener('popstate', this.onLocationChange);
         window.removeEventListener(
             '_dashprivate_pushstate',
             this.onLocationChange


### PR DESCRIPTION
Multiple dcc.Location were replacing the others event handlers for 'popstate'. If any dcc.Location was unmounted, there was no event handler left

fix #1312

## Contributor Checklist

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))

### optionals

- [x] I have added entry in the `CHANGELOG.md`
