### PR TITLE
Adding support for bringing your own driver to the Browser

### DIFF
--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -41,6 +41,7 @@ class Browser(DashPageMixin):
     def __init__(
         self,
         browser,
+        driver=None,
         remote=False,
         remote_url=None,
         headless=False,
@@ -65,8 +66,11 @@ class Browser(DashPageMixin):
         self._percy_run = percy_run
         self._pause = pause
 
-        self._driver = until(self.get_webdriver, timeout=1)
-        self._driver.implicitly_wait(2)
+        if driver:
+            self._driver = driver
+        else:
+            self._driver = until(self.get_webdriver, timeout=1)
+            self._driver.implicitly_wait(2)
 
         self._wd_wait = WebDriverWait(self.driver, wait_timeout)
         self._last_ts = 0


### PR DESCRIPTION
This is a proof-of-concept of being able to bring your own driver to the Browser object of dash.testing and be able to utilize predefined dash_duo tests.

Looking for feedback and usability.