### PR TITLE
Create a single cancel callback for each unique input.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Fixed
 
 - [#2589](https://github.com/plotly/dash/pull/2589) CSS for input elements not scoped to Dash application
+- [#2599](https://github.com/plotly/dash/pull/2599) Fix background callback cancel inputs used in multiple callbacks and mixed cancel inputs across pages.
 
 ## Changed
 

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -12,7 +12,6 @@ from .dependencies import (
 from .exceptions import (
     PreventUpdate,
     WildcardInLongCallback,
-    DuplicateCallback,
     MissingLongCallbackManagerError,
     LongCallbackError,
 )
@@ -171,25 +170,8 @@ def callback(
             cancel_inputs = coerce_to_list(cancel)
             validate_long_inputs(cancel_inputs)
 
-            cancels_output = [Output(c.component_id, "id") for c in cancel_inputs]
-
-            try:
-
-                @callback(cancels_output, cancel_inputs, prevent_initial_call=True)
-                def cancel_call(*_):
-                    job_ids = flask.request.args.getlist("cancelJob")
-                    executor = (
-                        manager or context_value.get().background_callback_manager
-                    )
-                    if job_ids:
-                        for job_id in job_ids:
-                            executor.terminate_job(job_id)
-                    return NoUpdate()
-
-            except DuplicateCallback:
-                pass  # Already a callback to cancel, will get the proper jobs from the store.
-
             long_spec["cancel"] = [c.to_dict() for c in cancel_inputs]
+            long_spec["cancel_inputs"] = cancel_inputs
 
         if cache_args_to_ignore:
             long_spec["cache_args_to_ignore"] = cache_args_to_ignore

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -183,6 +183,7 @@ def callback(
         *_args,
         **_kwargs,
         long=long_spec,
+        manager=manager,
     )
 
 
@@ -220,6 +221,7 @@ def insert_callback(
     inputs_state_indices,
     prevent_initial_call,
     long=None,
+    manager=None,
 ):
     if prevent_initial_call is None:
         prevent_initial_call = config_prevent_initial_callbacks
@@ -251,6 +253,7 @@ def insert_callback(
         "long": long,
         "output": output,
         "raw_inputs": inputs,
+        "manager": manager,
     }
     callback_list.append(callback_spec)
 
@@ -278,6 +281,7 @@ def register_callback(  # pylint: disable=R0914
         multi = True
 
     long = _kwargs.get("long")
+    manager = _kwargs.get("manager")
 
     output_indices = make_grouping_by_index(output, list(range(grouping_len(output))))
     callback_id = insert_callback(
@@ -291,6 +295,7 @@ def register_callback(  # pylint: disable=R0914
         inputs_state_indices,
         prevent_initial_call,
         long=long,
+        manager=manager,
     )
 
     # pylint: disable=too-many-locals

--- a/tests/integration/long_callback/app_page_cancel.py
+++ b/tests/integration/long_callback/app_page_cancel.py
@@ -1,0 +1,93 @@
+from dash import Dash, Input, Output, dcc, html, page_container, register_page
+
+import time
+
+from tests.integration.long_callback.utils import get_long_callback_manager
+
+long_callback_manager = get_long_callback_manager()
+handle = long_callback_manager.handle
+
+
+app = Dash(
+    __name__,
+    use_pages=True,
+    pages_folder="",
+    long_callback_manager=long_callback_manager,
+)
+
+app.layout = html.Div(
+    [
+        dcc.Link("page1", "/"),
+        dcc.Link("page2", "/2"),
+        html.Button("Cancel", id="cancel"),
+        page_container,
+    ]
+)
+
+
+register_page(
+    "one",
+    "/",
+    layout=html.Div(
+        [
+            html.Button("start", id="start1"),
+            html.Button("cancel1", id="cancel1"),
+            html.Div("idle", id="progress1"),
+            html.Div("initial", id="output1"),
+        ]
+    ),
+)
+register_page(
+    "two",
+    "/2",
+    layout=html.Div(
+        [
+            html.Button("start2", id="start2"),
+            html.Button("cancel2", id="cancel2"),
+            html.Div("idle", id="progress2"),
+            html.Div("initial", id="output2"),
+        ]
+    ),
+)
+
+
+@app.callback(
+    Output("output1", "children"),
+    Input("start1", "n_clicks"),
+    running=[
+        (Output("progress1", "children"), "running", "idle"),
+    ],
+    cancel=[
+        Input("cancel1", "n_clicks"),
+        Input("cancel", "n_clicks"),
+    ],
+    background=True,
+    prevent_initial_call=True,
+    interval=300,
+)
+def on_click1(n_clicks):
+    time.sleep(2)
+    return f"Click {n_clicks}"
+
+
+@app.callback(
+    Output("output2", "children"),
+    Input("start2", "n_clicks"),
+    running=[
+        (Output("progress2", "children"), "running", "idle"),
+    ],
+    cancel=[
+        Input("cancel2", "n_clicks"),
+        Input("cancel", "n_clicks"),
+    ],
+    background=True,
+    prevent_initial_call=True,
+    interval=300,
+)
+def on_click1(n_clicks):
+    time.sleep(2)
+    return f"Click {n_clicks}"
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/tests/integration/long_callback/app_page_cancel.py
+++ b/tests/integration/long_callback/app_page_cancel.py
@@ -19,7 +19,7 @@ app.layout = html.Div(
     [
         dcc.Link("page1", "/"),
         dcc.Link("page2", "/2"),
-        html.Button("Cancel", id="cancel"),
+        html.Button("Cancel", id="shared_cancel"),
         page_container,
     ]
 )
@@ -59,7 +59,7 @@ register_page(
     ],
     cancel=[
         Input("cancel1", "n_clicks"),
-        Input("cancel", "n_clicks"),
+        Input("shared_cancel", "n_clicks"),
     ],
     background=True,
     prevent_initial_call=True,
@@ -78,7 +78,7 @@ def on_click1(n_clicks):
     ],
     cancel=[
         Input("cancel2", "n_clicks"),
-        Input("cancel", "n_clicks"),
+        Input("shared_cancel", "n_clicks"),
     ],
     background=True,
     prevent_initial_call=True,

--- a/tests/integration/long_callback/test_basic_long_callback.py
+++ b/tests/integration/long_callback/test_basic_long_callback.py
@@ -63,6 +63,9 @@ def setup_long_callback_app(manager_name, app_name):
             ],
             preexec_fn=os.setpgrp,
         )
+        # Wait for the worker to be ready, if you cancel before it is ready, the job
+        # will still be queued.
+        time.sleep(1)
         try:
             yield import_app(f"tests.integration.long_callback.{app_name}")
         finally:

--- a/tests/integration/long_callback/test_basic_long_callback.py
+++ b/tests/integration/long_callback/test_basic_long_callback.py
@@ -556,3 +556,37 @@ def test_lcbc015_diff_outputs_same_func(dash_duo, manager):
         for i in range(1, 3):
             dash_duo.find_element(f"#button-{i}").click()
             dash_duo.wait_for_text_to_equal(f"#output-{i}", f"Clicked on {i}")
+
+
+def test_lcbc016_multi_page_cancel(dash_duo, manager):
+    with setup_long_callback_app(manager, "app_page_cancel") as app:
+        dash_duo.start_server(app)
+        dash_duo.find_element("#start1").click()
+        dash_duo.wait_for_text_to_equal("#progress1", "running")
+        dash_duo.find_element("#cancel").click()
+        dash_duo.wait_for_text_to_equal("#progress1", "idle")
+        time.sleep(2.1)
+        dash_duo.wait_for_text_to_equal("#output1", "initial")
+
+        dash_duo.find_element("#start1").click()
+        dash_duo.wait_for_text_to_equal("#progress1", "running")
+        dash_duo.find_element("#cancel1").click()
+        dash_duo.wait_for_text_to_equal("#progress1", "idle")
+        time.sleep(2.1)
+        dash_duo.wait_for_text_to_equal("#output1", "initial")
+
+        dash_duo.server_url = dash_duo.server_url + "/2"
+
+        dash_duo.find_element("#start2").click()
+        dash_duo.wait_for_text_to_equal("#progress2", "running")
+        dash_duo.find_element("#cancel").click()
+        dash_duo.wait_for_text_to_equal("#progress2", "idle")
+        time.sleep(2.1)
+        dash_duo.wait_for_text_to_equal("#output2", "initial")
+
+        dash_duo.find_element("#start2").click()
+        dash_duo.wait_for_text_to_equal("#progress2", "running")
+        dash_duo.find_element("#cancel2").click()
+        dash_duo.wait_for_text_to_equal("#progress2", "idle")
+        time.sleep(2.1)
+        dash_duo.wait_for_text_to_equal("#output2", "initial")

--- a/tests/integration/long_callback/test_basic_long_callback.py
+++ b/tests/integration/long_callback/test_basic_long_callback.py
@@ -570,7 +570,7 @@ def test_lcbc016_multi_page_cancel(dash_duo, manager):
         dash_duo.start_server(app)
         dash_duo.find_element("#start1").click()
         dash_duo.wait_for_text_to_equal("#progress1", "running")
-        dash_duo.find_element("#cancel").click()
+        dash_duo.find_element("#shared_cancel").click()
         dash_duo.wait_for_text_to_equal("#progress1", "idle")
         time.sleep(2.1)
         dash_duo.wait_for_text_to_equal("#output1", "initial")
@@ -586,7 +586,7 @@ def test_lcbc016_multi_page_cancel(dash_duo, manager):
 
         dash_duo.find_element("#start2").click()
         dash_duo.wait_for_text_to_equal("#progress2", "running")
-        dash_duo.find_element("#cancel").click()
+        dash_duo.find_element("#shared_cancel").click()
         dash_duo.wait_for_text_to_equal("#progress2", "idle")
         time.sleep(2.1)
         dash_duo.wait_for_text_to_equal("#output2", "initial")

--- a/tests/integration/long_callback/test_basic_long_callback.py
+++ b/tests/integration/long_callback/test_basic_long_callback.py
@@ -62,10 +62,14 @@ def setup_long_callback_app(manager_name, app_name):
                 "--loglevel=info",
             ],
             preexec_fn=os.setpgrp,
+            stderr=subprocess.PIPE,
         )
         # Wait for the worker to be ready, if you cancel before it is ready, the job
         # will still be queued.
-        time.sleep(1)
+        for line in iter(worker.stderr.readline, ""):
+            if "ready" in line.decode():
+                break
+
         try:
             yield import_app(f"tests.integration.long_callback.{app_name}")
         finally:


### PR DESCRIPTION
Partial fix for #2588, create a cancel callback for each unique cancel input of background callback. This allow to use a location input shared across pages (`_pages_location_container`) in multiple background callbacks cancel.