### PR TITLE
Sanitize html props with xss vulnerability.

### DIFF
--- a/components/dash-core-components/package-lock.json
+++ b/components/dash-core-components/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.12.1",
       "license": "MIT",
       "dependencies": {
+        "@braintree/sanitize-url": "^7.0.0",
         "@fortawesome/fontawesome-svg-core": "1.2.36",
         "@fortawesome/free-regular-svg-icons": "^5.15.4",
         "@fortawesome/free-solid-svg-icons": "^5.15.4",
@@ -1842,6 +1843,11 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.0.tgz",
+      "integrity": "sha512-GMu2OJiTd1HSe74bbJYQnVvELANpYiGFZELyyTM1CR0sdv5ReQAcJ/c/8pIrPab3lO11+D+EpuGLUxqz+y832g=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -10698,6 +10704,11 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="
+    },
+    "@braintree/sanitize-url": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.0.tgz",
+      "integrity": "sha512-GMu2OJiTd1HSe74bbJYQnVvELANpYiGFZELyyTM1CR0sdv5ReQAcJ/c/8pIrPab3lO11+D+EpuGLUxqz+y832g=="
     },
     "@colors/colors": {
       "version": "1.5.0",

--- a/components/dash-core-components/package.json
+++ b/components/dash-core-components/package.json
@@ -35,6 +35,7 @@
   "maintainer": "Alex Johnson <alex@plotly.com>",
   "license": "MIT",
   "dependencies": {
+    "@braintree/sanitize-url": "^7.0.0",
     "@fortawesome/fontawesome-svg-core": "1.2.36",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
     "@fortawesome/free-solid-svg-icons": "^5.15.4",

--- a/components/dash-core-components/src/components/Link.react.js
+++ b/components/dash-core-components/src/components/Link.react.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
-import React, {Component} from 'react';
-
+import React, {useEffect, useMemo} from 'react';
+import {sanitizeUrl} from '@braintree/sanitize-url';
 import {isNil} from 'ramda';
 
 /*
@@ -33,15 +33,23 @@ CustomEvent.prototype = window.Event.prototype;
  * For links with destinations outside the current app, `html.A` is a better
  * component to use.
  */
-export default class Link extends Component {
-    constructor(props) {
-        super(props);
-        this.updateLocation = this.updateLocation.bind(this);
-    }
+const Link = props => {
+    const {
+        className,
+        style,
+        id,
+        href,
+        loading_state,
+        children,
+        title,
+        target,
+        refresh,
+        setProps,
+    } = props;
+    const sanitizedUrl = useMemo(() => sanitizeUrl(href), [href]);
 
-    updateLocation(e) {
+    const updateLocation = e => {
         const hasModifiers = e.metaKey || e.shiftKey || e.altKey || e.ctrlKey;
-        const {href, refresh, target} = this.props;
 
         if (hasModifiers) {
             return;
@@ -52,49 +60,45 @@ export default class Link extends Component {
         // prevent anchor from updating location
         e.preventDefault();
         if (refresh) {
-            window.location = href;
+            window.location = sanitizedUrl;
         } else {
-            window.history.pushState({}, '', href);
+            window.history.pushState({}, '', sanitizedUrl);
             window.dispatchEvent(new CustomEvent('_dashprivate_pushstate'));
         }
         // scroll back to top
         window.scrollTo(0, 0);
-    }
+    };
 
-    render() {
-        const {
-            className,
-            style,
-            id,
-            href,
-            loading_state,
-            children,
-            title,
-            target,
-        } = this.props;
-        /*
-         * ideally, we would use cloneElement however
-         * that doesn't work with dash's recursive
-         * renderTree implementation for some reason
-         */
-        return (
-            <a
-                data-dash-is-loading={
-                    (loading_state && loading_state.is_loading) || undefined
-                }
-                id={id}
-                className={className}
-                style={style}
-                href={href}
-                onClick={e => this.updateLocation(e)}
-                title={title}
-                target={target}
-            >
-                {isNil(children) ? href : children}
-            </a>
-        );
-    }
-}
+    useEffect(() => {
+        if (sanitizedUrl !== href) {
+            setProps({
+                _dash_error: new Error(`Dangerous link detected:: ${href}`),
+            });
+        }
+    }, [href, sanitizedUrl]);
+
+    /*
+     * ideally, we would use cloneElement however
+     * that doesn't work with dash's recursive
+     * renderTree implementation for some reason
+     */
+    return (
+        <a
+            data-dash-is-loading={
+                (loading_state && loading_state.is_loading) || undefined
+            }
+            id={id}
+            className={className}
+            style={style}
+            href={sanitizedUrl}
+            onClick={updateLocation}
+            title={title}
+            target={target}
+        >
+            {isNil(children) ? sanitizedUrl : children}
+        </a>
+    );
+};
 
 Link.propTypes = {
     /**
@@ -151,8 +155,10 @@ Link.propTypes = {
          */
         component_name: PropTypes.string,
     }),
+    setProps: PropTypes.func,
 };
 
 Link.defaultProps = {
     refresh: false,
 };
+export default Link;

--- a/components/dash-html-components/package-lock.json
+++ b/components/dash-html-components/package-lock.json
@@ -9,10 +9,11 @@
       "version": "2.0.15",
       "license": "MIT",
       "dependencies": {
+        "@braintree/sanitize-url": "^7.0.0",
         "prop-types": "^15.8.1",
         "ramda": "^0.29.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": ">=17",
+        "react-dom": ">=17"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.0",
@@ -1835,6 +1836,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.0.tgz",
+      "integrity": "sha512-GMu2OJiTd1HSe74bbJYQnVvELANpYiGFZELyyTM1CR0sdv5ReQAcJ/c/8pIrPab3lO11+D+EpuGLUxqz+y832g=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -8919,6 +8925,11 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@braintree/sanitize-url": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.0.tgz",
+      "integrity": "sha512-GMu2OJiTd1HSe74bbJYQnVvELANpYiGFZELyyTM1CR0sdv5ReQAcJ/c/8pIrPab3lO11+D+EpuGLUxqz+y832g=="
     },
     "@colors/colors": {
       "version": "1.5.0",

--- a/components/dash-html-components/package.json
+++ b/components/dash-html-components/package.json
@@ -28,10 +28,11 @@
   "author": "Chris Parmer <chris@plotly.com>",
   "maintainer": "Alex Johnson <alex@plotly.com>",
   "dependencies": {
+    "@braintree/sanitize-url": "^7.0.0",
     "prop-types": "^15.8.1",
     "ramda": "^0.29.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": ">=17",
+    "react-dom": ">=17"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.0",

--- a/dash/dash-renderer/src/TreeContainer.js
+++ b/dash/dash-renderer/src/TreeContainer.js
@@ -23,7 +23,7 @@ import {
     pathOr,
     type
 } from 'ramda';
-import {notifyObservers, updateProps} from './actions';
+import {notifyObservers, updateProps, onError} from './actions';
 import isSimpleComponent from './isSimpleComponent';
 import {recordUiEdit} from './persistence';
 import ComponentErrorBoundary from './components/error/ComponentErrorBoundary.react';
@@ -138,8 +138,17 @@ class BaseTreeContainer extends Component {
         const {id} = oldProps;
         const changedProps = pickBy(
             (val, key) => !equals(val, oldProps[key]),
-            newProps
+            dissoc('_dash_error', newProps)
         );
+
+        if (newProps._dash_error) {
+            _dashprivate_dispatch(
+                onError({
+                    type: 'frontEnd',
+                    error: newProps._dash_error
+                })
+            );
+        }
 
         if (!isEmpty(changedProps)) {
             _dashprivate_dispatch((dispatch, getState) => {

--- a/tests/integration/security/test_xss.py
+++ b/tests/integration/security/test_xss.py
@@ -1,0 +1,50 @@
+from dash import Dash, html, dcc
+
+
+def test_xss001_banned_protocols(dash_duo):
+    app = Dash()
+
+    app.layout = html.Div(
+        [
+            dcc.Link("dcc-link", href="javascript:alert(1)", id="dcc-link"),
+            html.Br(),
+            html.A(
+                "html.A", href='javascr\nipt:alert(1);console.log("xss");', id="html-A"
+            ),
+            html.Br(),
+            html.Form(
+                [
+                    html.Button(
+                        "form-action",
+                        formAction="javascript:alert('form-action')",
+                        id="button-form-action",
+                    ),
+                    html.Button("submit", role="submit"),
+                ],
+                action='javascript:alert(1);console.log("xss");',
+                id="form",
+            ),
+            html.Iframe(src='javascript:alert("iframe")', id="iframe-src"),
+            html.ObjectEl(data='javascript:alert("data-object")', id="object-data"),
+            html.Embed(src='javascript:alert("embed")', id="embed-src"),
+            # older browser
+            html.Img(src="javascript:alert('img-sr')", id="img-src"),
+        ]
+    )
+
+    dash_duo.start_server(app)
+
+    for element_id, prop in (
+        ("#dcc-link", "href"),
+        ("#html-A", "href"),
+        ("#iframe-src", "src"),
+        ("#object-data", "data"),
+        ("#embed-src", "src"),
+        ("#button-form-action", "formAction"),
+        ("#img-src", "src"),
+    ):
+
+        element = dash_duo.find_element(element_id)
+        assert (
+            element.get_attribute(prop) == "about:blank"
+        ), f"Failed prop: {element_id}.{prop}"


### PR DESCRIPTION
- Sanitize html props that are vulnerable to xss vulnerability if user data is inserted. Fix #2729 
  - `dcc.Link.href`
  - `html.A.href`
  - `html.Iframe.src`
  - `html.ObjectEl.data`
  - `html.Embed.src`
  - `html.Button.formAction`
  - `html.Form.action`
- Add special key `_dash_error` to setProps, allowing component developers to send error without throwing in render. Usage `props.setProps({_dash_error: new Error("custom error")})`