### PR TITLE
utils: get_caller_name: handle cases when source is unavailable

### DIFF
--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -287,7 +287,7 @@ def parse_version(version):
 def get_caller_name(name: str):
     stack = inspect.stack()
     for s in stack:
-        for code in s.code_context:
+        for code in s.code_context or []:
             if f"{name}(" in code:
                 return s.frame.f_locals.get("__name__", "__main__")
     return "__main__"


### PR DESCRIPTION
Fix `get_caller_name` to gracefully handle cases when a module's source code is unavailable. In such cases, `FrameInfo.code_context` is `None` an cannot be iterated over:

``` 
Traceback (most recent call last):
  File "program.py", line 6, in <module>
    app = dash.Dash(__name__)
  File "dash/dash.py", line 399, in __init__
  File "dash/_utils.py", line 290, in get_caller_name
TypeError: 'NoneType' object is not iterable
``` 

This happens with `PyInstaller`, where both `dash` modules and the program's entry-point script are collected as byte-compiled .pyc modules, without corresponding source .py files. 

But it can be also triggered by simply byte-compiling the python script into .pyc, removing the source .py, and running the .pyc.
