### PR TITLE
Fixing poor docstring formatting for @callback

### DIFF
--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -81,12 +81,15 @@ def callback(
     not to fire when its outputs are first added to the page. Defaults to
     `False` and unlike `app.callback` is not configurable at the app level.
 
-    :Keyword Arguments:
-        :param background:
+    Keyword Arguments
+    -----------------
+    
+    param background:
             Mark the callback as a long callback to execute in a manager for
             callbacks that take a long time without locking up the Dash app
             or timing out.
-        :param manager:
+            
+    param manager:
             A long callback manager instance. Currently, an instance of one of
             `DiskcacheManager` or `CeleryManager`.
             Defaults to the `background_callback_manager` instance provided to the
@@ -98,19 +101,22 @@ def callback(
             - A Celery manager (`CeleryManager`) that runs callback logic
               in a celery worker and returns results to the Dash app through a Celery
               broker like RabbitMQ or Redis.
-        :param running:
+              
+    param running:
             A list of 3-element tuples. The first element of each tuple should be
             an `Output` dependency object referencing a property of a component in
             the app layout. The second element is the value that the property
             should be set to while the callback is running, and the third element
             is the value the property should be set to when the callback completes.
-        :param cancel:
+            
+    param cancel:
             A list of `Input` dependency objects that reference a property of a
             component in the app's layout.  When the value of this property changes
             while a callback is running, the callback is canceled.
             Note that the value of the property is not significant, any change in
             value will result in the cancellation of the running job (if any).
-        :param progress:
+            
+    param progress:
             An `Output` dependency grouping that references properties of
             components in the app's layout. When provided, the decorated function
             will be called with an extra argument as the first argument to the
@@ -119,18 +125,21 @@ def callback(
             current progress. This function accepts a single argument, which
             correspond to the grouping of properties specified in the provided
             `Output` dependency grouping
-        :param progress_default:
+            
+    param progress_default:
             A grouping of values that should be assigned to the components
             specified by the `progress` argument when the callback is not in
             progress. If `progress_default` is not provided, all the dependency
             properties specified in `progress` will be set to `None` when the
             callback is not running.
-        :param cache_args_to_ignore:
+            
+    param cache_args_to_ignore:
             Arguments to ignore when caching is enabled. If callback is configured
             with keyword arguments (Input/State provided in a dict),
             this should be a list of argument names as strings. Otherwise,
             this should be a list of argument indices as integers.
-        :param interval:
+            
+    param interval:
             Time to wait between the long callback update requests.
     """
 

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -81,13 +81,11 @@ def callback(
     not to fire when its outputs are first added to the page. Defaults to
     `False` and unlike `app.callback` is not configurable at the app level.
 
-    Keyword Arguments
-    -----------------
-    param background:
+    :param background:
             Mark the callback as a long callback to execute in a manager for
             callbacks that take a long time without locking up the Dash app
-            or timing out. \n
-    param manager:
+            or timing out.\n
+    :param manager:
             A long callback manager instance. Currently, an instance of one of
             `DiskcacheManager` or `CeleryManager`.
             Defaults to the `background_callback_manager` instance provided to the
@@ -98,20 +96,20 @@ def callback(
           development.
         - A Celery manager (`CeleryManager`) that runs callback logic
           in a celery worker and returns results to the Dash app through a Celery
-          broker like RabbitMQ or Redis. \n
-    param running:
+          broker like RabbitMQ or Redis.\n
+    :param running:
             A list of 3-element tuples. The first element of each tuple should be
             an `Output` dependency object referencing a property of a component in
             the app layout. The second element is the value that the property
             should be set to while the callback is running, and the third element
-            is the value the property should be set to when the callback completes. \n
-    param cancel:
+            is the value the property should be set to when the callback completes.\n
+    :param cancel:
             A list of `Input` dependency objects that reference a property of a
             component in the app's layout.  When the value of this property changes
             while a callback is running, the callback is canceled.
             Note that the value of the property is not significant, any change in
-            value will result in the cancellation of the running job (if any). \n
-    param progress:
+            value will result in the cancellation of the running job (if any).\n
+    :param progress:
             An `Output` dependency grouping that references properties of
             components in the app's layout. When provided, the decorated function
             will be called with an extra argument as the first argument to the
@@ -119,20 +117,20 @@ def callback(
             function should call in order to provide updates to the app on its
             current progress. This function accepts a single argument, which
             correspond to the grouping of properties specified in the provided
-            `Output` dependency grouping \n
-    param progress_default:
+            `Output` dependency grouping. \n
+    :param progress_default:
             A grouping of values that should be assigned to the components
             specified by the `progress` argument when the callback is not in
             progress. If `progress_default` is not provided, all the dependency
             properties specified in `progress` will be set to `None` when the
             callback is not running. \n
-    param cache_args_to_ignore:
+    :param cache_args_to_ignore:
             Arguments to ignore when caching is enabled. If callback is configured
             with keyword arguments (Input/State provided in a dict),
             this should be a list of argument names as strings. Otherwise,
             this should be a list of argument indices as integers. \n
-    param interval:
-            Time to wait between the long callback update requests. \n
+    :param interval:
+            Time to wait between the long callback update requests.
     """
 
     long_spec = None

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -94,13 +94,13 @@ def callback(
             `DiskcacheManager` or `CeleryManager`.
             Defaults to the `background_callback_manager` instance provided to the
             `dash.Dash constructor`.
-            - A diskcache manager (`DiskcacheManager`) that runs callback
-              logic in a separate process and stores the results to disk using the
-              diskcache library. This is the easiest backend to use for local
-              development.
-            - A Celery manager (`CeleryManager`) that runs callback logic
-              in a celery worker and returns results to the Dash app through a Celery
-              broker like RabbitMQ or Redis.
+        - A diskcache manager (`DiskcacheManager`) that runs callback
+          logic in a separate process and stores the results to disk using the
+          diskcache library. This is the easiest backend to use for local
+          development.
+        - A Celery manager (`CeleryManager`) that runs callback logic
+          in a celery worker and returns results to the Dash app through a Celery
+          broker like RabbitMQ or Redis.
               
     param running:
             A list of 3-element tuples. The first element of each tuple should be

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -83,12 +83,10 @@ def callback(
 
     Keyword Arguments
     -----------------
-    
     param background:
             Mark the callback as a long callback to execute in a manager for
             callbacks that take a long time without locking up the Dash app
-            or timing out.
-            
+            or timing out. \n
     param manager:
             A long callback manager instance. Currently, an instance of one of
             `DiskcacheManager` or `CeleryManager`.
@@ -100,22 +98,19 @@ def callback(
           development.
         - A Celery manager (`CeleryManager`) that runs callback logic
           in a celery worker and returns results to the Dash app through a Celery
-          broker like RabbitMQ or Redis.
-              
+          broker like RabbitMQ or Redis. \n
     param running:
             A list of 3-element tuples. The first element of each tuple should be
             an `Output` dependency object referencing a property of a component in
             the app layout. The second element is the value that the property
             should be set to while the callback is running, and the third element
-            is the value the property should be set to when the callback completes.
-            
+            is the value the property should be set to when the callback completes. \n
     param cancel:
             A list of `Input` dependency objects that reference a property of a
             component in the app's layout.  When the value of this property changes
             while a callback is running, the callback is canceled.
             Note that the value of the property is not significant, any change in
-            value will result in the cancellation of the running job (if any).
-            
+            value will result in the cancellation of the running job (if any). \n
     param progress:
             An `Output` dependency grouping that references properties of
             components in the app's layout. When provided, the decorated function
@@ -124,23 +119,20 @@ def callback(
             function should call in order to provide updates to the app on its
             current progress. This function accepts a single argument, which
             correspond to the grouping of properties specified in the provided
-            `Output` dependency grouping
-            
+            `Output` dependency grouping \n
     param progress_default:
             A grouping of values that should be assigned to the components
             specified by the `progress` argument when the callback is not in
             progress. If `progress_default` is not provided, all the dependency
             properties specified in `progress` will be set to `None` when the
-            callback is not running.
-            
+            callback is not running. \n
     param cache_args_to_ignore:
             Arguments to ignore when caching is enabled. If callback is configured
             with keyword arguments (Input/State provided in a dict),
             this should be a list of argument names as strings. Otherwise,
-            this should be a list of argument indices as integers.
-            
+            this should be a list of argument indices as integers. \n
     param interval:
-            Time to wait between the long callback update requests.
+            Time to wait between the long callback update requests. \n
     """
 
     long_spec = None


### PR DESCRIPTION
It seems like some reStructuredText elements don't render well in vscodes docstring preview window #2670. I replaced feature lists with elements that were supported according to this example in [pandas contributing guidelines](https://pandas.pydata.org/docs/development/contributing_docstring.html). In terms of content, nothing is added or changed, just formatted it differently. 

- [X] I have broken down my PR scope into the following TODO tasks
   -  [X] Set up local repo according to contributing guidelines. 
   -  [X] Figure out why the doc string was not formatting properly.
   -  [X] Replace problematic reStructure elements with more agreeable elements.
   -  [X] Conform additions to code style, eliminating linter errors.  