### PR TITLE
expose NoUpdate

### DIFF
--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -19,7 +19,8 @@ from . import html  # noqa: F401,E402
 from . import dash_table  # noqa: F401,E402
 from .version import __version__  # noqa: F401,E402
 from ._callback_context import callback_context  # noqa: F401,E402
-from ._callback import callback, clientside_callback, NoUpdate  # noqa: F401,E402
+from ._callback import callback, clientside_callback  # noqa: F401,E402
+from ._callback import NoUpdate as NoUpdateType  # noqa: F401,E402
 from ._get_app import get_app  # noqa: F401,E402
 from ._get_paths import (  # noqa: F401,E402
     get_asset_url,

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -19,8 +19,7 @@ from . import html  # noqa: F401,E402
 from . import dash_table  # noqa: F401,E402
 from .version import __version__  # noqa: F401,E402
 from ._callback_context import callback_context  # noqa: F401,E402
-from ._callback import callback, clientside_callback  # noqa: F401,E402
-from ._callback import NoUpdate as NoUpdateType  # noqa: F401,E402
+from ._callback import callback, clientside_callback, NoUpdateType  # noqa: F401,E402
 from ._get_app import get_app  # noqa: F401,E402
 from ._get_paths import (  # noqa: F401,E402
     get_asset_url,

--- a/dash/__init__.py
+++ b/dash/__init__.py
@@ -19,7 +19,7 @@ from . import html  # noqa: F401,E402
 from . import dash_table  # noqa: F401,E402
 from .version import __version__  # noqa: F401,E402
 from ._callback_context import callback_context  # noqa: F401,E402
-from ._callback import callback, clientside_callback  # noqa: F401,E402
+from ._callback import callback, clientside_callback, NoUpdate  # noqa: F401,E402
 from ._get_app import get_app  # noqa: F401,E402
 from ._get_paths import (  # noqa: F401,E402
     get_asset_url,

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -39,13 +39,13 @@ def _invoke_callback(func, *args, **kwargs):  # used to mark the frame for the d
     return func(*args, **kwargs)  # %% callback invoked %%
 
 
-class NoUpdate:
+class NoUpdateType:
     def to_plotly_json(self):  # pylint: disable=no-self-use
         return {"_dash_no_update": "_dash_no_update"}
 
     @staticmethod
     def is_no_update(obj):
-        return isinstance(obj, NoUpdate) or (
+        return isinstance(obj, NoUpdateType) or (
             isinstance(obj, dict) and obj == {"_dash_no_update": "_dash_no_update"}
         )
 
@@ -423,7 +423,7 @@ def register_callback(  # pylint: disable=R0914
                 job_running = callback_manager.job_running(job_id)
                 if not job_running and output_value is callback_manager.UNDEFINED:
                     # Job canceled -> no output to close the loop.
-                    output_value = NoUpdate()
+                    output_value = NoUpdateType()
 
                 elif (
                     isinstance(output_value, dict)
@@ -440,7 +440,7 @@ def register_callback(  # pylint: disable=R0914
 
                 if multi and isinstance(output_value, (list, tuple)):
                     output_value = [
-                        NoUpdate() if NoUpdate.is_no_update(r) else r
+                        NoUpdateType() if NoUpdateType.is_no_update(r) else r
                         for r in output_value
                     ]
 
@@ -449,7 +449,7 @@ def register_callback(  # pylint: disable=R0914
             else:
                 output_value = _invoke_callback(func, *func_args, **func_kwargs)
 
-            if NoUpdate.is_no_update(output_value):
+            if NoUpdateType.is_no_update(output_value):
                 raise PreventUpdate
 
             if not multi:
@@ -471,12 +471,12 @@ def register_callback(  # pylint: disable=R0914
             component_ids = collections.defaultdict(dict)
             has_update = False
             for val, spec in zip(flat_output_values, output_spec):
-                if isinstance(val, NoUpdate):
+                if isinstance(val, NoUpdateType):
                     continue
                 for vali, speci in (
                     zip(val, spec) if isinstance(spec, list) else [[val, spec]]
                 ):
-                    if not isinstance(vali, NoUpdate):
+                    if not isinstance(vali, NoUpdateType):
                         has_update = True
                         id_str = stringify_id(speci["id"])
                         prop = clean_property_name(speci["property"])

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -187,7 +187,7 @@ def _get_traceback(secret, error: Exception):
 
 
 # Singleton signal to not update an output, alternative to PreventUpdate
-no_update = _callback.NoUpdate()  # pylint: disable=protected-access
+no_update = _callback.NoUpdateType()  # pylint: disable=protected-access
 
 
 # pylint: disable=too-many-instance-attributes

--- a/dash/long_callback/managers/celery_manager.py
+++ b/dash/long_callback/managers/celery_manager.py
@@ -152,7 +152,7 @@ def _make_job_fn(fn, celery_app, progress, key):
                 else:
                     user_callback_output = fn(*maybe_progress, user_callback_args)
             except PreventUpdate:
-                # Put NoUpdate dict directly to avoid circular imports.
+                # Put NoUpdateType dict directly to avoid circular imports.
                 cache.set(
                     result_key,
                     json.dumps(


### PR DESCRIPTION
Expose `NoUpdate` at top-level dash.

The primary application is for type hinting, allowing for comprehensive type checking of dash callbacks.

See: #2799

## Contributor Checklist

- [X] Expose `NoUpdate` from `dash._callback`
- [X] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [X] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR