### PR TITLE
remove misleading py3.9 from snapshot names

### DIFF
--- a/dash/testing/browser.py
+++ b/dash/testing/browser.py
@@ -160,10 +160,7 @@ class Browser(DashPageMixin):
         if widths is None:
             widths = [1280]
 
-        # py3.9 hardcoded here to keep snapshot names the same accorss
-        # future python upgrades
-        snapshot_name = f"{name} - py3.9"
-        logger.info("taking snapshot name => %s", snapshot_name)
+        logger.info("taking snapshot name => %s", name)
         try:
             if wait_for_callbacks:
                 # the extra one second sleep adds safe margin in the context
@@ -199,7 +196,7 @@ class Browser(DashPageMixin):
             )
 
         try:
-            self.percy_runner.snapshot(name=snapshot_name, widths=widths)
+            self.percy_runner.snapshot(name=name, widths=widths)
         except requests.HTTPError as err:
             # Ignore retries.
             if err.request.status_code != 400:


### PR DESCRIPTION
## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] remove misleading py3.9 from snapshot names
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
