### PR TITLE
Check href before sanitize url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [UNRELEASED]
 
+## Fixed
+
+- [#2756](https://github.com/plotly/dash/pull/2756) Prevent false dangerous link warning. Fixes [#2743](https://github.com/plotly/dash/issues/2743)
+
 ## Changed
 
 - [#2734](https://github.com/plotly/dash/pull/2734) Configure CI for Python 3.10 [#1863](https://github.com/plotly/dash/issues/1863)

--- a/components/dash-core-components/src/components/Link.react.js
+++ b/components/dash-core-components/src/components/Link.react.js
@@ -46,7 +46,9 @@ const Link = props => {
         refresh,
         setProps,
     } = props;
-    const sanitizedUrl = useMemo(() => sanitizeUrl(href), [href]);
+    const sanitizedUrl = useMemo(() => {
+        return href ? sanitizeUrl(href) : undefined;
+    }, [href]);
 
     const updateLocation = e => {
         const hasModifiers = e.metaKey || e.shiftKey || e.altKey || e.ctrlKey;
@@ -70,7 +72,7 @@ const Link = props => {
     };
 
     useEffect(() => {
-        if (sanitizedUrl !== href) {
+        if (sanitizedUrl && sanitizedUrl !== href) {
             setProps({
                 _dash_error: new Error(`Dangerous link detected:: ${href}`),
             });

--- a/tests/integration/security/test_xss.py
+++ b/tests/integration/security/test_xss.py
@@ -45,3 +45,16 @@ def test_xss001_banned_protocols(dash_duo):
         assert (
             element.get_attribute(prop) == "about:blank"
         ), f"Failed prop: {element_id}.{prop}"
+
+
+def test_xss002_blank_href(dash_duo):
+    app = Dash()
+
+    app.layout = html.Div(dcc.Link("dcc-link", href="", id="dcc-link-no-href"))
+
+    dash_duo.start_server(app)
+
+    element = dash_duo.find_element("#dcc-link-no-href")
+    assert element.get_attribute("href") is None
+
+    assert dash_duo.get_logs() == []


### PR DESCRIPTION
Closes https://github.com/plotly/dash/issues/2743

Check for blank `href` before sanitizing the url to  prevent the dangerous link warnings in `dcc.Link(href="")`
