### PR TITLE
Fix get_caller_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED]
+
+## Fixed
+
+- [#2672](https://github.com/plotly/dash/pull/2672) Fix `get_caller_name` in case the source is not available.
+
 ## [2.14.0] - 2023-10-11
 
 ## Fixed

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -284,10 +284,10 @@ def parse_version(version):
     return tuple(int(s) for s in version.split("."))
 
 
-def get_caller_name(name: str):
+def get_caller_name():
     stack = inspect.stack()
     for s in stack:
-        for code in s.code_context:
-            if f"{name}(" in code:
-                return s.frame.f_locals.get("__name__", "__main__")
+        if s.function == "<module>":
+            return s.frame.f_locals.get("__name__", "__main__")
+
     return "__main__"

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -396,7 +396,7 @@ class Dash:
     ):
         _validate.check_obsolete(obsolete)
 
-        caller_name = get_caller_name(self.__class__.__name__)
+        caller_name = get_caller_name()
 
         # We have 3 cases: server is either True (we create the server), False
         # (defer server creation) or a Flask app instance (we use their server)

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -396,7 +396,7 @@ class Dash:
     ):
         _validate.check_obsolete(obsolete)
 
-        caller_name = get_caller_name()
+        caller_name = None if name else get_caller_name()
 
         # We have 3 cases: server is either True (we create the server), False
         # (defer server creation) or a Flask app instance (we use their server)


### PR DESCRIPTION
Fix `get_caller_name` by always taking the third stack frame from the function call. (0 is `get_caller_name`, `__init__` is 1 then next one is the `app = Dash()` call)
