### PR TITLE
prevent celery tests hanging if celery fails to start

### DIFF
--- a/tests/integration/long_callback/utils.py
+++ b/tests/integration/long_callback/utils.py
@@ -94,14 +94,19 @@ def setup_long_callback_app(manager_name, app_name):
                 "2",
                 "--loglevel=info",
             ],
+            encoding="utf8",
             preexec_fn=os.setpgrp,
             stderr=subprocess.PIPE,
         )
         # Wait for the worker to be ready, if you cancel before it is ready, the job
         # will still be queued.
+        lines = []
         for line in iter(worker.stderr.readline, ""):
-            if "ready" in line.decode():
+            if "ready" in line:
                 break
+            lines.append(line)
+        else:
+            raise RuntimeError(f"celery failed to start: {'\n'.join(lines)}")
 
         try:
             yield import_app(f"tests.integration.long_callback.{app_name}")

--- a/tests/integration/long_callback/utils.py
+++ b/tests/integration/long_callback/utils.py
@@ -106,7 +106,7 @@ def setup_long_callback_app(manager_name, app_name):
                 break
             lines.append(line)
         else:
-            raise RuntimeError(f"celery failed to start: {'\n'.join(lines)}")
+            raise RuntimeError("celery failed to start: " + {"\n".join(lines)})
 
         try:
             yield import_app(f"tests.integration.long_callback.{app_name}")


### PR DESCRIPTION
## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] prevent celery tests hanging if celery fails to start
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
