### PR TITLE
Ignore component files based on their filename or parent directory 

### DIFF
--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -166,7 +166,11 @@ function gatherComponents(sources, components = {}) {
     const filepaths = [];
 
     const gather = filepath => {
-        if (ignorePattern && ignorePattern.test(filepath)) {
+
+        // Ignore file names that match the ignore pattern.
+        const filename = filepath.substring(filepath.lastIndexOf('/') + 1);
+
+        if (ignorePattern && ignorePattern.test(filename)) {
             return;
         }
         const extension = path.extname(filepath);

--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -167,10 +167,11 @@ function gatherComponents(sources, components = {}) {
 
     const gather = filepath => {
 
-        // Ignore file names that match the ignore pattern.
-        const filename = filepath.substring(filepath.lastIndexOf('/') + 1);
+        // Ignore files with names that match the ignore pattern along with
+        // any files in directories with names that match the ignore pattern.
+        const filepathSegments = filepath.split(path.sep);
 
-        if (ignorePattern && ignorePattern.test(filename)) {
+        if (ignorePattern && filepathSegments.some(segment => ignorePattern.test(segment))) {
             return;
         }
         const extension = path.extname(filepath);


### PR DESCRIPTION
This PR updates the ignore pattern check we run as we're gathering component files during `dash-generate-components`. 

As an example, if the filepath is in the following common form, `src/lib/components/_MyComponent.react.js`, the RegEx doesn't find anything matching the default `^_` pattern, or any other pattern that might match the beginning of a file or directory unless it's at the top-level - the directory passed in via `components-source` argument. 

With this change, we would ignore the component file if the filename or any other directories along the path contain the ignore pattern, which I believe fits more in line with the intended function.



### optionals

- [ ] I have added entry in the `CHANGELOG.md`
