### PR TITLE
Feature/clipboard-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Added
 - [#2695](https://github.com/plotly/dash/pull/2695) Adds  `triggered_id` to `dash_clientside.callback_context`.  Fixes [#2692](https://github.com/plotly/dash/issues/2692)
 
+## Changed
+- [#2652](https://github.com/plotly/dash/pull/2652) dcc.Clipboard supports htm_content and triggers a copy to clipboard when n_clicks are changed
+
 ## [2.14.2] - 2023-11-27
 
 ## Fixed

--- a/components/dash-core-components/src/components/Clipboard.react.js
+++ b/components/dash-core-components/src/components/Clipboard.react.js
@@ -17,6 +17,7 @@ export default class Clipboard extends React.Component {
     constructor(props) {
         super(props);
         this.copyToClipboard = this.copyToClipboard.bind(this);
+        this.onClickHandler = this.onClickHandler.bind(this);
         this.copySuccess = this.copySuccess.bind(this);
         this.getTargetText = this.getTargetText.bind(this);
         this.loading = this.loading.bind(this);
@@ -26,12 +27,19 @@ export default class Clipboard extends React.Component {
         };
     }
 
+    onClickHandler() {
+        this.props.setProps({n_clicks: this.props.n_clicks + 1});
+    }
+
     componentDidUpdate(prevProps) {
-        // If the data hasn't changed, do nothing.
-        if (!this.props.content || this.props.content === prevProps.content) {
+        // If the clicks has not changed, do nothing
+        if (
+            !this.props.n_clicks ||
+            this.props.n_clicks === prevProps.n_clicks
+        ) {
             return;
         }
-        // If the data has changed, copy to clipboard
+        // If the clicks has changed, copy to clipboard
         this.copyToClipboard();
     }
 
@@ -94,10 +102,6 @@ export default class Clipboard extends React.Component {
     }
 
     async copyToClipboard() {
-        this.props.setProps({
-            n_clicks: this.props.n_clicks + 1,
-        });
-
         let content;
         let htmlContent;
         if (this.props.target_id) {
@@ -131,7 +135,7 @@ export default class Clipboard extends React.Component {
                 title={title}
                 style={style}
                 className={className}
-                onClick={this.copyToClipboard}
+                onClick={this.onClickHandler}
                 data-dash-is-loading={
                     (loading_state && loading_state.is_loading) || undefined
                 }

--- a/components/dash-core-components/src/components/Clipboard.react.js
+++ b/components/dash-core-components/src/components/Clipboard.react.js
@@ -26,6 +26,15 @@ export default class Clipboard extends React.Component {
         };
     }
 
+    componentDidUpdate(prevProps) {
+        // If the data hasn't changed, do nothing.
+        if (!this.props.content || this.props.content === prevProps.content) {
+            return;
+        }
+        // If the data has changed, copy to clipboard
+        this.copyToClipboard();
+    }
+
     // stringifies object ids used in pattern matching callbacks
     stringifyId(id) {
         if (typeof id !== 'object') {

--- a/components/dash-core-components/tests/integration/clipboard/test_clipboard.py
+++ b/components/dash-core-components/tests/integration/clipboard/test_clipboard.py
@@ -61,9 +61,9 @@ def test_clp003_clipboard_text(dash_dcc_headed):
     app = Dash(__name__, prevent_initial_callbacks=True)
     app.layout = html.Div(
         [
-            dcc.Clipboard(id="copy_icon", content=copy_text),
+            dcc.Clipboard(id="copy_icon", content=copy_text, n_clicks=0),
             dcc.Textarea(id="paste"),
-            html.Button("Copy", id="copy_button"),
+            html.Button("Copy", id="copy_button", n_clicks=0),
         ]
     )
 

--- a/components/dash-core-components/tests/integration/clipboard/test_clipboard.py
+++ b/components/dash-core-components/tests/integration/clipboard/test_clipboard.py
@@ -1,4 +1,4 @@
-from dash import Dash, html, dcc, callback, Output, Input
+from dash import Dash, html, dcc, callback, Output, Input, State
 
 import dash.testing.wait as wait
 import time
@@ -55,20 +55,27 @@ def test_clp002_clipboard_text(dash_dcc_headed):
         timeout=3,
     )
 
+
 def test_clp003_clipboard_text(dash_dcc_headed):
     copy_text = "Copy this text to the clipboard using a separate button"
     app = Dash(__name__, prevent_initial_callbacks=True)
     app.layout = html.Div(
-        [dcc.Clipboard(id="copy_icon", content=copy_text), dcc.Textarea(id="paste"), html.Button("Copy", id="copy_button")]
+        [
+            dcc.Clipboard(id="copy_icon", content=copy_text),
+            dcc.Textarea(id="paste"),
+            html.Button("Copy", id="copy_button"),
+        ]
     )
+
     @callback(
-        Output("copy_icon", "content"),
+        Output("copy_icon", "n_clicks"),
+        State("copy_icon", "n_clicks"),
         Input("copy_button", "n_clicks"),
         prevent_initial_call=True,
     )
-    def selected(clicks):
-        return f"{clicks}"
-    
+    def selected(icon_clicks, button_clicks):
+        return icon_clicks + 1
+
     dash_dcc_headed.start_server(app)
 
     dash_dcc_headed.find_element("#copy_button").click()

--- a/components/dash-core-components/tests/integration/clipboard/test_clipboard.py
+++ b/components/dash-core-components/tests/integration/clipboard/test_clipboard.py
@@ -1,4 +1,4 @@
-from dash import Dash, html, dcc
+from dash import Dash, html, dcc, callback, Output, Input
 
 import dash.testing.wait as wait
 import time
@@ -43,6 +43,35 @@ def test_clp002_clipboard_text(dash_dcc_headed):
     dash_dcc_headed.start_server(app)
 
     dash_dcc_headed.find_element("#copy_icon").click()
+    time.sleep(1)
+    dash_dcc_headed.find_element("#paste").click()
+    ActionChains(dash_dcc_headed.driver).key_down(Keys.CONTROL).send_keys("v").key_up(
+        Keys.CONTROL
+    ).perform()
+
+    wait.until(
+        lambda: dash_dcc_headed.find_element("#paste").get_attribute("value")
+        == copy_text,
+        timeout=3,
+    )
+
+def test_clp003_clipboard_text(dash_dcc_headed):
+    copy_text = "Copy this text to the clipboard using a separate button"
+    app = Dash(__name__, prevent_initial_callbacks=True)
+    app.layout = html.Div(
+        [dcc.Clipboard(id="copy_icon", content=copy_text), dcc.Textarea(id="paste"), html.Button("Copy", id="copy_button")]
+    )
+    @callback(
+        Output("copy_icon", "content"),
+        Input("copy_button", "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def selected(clicks):
+        return f"{clicks}"
+    
+    dash_dcc_headed.start_server(app)
+
+    dash_dcc_headed.find_element("#copy_button").click()
     time.sleep(1)
     dash_dcc_headed.find_element("#paste").click()
     ActionChains(dash_dcc_headed.driver).key_down(Keys.CONTROL).send_keys("v").key_up(


### PR DESCRIPTION
This allows the clipboard to firstly support HTML MIME type. This allows us to copy to clipboard for example, both df.to_string and df.to_html and be able to get the full table on paste where HTML is accepted such as email or other apps. This is optional and independent prop called html_content.

Secondly, the clipboard will now copy on a change to it's content. Previously you could only copy if you clicked on the clipboard item itself. The clipboard item may not be suited for some UIs and so now you can use another component to trigger the copy, such as a button. This behaviour is in line with dcc.Download and many other components.

- ✅ I have broken down my PR scope into the following TODO tasks
   -  ✅ HTML support
   -  ✅ Copy on change to content changes as per
- ✅ I have run the tests locally and they passed. (refer to testing section in [contributing]I think so. I was able to run CI and build.
- ✅ I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
