### PR TITLE
Add mapping of tsconfig compiler option 'moduleResolution'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Fixed
 
+- [#2616](https://github.com/plotly/dash/pull/2616) Add mapping of tsconfig compiler option `moduleResolution`, fixes [#2618](https://github.com/plotly/dash/issues/2618) 
 - [#2596](https://github.com/plotly/dash/pull/2596) Fix react-dom throwing unique key prop error for markdown table, fix [#1433](https://github.com/plotly/dash/issues/1433)
 - [#2589](https://github.com/plotly/dash/pull/2589) CSS for input elements not scoped to Dash application
 - [#2599](https://github.com/plotly/dash/pull/2599) Fix background callback cancel inputs used in multiple callbacks and mixed cancel inputs across pages.

--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -49,7 +49,7 @@ if (fs.existsSync('tsconfig.json')) {
         case 'nodenext':
             tsconfig.moduleResolution = ts.ModuleResolutionKind.NodeNext;
             break;
-                case 'classic':
+        case 'classic':
             tsconfig.moduleResolution = ts.ModuleResolutionKind.Classic;
             break;
         default:

--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -38,6 +38,23 @@ if (!src.length) {
 
 if (fs.existsSync('tsconfig.json')) {
     tsconfig = JSON.parse(fs.readFileSync('tsconfig.json')).compilerOptions;
+    // Map moduleResolution to the appropriate enum.
+    switch (tsconfig.moduleResolution) {
+        case 'node':
+            tsconfig.moduleResolution = ts.ModuleResolutionKind.NodeJs;
+            break;
+        case 'node16':
+            tsconfig.moduleResolution = ts.ModuleResolutionKind.Node16;
+            break;
+        case 'nodenext':
+            tsconfig.moduleResolution = ts.ModuleResolutionKind.NodeNext;
+            break;
+                case 'classic':
+            tsconfig.moduleResolution = ts.ModuleResolutionKind.Classic;
+            break;
+        default:
+            break;
+    }
 }
 
 let failedBuild = false;


### PR DESCRIPTION
This PR adds a mapping of tsconfig compiler option `moduleResolution` from string representation to the appropriate enum representation. Currently, if you set the moduleResolution option in` tsconfig.json ` to one of the allowed values ('node', 'classic', 'node16', 'nodenext'), e.g.

```
{
  "compilerOptions": {
    "moduleResolution": "node",
    ...
  },
  ...
}
```

you will get an error like,

```
> dash-generate-components ./src/ts/components tsconvert -p package-info.json --r-prefix '' --jl-prefix '' --ignore \.test\.

/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:2572
            throw e;
            ^

Error: Debug Failure. Unexpected moduleResolution: node
    at Object.resolveModuleName (/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:44046:37)
    at loader_1 (/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:119377:117)
    at loadWithModeAwareCache (/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:118997:46)
    at actualResolveModuleNamesWorker (/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:119378:149)
    at resolveModuleNamesWorker (/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:119667:26)
    at resolveModuleNamesReusingOldState (/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:119765:24)
    at processImportedModules (/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:121296:35)
    at findSourceFileWorker (/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:121076:17)
    at findSourceFile (/home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:120922:26)
    at /home/emher/Code/tsconvert/node_modules/typescript/lib/typescript.js:120871:85

Node.js v18.16.1

Error generating metadata in tsconvert (status=1)

```

This PR fixes this issue. The PR builds on dicussions from [this thread](https://community.plotly.com/t/introducing-typescript-dash-component-generation/61988/9?u=emil).
