### PR TITLE
Feature: dcc.Input accepts a number for its debounce argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## UNRELEASED
+
+## Fixed
+
+- [#2593](https://github.com/plotly/dash/pull/2593) dcc.Input accepts a number for its debounce argument
+
 ## [2.11.1] - 2023-06-29
 
 ## Fixed

--- a/components/dash-core-components/.eslintrc
+++ b/components/dash-core-components/.eslintrc
@@ -117,7 +117,7 @@
     }],
     "no-magic-numbers": ["error", {
       "ignoreArrayIndexes": true,
-      "ignore": [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 100, 10, 16, 0.5, 25]
+      "ignore": [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 100, 10, 16, 0.5, 25, 1000]
     }],
     "no-underscore-dangle": ["off"],
     "no-useless-escape": ["off"]

--- a/components/dash-core-components/src/components/Input.react.js
+++ b/components/dash-core-components/src/components/Input.react.js
@@ -134,15 +134,13 @@ export default class Input extends PureComponent {
         this.setState({pendingEvent: undefined});
     }
 
-    debounceEvent(time = 0.5) {
+    debounceEvent(seconds = 0.5) {
         const {value} = this.input.current;
-        const MILLISECONDS = 1000;
-        time = time * MILLISECONDS;
 
         window.clearTimeout(this.state?.pendingEvent);
         const pendingEvent = window.setTimeout(() => {
             this.onEvent();
-        }, time);
+        }, seconds * 1000);
 
         this.setState({
             value,

--- a/components/dash-core-components/src/components/Input.react.js
+++ b/components/dash-core-components/src/components/Input.react.js
@@ -33,7 +33,7 @@ export default class Input extends PureComponent {
 
     UNSAFE_componentWillReceiveProps(nextProps) {
         const {value} = this.input.current;
-        if (this.state?.pendingEvent && nextProps.value !== value) {
+        if (this.state?.pendingEvent) {
             // avoid updating the input while awaiting a debounced event
             return;
         }
@@ -126,6 +126,7 @@ export default class Input extends PureComponent {
         } else {
             this.props.setProps({value});
         }
+        this.setState({pendingEvent: undefined});
     }
 
     debounceEvent(time = 0.5) {

--- a/components/dash-core-components/src/components/Input.react.js
+++ b/components/dash-core-components/src/components/Input.react.js
@@ -20,6 +20,11 @@ export default class Input extends PureComponent {
     constructor(props) {
         super(props);
 
+        this.state = {
+            pendingEvent: undefined,
+            value: '',
+        };
+
         this.input = React.createRef();
 
         this.onBlur = this.onBlur.bind(this);
@@ -33,7 +38,7 @@ export default class Input extends PureComponent {
 
     UNSAFE_componentWillReceiveProps(nextProps) {
         const {value} = this.input.current;
-        if (this.state?.pendingEvent) {
+        if (this.state.pendingEvent) {
             // avoid updating the input while awaiting a debounced event
             return;
         }

--- a/components/dash-core-components/tests/integration/input/conftest.py
+++ b/components/dash-core-components/tests/integration/input/conftest.py
@@ -58,6 +58,7 @@ def input_range_app():
 
     yield app
 
+
 @pytest.fixture(scope="module")
 def debounce_text_app():
     app = Dash(__name__)
@@ -69,7 +70,6 @@ def debounce_text_app():
                 placeholder="long wait",
             ),
             html.Div(id="div-slow"),
-
             dcc.Input(
                 id="input-fast",
                 debounce=0.25,
@@ -88,6 +88,7 @@ def debounce_text_app():
 
     yield app
 
+
 @pytest.fixture(scope="module")
 def debounce_number_app():
     app = Dash(__name__)
@@ -100,7 +101,6 @@ def debounce_number_app():
                 placeholder="long wait",
             ),
             html.Div(id="div-slow"),
-
             dcc.Input(
                 id="input-fast",
                 debounce=0.25,

--- a/components/dash-core-components/tests/integration/input/conftest.py
+++ b/components/dash-core-components/tests/integration/input/conftest.py
@@ -57,3 +57,68 @@ def input_range_app():
         return val
 
     yield app
+
+@pytest.fixture(scope="module")
+def debounce_text_app():
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.Input(
+                id="input-slow",
+                debounce=3,
+                placeholder="long wait",
+            ),
+            html.Div(id="div-slow"),
+
+            dcc.Input(
+                id="input-fast",
+                debounce=0.25,
+                placeholder="short wait",
+            ),
+            html.Div(id="div-fast"),
+        ]
+    )
+
+    @app.callback(
+        [Output("div-slow", "children"), Output("div-fast", "children")],
+        [Input("input-slow", "value"), Input("input-fast", "value")],
+    )
+    def render(slow_val, fast_val):
+        return [slow_val, fast_val]
+
+    yield app
+
+@pytest.fixture(scope="module")
+def debounce_number_app():
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.Input(
+                id="input-slow",
+                debounce=3,
+                type="number",
+                placeholder="long wait",
+            ),
+            html.Div(id="div-slow"),
+
+            dcc.Input(
+                id="input-fast",
+                debounce=0.25,
+                type="number",
+                min=10,
+                max=10000,
+                step=3,
+                placeholder="short wait",
+            ),
+            html.Div(id="div-fast"),
+        ]
+    )
+
+    @app.callback(
+        [Output("div-slow", "children"), Output("div-fast", "children")],
+        [Input("input-slow", "value"), Input("input-fast", "value")],
+    )
+    def render(slow_val, fast_val):
+        return [slow_val, fast_val]
+
+    yield app

--- a/components/dash-core-components/tests/integration/input/test_debounce.py
+++ b/components/dash-core-components/tests/integration/input/test_debounce.py
@@ -3,12 +3,13 @@ from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.by import By
 import pytest
 
+
 def test_debounce_text_by_time(dash_dcc, debounce_text_app):
     dash_dcc.start_server(debounce_text_app)
 
     # expect that a long debounce does not call back in a short amount of time
     elem = dash_dcc.find_element("#input-slow")
-    elem.send_keys('unit test slow')
+    elem.send_keys("unit test slow")
     with pytest.raises(TimeoutException):
         WebDriverWait(dash_dcc.driver, timeout=1).until(
             lambda d: d.find_element(By.XPATH, "//*[text()='unit test slow']")
@@ -19,10 +20,9 @@ def test_debounce_text_by_time(dash_dcc, debounce_text_app):
         "#div-slow", "unit test slow"
     ), "long debounce is eventually called back"
 
-
     # expect that a short debounce calls back within a short amount of time
     elem = dash_dcc.find_element("#input-fast")
-    elem.send_keys('unit test fast')
+    elem.send_keys("unit test fast")
     WebDriverWait(dash_dcc.driver, timeout=1).until(
         lambda d: d.find_element(By.XPATH, "//*[text()='unit test fast']")
     )
@@ -35,7 +35,7 @@ def test_debounce_number_by_time(dash_dcc, debounce_number_app):
 
     # expect that a long debounce does not call back in a short amount of time
     elem = dash_dcc.find_element("#input-slow")
-    elem.send_keys('12345')
+    elem.send_keys("12345")
     with pytest.raises(TimeoutException):
         WebDriverWait(dash_dcc.driver, timeout=1).until(
             lambda d: d.find_element(By.XPATH, "//*[text()='12345']")
@@ -46,10 +46,9 @@ def test_debounce_number_by_time(dash_dcc, debounce_number_app):
         "#div-slow", "12345"
     ), "long debounce is eventually called back"
 
-
     # expect that a short debounce calls back within a short amount of time
     elem = dash_dcc.find_element("#input-fast")
-    elem.send_keys('67890')
+    elem.send_keys("67890")
     WebDriverWait(dash_dcc.driver, timeout=1).until(
         lambda d: d.find_element(By.XPATH, "//*[text()='67890']")
     )

--- a/components/dash-core-components/tests/integration/input/test_debounce.py
+++ b/components/dash-core-components/tests/integration/input/test_debounce.py
@@ -1,4 +1,4 @@
-from selenium.common import TimeoutException
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.webdriver.common.by import By
 import pytest
@@ -48,9 +48,9 @@ def test_debounce_number_by_time(dash_dcc, debounce_number_app):
 
     # expect that a short debounce calls back within a short amount of time
     elem = dash_dcc.find_element("#input-fast")
-    elem.send_keys("67890")
+    elem.send_keys("10000")
     WebDriverWait(dash_dcc.driver, timeout=1).until(
-        lambda d: d.find_element(By.XPATH, "//*[text()='67890']")
+        lambda d: d.find_element(By.XPATH, "//*[text()='10000']")
     )
 
     assert dash_dcc.get_logs() == []

--- a/components/dash-core-components/tests/integration/input/test_debounce.py
+++ b/components/dash-core-components/tests/integration/input/test_debounce.py
@@ -1,0 +1,57 @@
+from selenium.common import TimeoutException
+from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.common.by import By
+import pytest
+
+def test_debounce_text_by_time(dash_dcc, debounce_text_app):
+    dash_dcc.start_server(debounce_text_app)
+
+    # expect that a long debounce does not call back in a short amount of time
+    elem = dash_dcc.find_element("#input-slow")
+    elem.send_keys('unit test slow')
+    with pytest.raises(TimeoutException):
+        WebDriverWait(dash_dcc.driver, timeout=1).until(
+            lambda d: d.find_element(By.XPATH, "//*[text()='unit test slow']")
+        )
+
+    # but do expect that it is eventually called
+    assert dash_dcc.wait_for_text_to_equal(
+        "#div-slow", "unit test slow"
+    ), "long debounce is eventually called back"
+
+
+    # expect that a short debounce calls back within a short amount of time
+    elem = dash_dcc.find_element("#input-fast")
+    elem.send_keys('unit test fast')
+    WebDriverWait(dash_dcc.driver, timeout=1).until(
+        lambda d: d.find_element(By.XPATH, "//*[text()='unit test fast']")
+    )
+
+    assert dash_dcc.get_logs() == []
+
+
+def test_debounce_number_by_time(dash_dcc, debounce_number_app):
+    dash_dcc.start_server(debounce_number_app)
+
+    # expect that a long debounce does not call back in a short amount of time
+    elem = dash_dcc.find_element("#input-slow")
+    elem.send_keys('12345')
+    with pytest.raises(TimeoutException):
+        WebDriverWait(dash_dcc.driver, timeout=1).until(
+            lambda d: d.find_element(By.XPATH, "//*[text()='12345']")
+        )
+
+    # but do expect that it is eventually called
+    assert dash_dcc.wait_for_text_to_equal(
+        "#div-slow", "12345"
+    ), "long debounce is eventually called back"
+
+
+    # expect that a short debounce calls back within a short amount of time
+    elem = dash_dcc.find_element("#input-fast")
+    elem.send_keys('67890')
+    WebDriverWait(dash_dcc.driver, timeout=1).until(
+        lambda d: d.find_element(By.XPATH, "//*[text()='67890']")
+    )
+
+    assert dash_dcc.get_logs() == []

--- a/components/dash-core-components/tests/integration/input/test_debounce.py
+++ b/components/dash-core-components/tests/integration/input/test_debounce.py
@@ -16,7 +16,7 @@ def test_debounce_text_by_time(dash_dcc, debounce_text_app):
         )
 
     # but do expect that it is eventually called
-    assert dash_dcc.wait_for_text_to_equal(
+    dash_dcc.wait_for_text_to_equal(
         "#div-slow", "unit test slow"
     ), "long debounce is eventually called back"
 
@@ -42,7 +42,7 @@ def test_debounce_number_by_time(dash_dcc, debounce_number_app):
         )
 
     # but do expect that it is eventually called
-    assert dash_dcc.wait_for_text_to_equal(
+    dash_dcc.wait_for_text_to_equal(
         "#div-slow", "12345"
     ), "long debounce is eventually called back"
 

--- a/components/dash-html-components/scripts/extract-elements.js
+++ b/components/dash-html-components/scripts/extract-elements.js
@@ -13,7 +13,7 @@ const expectedElCount = 125;
  */
 function extractElements($) {
     const excludeElements = [
-        'html', 'head', 'body', 'style', 'h1–h6', 'input',
+        'html', 'head', 'body', 'style', 'h1–h6', 'input', 'search',
         // out of scope, different namespaces - but Mozilla added these to the
         // above reference page Jan 2021 so we need to exclude them now.
         // see https://github.com/mdn/content/pull/410

--- a/requires-all.txt
+++ b/requires-all.txt
@@ -2,7 +2,7 @@
 redis>=3.5.3
 celery[redis]>=5.1.2
 # Dependencies used by CI on github.com/plotly/dash
-black==21.6b0
+black==22.3.0
 dash-flow-example==0.0.5
 dash-dangerously-set-inner-html
 flake8==3.9.2

--- a/tests/integration/devtools/test_props_check.py
+++ b/tests/integration/devtools/test_props_check.py
@@ -7,7 +7,7 @@ test_cases = {
         "fail": True,
         "name": 'simple "not a boolean" check',
         "component": dcc.Input,
-        "props": {"debounce": 0},
+        "props": {"multiple": 0},
     },
     "missing-required-nested-prop": {
         "fail": True,


### PR DESCRIPTION
This PR changes dcc.Input so that it accepts a "number of seconds" for the debounce argument.
When passing a number, the callbacks to the Dash server are debounced accordingly.
This does not change the behaviour of a boolean debounce argument.

With this PR in place, we will be able to address [this issue](https://github.com/plotly/dashboard-engine/issues/1051) in the dbe project.

## Contributor Checklist

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
