### PR TITLE
Fix Dropdown Option Removal Regression

### DIFF
--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -42,12 +42,12 @@ const Dropdown = props => {
         multi,
         options,
         setProps,
+        search_value,
         style,
         loading_state,
         value,
     } = props;
     const [optionsCheck, setOptionsCheck] = useState(null);
-    const [searchValue, setSearchValue] = useState(null);
     const persistentOptions = useRef(null);
 
     if (!persistentOptions || !isEqual(options, persistentOptions.current)) {
@@ -115,14 +115,14 @@ const Dropdown = props => {
         [multi]
     );
 
-    const onInputChange = useCallback(search_value => {
-        setProps({search_value});
-        setSearchValue(search_value);
-    }, []);
+    const onInputChange = useCallback(
+        search_value => setProps({search_value}),
+        []
+    );
 
     useEffect(() => {
         if (
-            !searchValue &&
+            !search_value &&
             !isNil(sanitizedOptions) &&
             optionsCheck !== sanitizedOptions &&
             !isNil(value)

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -39,7 +39,6 @@ const Dropdown = props => {
     const {
         id,
         clearable,
-        searchable,
         multi,
         options,
         setProps,
@@ -48,6 +47,7 @@ const Dropdown = props => {
         value,
     } = props;
     const [optionsCheck, setOptionsCheck] = useState(null);
+    const [searchValue, setSearchValue] = useState(null);
     const persistentOptions = useRef(null);
 
     if (!persistentOptions || !isEqual(options, persistentOptions.current)) {
@@ -115,14 +115,14 @@ const Dropdown = props => {
         [multi]
     );
 
-    const onInputChange = useCallback(
-        search_value => setProps({search_value}),
-        []
-    );
+    const onInputChange = useCallback(search_value => {
+        setProps({search_value});
+        setSearchValue(search_value);
+    }, []);
 
     useEffect(() => {
         if (
-            !searchable &&
+            !searchValue &&
             !isNil(sanitizedOptions) &&
             optionsCheck !== sanitizedOptions &&
             !isNil(value)

--- a/components/dash-core-components/tests/integration/dropdown/test_remove_option.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_remove_option.py
@@ -1,5 +1,7 @@
 import json
 
+import pytest
+
 from dash import Dash, html, dcc, Output, Input
 from dash.exceptions import PreventUpdate
 
@@ -11,7 +13,8 @@ sample_dropdown_options = [
 ]
 
 
-def test_ddro001_remove_option_single(dash_dcc):
+@pytest.mark.parametrize("searchable", (True, False))
+def test_ddro001_remove_option_single(dash_dcc, searchable):
     dropdown_options = sample_dropdown_options
 
     app = Dash(__name__)
@@ -22,7 +25,7 @@ def test_ddro001_remove_option_single(dash_dcc):
             dcc.Dropdown(
                 options=dropdown_options,
                 value=value,
-                searchable=False,
+                searchable=searchable,
                 id="dropdown",
             ),
             html.Button("Remove option", id="remove"),
@@ -49,7 +52,8 @@ def test_ddro001_remove_option_single(dash_dcc):
     dash_dcc.wait_for_text_to_equal("#value-output", "None")
 
 
-def test_ddro002_remove_option_multi(dash_dcc):
+@pytest.mark.parametrize("searchable", (True, False))
+def test_ddro002_remove_option_multi(dash_dcc, searchable):
     dropdown_options = sample_dropdown_options
 
     app = Dash(__name__)
@@ -62,7 +66,7 @@ def test_ddro002_remove_option_multi(dash_dcc):
                 value=value,
                 multi=True,
                 id="dropdown",
-                searchable=False,
+                searchable=searchable,
             ),
             html.Button("Remove option", id="remove"),
             html.Div(id="value-output"),

--- a/components/dash-core-components/tests/integration/dropdown/test_remove_option.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_remove_option.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 
-from dash import Dash, html, dcc, Output, Input
+from dash import Dash, html, dcc, Output, Input, State
 from dash.exceptions import PreventUpdate
 
 
@@ -88,3 +88,64 @@ def test_ddro002_remove_option_multi(dash_dcc, searchable):
     btn.click()
 
     dash_dcc.wait_for_text_to_equal("#value-output", '["MTL"]')
+
+
+def test_ddro003_remove_option_multiple_dropdowns(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(
+                id="available-options",
+                multi=True,
+                options=sample_dropdown_options,
+                value=["MTL", "NYC", "SF"],
+            ),
+            dcc.Dropdown(
+                id="chosen",
+                multi=True,
+                options=sample_dropdown_options,
+                value=["NYC", "SF"],
+            ),
+            html.Button(id="remove-btn", children="Remove"),
+            html.Button(id="submit-btn", children="Submit"),
+            html.Div(id="value-output"),
+            html.Div(id="options-output"),
+        ],
+    )
+
+    @app.callback(
+        Output("chosen", "options"),
+        Input("available-options", "value"),
+    )
+    def update_options(available_options):
+        if available_options is None:
+            return []
+        else:
+            return [{"label": i, "value": i} for i in available_options]
+
+    @app.callback(
+        Output("available-options", "options"), [Input("remove-btn", "n_clicks")]
+    )
+    def on_click(n_clicks):
+        if not n_clicks:
+            raise PreventUpdate
+        return sample_dropdown_options[:-1]
+
+    @app.callback(
+        [Output("value-output", "children"), Output("options-output", "children")],
+        Input("submit-btn", "n_clicks"),
+        State("chosen", "options"),
+        State("chosen", "value"),
+    )
+    def print_value(n_clicks, options, value):
+        if not n_clicks:
+            raise PreventUpdate
+        return [json.dumps(value), json.dumps([i["value"] for i in options])]
+
+    dash_dcc.start_server(app)
+    btn = dash_dcc.wait_for_element("#remove-btn")
+    btn.click()
+    btn = dash_dcc.wait_for_element("#submit-btn")
+    btn.click()
+    dash_dcc.wait_for_text_to_equal("#value-output", '["NYC"]')
+    dash_dcc.wait_for_text_to_equal("#options-output", '["MTL", "NYC"]')

--- a/components/dash-core-components/tests/integration/dropdown/test_remove_option.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_remove_option.py
@@ -41,15 +41,13 @@ def test_ddro001_remove_option_single(dash_dcc, searchable):
 
     @app.callback(Output("value-output", "children"), [Input("dropdown", "value")])
     def on_change(val):
-        if not val:
-            raise PreventUpdate
-        return val or "None"
+        return val or "Nothing Here"
 
     dash_dcc.start_server(app)
     btn = dash_dcc.wait_for_element("#remove")
     btn.click()
 
-    dash_dcc.wait_for_text_to_equal("#value-output", "None")
+    dash_dcc.wait_for_text_to_equal("#value-output", "Nothing Here")
 
 
 @pytest.mark.parametrize("searchable", (True, False))


### PR DESCRIPTION
Fixes #2733.

The tests for the option removal only included non-searchable dropdowns.

The problem was that the guard clause would always be false for searchable dropdowns and the props on the component were never updated, even though the React component was showing the expected behavior. Removing the `!searchable` reintroduced another issue (#2099), so there needed to be a way to know if there was a current search happening or if the options had actually been changed.

Instead of using `searchable`, create a state that is changed when the input is changed, indicating a search is being done. If there is a current search, don't update the options (and hence, don't render changes), else update the options.


## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Set a state variable for the `search_value`.
   -  [x] Use the state to check if it's an actual option change or just a search.
   -  [x] Parameterize the dropdown tests to make searchable `True` and `False`.
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
