### PR TITLE
dynamic callback creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - [#2635](https://github.com/plotly/dash/pull/2635) Get proper app module name, remove need to give `__name__` to Dash constructor.
 
+## Added
+
+- [#2649](https://github.com/plotly/dash/pull/2649) Add `_allow_dynamic_callbacks`, register new callbacks inside other callbacks.
+
 ## [2.13.0] 2023-08-28
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Added
 
 - [#2649](https://github.com/plotly/dash/pull/2649) Add `_allow_dynamic_callbacks`, register new callbacks inside other callbacks.
+  **WARNING: dynamic callback creation can be dangerous, use at you own risk. It is not intended for use in a production app, multi-user or multiprocess use as it only works for a single user.**
 
 ## [2.13.0] 2023-08-28
 ## Changed

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -210,6 +210,7 @@ def clientside_callback(clientside_function, *args, **kwargs):
     )
 
 
+# pylint: disable=too-many-arguments
 def insert_callback(
     callback_list,
     callback_map,
@@ -222,6 +223,7 @@ def insert_callback(
     prevent_initial_call,
     long=None,
     manager=None,
+    dynamic_creator=False,
 ):
     if prevent_initial_call is None:
         prevent_initial_call = config_prevent_initial_callbacks
@@ -243,6 +245,7 @@ def insert_callback(
         and {
             "interval": long["interval"],
         },
+        "dynamic_creator": dynamic_creator,
     }
 
     callback_map[callback_id] = {
@@ -282,6 +285,7 @@ def register_callback(  # pylint: disable=R0914
 
     long = _kwargs.get("long")
     manager = _kwargs.get("manager")
+    allow_dynamic_callbacks = _kwargs.get("_allow_dynamic_callbacks")
 
     output_indices = make_grouping_by_index(output, list(range(grouping_len(output))))
     callback_id = insert_callback(
@@ -296,6 +300,7 @@ def register_callback(  # pylint: disable=R0914
         prevent_initial_call,
         long=long,
         manager=manager,
+        dynamic_creator=allow_dynamic_callbacks,
     )
 
     # pylint: disable=too-many-locals

--- a/dash/dash-renderer/src/actions/callbacks.ts
+++ b/dash/dash-renderer/src/actions/callbacks.ts
@@ -42,7 +42,8 @@ import {notifyObservers, updateProps} from './index';
 import {CallbackJobPayload} from '../reducers/callbackJobs';
 import {handlePatch, isPatch} from './patch';
 import {getPath} from './paths';
-import {requestDependencies} from './dependencies_ts';
+
+import {requestDependencies} from './requestDependencies';
 
 export const addBlockedCallbacks = createAction<IBlockedCallback[]>(
     CallbackActionType.AddBlocked

--- a/dash/dash-renderer/src/actions/callbacks.ts
+++ b/dash/dash-renderer/src/actions/callbacks.ts
@@ -42,6 +42,7 @@ import {notifyObservers, updateProps} from './index';
 import {CallbackJobPayload} from '../reducers/callbackJobs';
 import {handlePatch, isPatch} from './patch';
 import {getPath} from './paths';
+import {requestDependencies} from './dependencies_ts';
 
 export const addBlockedCallbacks = createAction<IBlockedCallback[]>(
     CallbackActionType.AddBlocked
@@ -584,7 +585,8 @@ export function executeCallback(
     dispatch: any,
     getState: any
 ): IExecutingCallback {
-    const {output, inputs, state, clientside_function, long} = cb.callback;
+    const {output, inputs, state, clientside_function, long, dynamic_creator} =
+        cb.callback;
     try {
         const inVals = fillVals(paths, layout, cb, inputs, 'Input', true);
 
@@ -727,6 +729,13 @@ export function executeCallback(
                                 );
                             }
                         });
+
+                        if (dynamic_creator) {
+                            setTimeout(
+                                () => dispatch(requestDependencies()),
+                                0
+                            );
+                        }
 
                         return {data, payload};
                     } catch (res: any) {

--- a/dash/dash-renderer/src/actions/dependencies_ts.ts
+++ b/dash/dash-renderer/src/actions/dependencies_ts.ts
@@ -32,6 +32,9 @@ import {
     idMatch
 } from './dependencies';
 import {getPath} from './paths';
+import apiThunk from './api';
+import {setGraphs} from './index';
+import {batch} from 'react-redux';
 
 export const DIRECT = 2;
 export const INDIRECT = 1;
@@ -444,4 +447,15 @@ export function resolveDeps(
             });
             return result;
         };
+}
+
+export function requestDependencies() {
+    return (dispatch: any) => {
+        batch(() => {
+            dispatch(setGraphs({}));
+            dispatch(
+                apiThunk('_dash-dependencies', 'GET', 'dependenciesRequest')
+            );
+        });
+    };
 }

--- a/dash/dash-renderer/src/actions/dependencies_ts.ts
+++ b/dash/dash-renderer/src/actions/dependencies_ts.ts
@@ -18,23 +18,20 @@ import {
 } from 'ramda';
 import {
     ICallback,
-    ICallbackProperty,
     ICallbackDefinition,
-    ILayoutCallbackProperty,
-    ICallbackTemplate
+    ICallbackProperty,
+    ICallbackTemplate,
+    ILayoutCallbackProperty
 } from '../types/callbacks';
 import {
     addAllResolvedFromOutputs,
-    splitIdAndProp,
-    stringifyId,
     getUnfilteredLayoutCallbacks,
+    idMatch,
     isMultiValued,
-    idMatch
+    splitIdAndProp,
+    stringifyId
 } from './dependencies';
 import {getPath} from './paths';
-import apiThunk from './api';
-import {setGraphs} from './index';
-import {batch} from 'react-redux';
 
 export const DIRECT = 2;
 export const INDIRECT = 1;
@@ -447,15 +444,4 @@ export function resolveDeps(
             });
             return result;
         };
-}
-
-export function requestDependencies() {
-    return (dispatch: any) => {
-        batch(() => {
-            dispatch(setGraphs({}));
-            dispatch(
-                apiThunk('_dash-dependencies', 'GET', 'dependenciesRequest')
-            );
-        });
-    };
 }

--- a/dash/dash-renderer/src/actions/requestDependencies.ts
+++ b/dash/dash-renderer/src/actions/requestDependencies.ts
@@ -1,0 +1,14 @@
+import {batch} from 'react-redux';
+import {setGraphs} from './index';
+import apiThunk from './api';
+
+export function requestDependencies() {
+    return (dispatch: any) => {
+        batch(() => {
+            dispatch(setGraphs({}));
+            dispatch(
+                apiThunk('_dash-dependencies', 'GET', 'dependenciesRequest')
+            );
+        });
+    };
+}

--- a/dash/dash-renderer/src/types/callbacks.ts
+++ b/dash/dash-renderer/src/types/callbacks.ts
@@ -12,6 +12,7 @@ export interface ICallbackDefinition {
     prevent_initial_call: boolean;
     state: ICallbackProperty[];
     long?: LongCallbackInfo;
+    dynamic_creator?: boolean;
 }
 
 export interface ICallbackProperty {

--- a/requires-ci.txt
+++ b/requires-ci.txt
@@ -9,7 +9,7 @@ flask-talisman==1.0.0
 isort==4.3.21;python_version<"3.7"
 mimesis
 mock==4.0.3
-numpy
+numpy<=1.25.2
 orjson==3.5.4;python_version<"3.7"
 orjson==3.6.7;python_version>="3.7"
 openpyxl;python_version>="3.8"

--- a/tests/integration/callbacks/test_dynamic_callback.py
+++ b/tests/integration/callbacks/test_dynamic_callback.py
@@ -1,0 +1,39 @@
+from dash import html, Dash, Input, Output
+
+
+def test_dync001_dynamic_callback(dash_duo):
+    app = Dash()
+
+    app.layout = html.Div(
+        [
+            html.Div(id="output"),
+            html.Button("create", id="create"),
+            html.Div("initial", id="output-2"),
+            html.Button("dynamic", id="dynamic"),
+        ]
+    )
+
+    @app.callback(
+        Output("output", "children"),
+        Input("create", "n_clicks"),
+        _allow_dynamic_callbacks=True,
+        prevent_initial_call=True,
+    )
+    def on_click(n_clicks):
+        @app.callback(
+            Output("output-2", "children"),
+            Input("dynamic", "n_clicks"),
+            prevent_initial_call=True,
+        )
+        def on_click2(n_clicks2):
+            return f"Dynamic clicks {n_clicks2}"
+
+        return f"creator {n_clicks}"
+
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_element("#create").click()
+    dash_duo.wait_for_text_to_equal("#output", "creator 1")
+
+    dash_duo.wait_for_element("#dynamic").click()
+    dash_duo.wait_for_text_to_equal("#output-2", "Dynamic clicks 1")

--- a/tests/integration/callbacks/test_dynamic_callback.py
+++ b/tests/integration/callbacks/test_dynamic_callback.py
@@ -32,8 +32,10 @@ def test_dync001_dynamic_callback(dash_duo):
 
     dash_duo.start_server(app)
 
+    dash_duo.wait_for_element("#dynamic").click()
     dash_duo.wait_for_element("#create").click()
     dash_duo.wait_for_text_to_equal("#output", "creator 1")
+    dash_duo.wait_for_text_to_equal("#output-2", "initial")
 
     dash_duo.wait_for_element("#dynamic").click()
-    dash_duo.wait_for_text_to_equal("#output-2", "Dynamic clicks 1")
+    dash_duo.wait_for_text_to_equal("#output-2", "Dynamic clicks 2")

--- a/tests/integration/callbacks/test_dynamic_callback.py
+++ b/tests/integration/callbacks/test_dynamic_callback.py
@@ -1,6 +1,9 @@
 from dash import html, Dash, Input, Output
 
 
+# WARNING: dynamic callback creation can be dangerous, use at you own risk.
+# It is not intended for use in a production app, multi-user
+# or multiprocess use as it only works for a single user.
 def test_dync001_dynamic_callback(dash_duo):
     app = Dash()
 


### PR DESCRIPTION
Add a new `app.callback` argument: `_allow_dynamic_callbacks` to add new callbacks defined inside a callback.

- Only `app.callback` for the same will be registered.
- Need to return a value from the callback, `PreventUpdate` not supported in the callback creator.
- Only the user that created the callback will receive the updated callbacks, other users would need to refresh.

**_:warning: Intended for internal usage, use only with a local server for 1 user per app._** 