### PR TITLE
add setuptools as a dependency

### DIFF
--- a/requires-all.txt
+++ b/requires-all.txt
@@ -47,3 +47,4 @@ requests[security]>=2.21.0
 selenium>=3.141.0
 waitress>=1.4.4
 webdriver-manager>=3.5.1
+setuptools

--- a/requires-install.txt
+++ b/requires-install.txt
@@ -11,3 +11,4 @@ requests
 retrying
 ansi2html
 nest-asyncio
+setuptools


### PR DESCRIPTION
this might sound silly, but setuptools is actually [required to run this library](https://github.com/plotly/dash/blob/dev/dash/dash.py#L22C1-L22C58), so explicitly declaring it in req files. we had issues about using this library where the solution has been installing setuptools (we try to only include declared dependencies)