### PR TITLE
Fix to hashing compatability issues [2697] with some environments (FIPS)

### DIFF
--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -535,7 +535,7 @@ def register_clientside_callback(
     if isinstance(clientside_function, str):
         namespace = "_dashprivate_clientside_funcs"
         # Create a hash from the function, it will be the same always
-        function_name = hashlib.md5(clientside_function.encode("utf-8")).hexdigest()
+        function_name = hashlib.sha256(clientside_function.encode("utf-8")).hexdigest()
 
         inline_scripts.append(
             _inline_clientside_template.format(

--- a/dash/_utils.py
+++ b/dash/_utils.py
@@ -142,7 +142,7 @@ def create_callback_id(output, inputs):
         _id = x.component_id_str().replace(".", "\\.") + "." + x.component_property
         if x.allow_duplicate:
             if not hashed_inputs:
-                hashed_inputs = hashlib.md5(
+                hashed_inputs = hashlib.sha256(
                     ".".join(str(x) for x in inputs).encode("utf-8")
                 ).hexdigest()
             # Actually adds on the property part.
@@ -213,9 +213,9 @@ def run_command_with_process(cmd):
                 proc.communicate()
 
 
-def compute_md5(path):
+def compute_hash(path):
     with io.open(path, encoding="utf-8") as fp:
-        return hashlib.md5(fp.read().encode("utf-8")).hexdigest()
+        return hashlib.sha256(fp.read().encode("utf-8")).hexdigest()
 
 
 def job(msg=""):

--- a/dash/development/_jl_components_generation.py
+++ b/dash/development/_jl_components_generation.py
@@ -416,7 +416,7 @@ def generate_toml_file(project_shortname, pkg_data):
     u = uuid.UUID(jl_dash_uuid)
 
     package_uuid = uuid.UUID(
-        hex=u.hex[:-12] + hashlib.md5(package_name.encode("utf-8")).hexdigest()[-12:]
+        hex=u.hex[:-12] + hashlib.sha256(package_name.encode("utf-8")).hexdigest()[-12:]
     )
 
     authors_string = (

--- a/dash/development/build_process.py
+++ b/dash/development/build_process.py
@@ -97,8 +97,7 @@ class BuildProcess:
             logger.info("bundles in %s %s", folder, copies)
 
             for copy in copies:
-                # note md5 has been replaced with sha256, leaving string 'MD5 (hash)' as is because impacts are unclear
-                payload[f"MD5 ({copy})"] = compute_hash(self._concat(folder, copy)) 
+                payload[f"SHA256 ({copy})"] = compute_hash(self._concat(folder, copy)) 
 
         with open(self._concat(self.main, "digest.json"), "w", encoding="utf-8") as fp:
             json.dump(payload, fp, sort_keys=True, indent=4, separators=(",", ":"))

--- a/dash/development/build_process.py
+++ b/dash/development/build_process.py
@@ -8,7 +8,7 @@ import coloredlogs
 import fire
 import requests
 
-from .._utils import run_command_with_process, compute_md5, job
+from .._utils import run_command_with_process, compute_hash, job
 
 logger = logging.getLogger(__name__)
 coloredlogs.install(
@@ -97,7 +97,8 @@ class BuildProcess:
             logger.info("bundles in %s %s", folder, copies)
 
             for copy in copies:
-                payload[f"MD5 ({copy})"] = compute_md5(self._concat(folder, copy))
+                # note md5 has been replaced with sha256, leaving string 'MD5 (hash)' as is because impacts are unclear
+                payload[f"MD5 ({copy})"] = compute_hash(self._concat(folder, copy)) 
 
         with open(self._concat(self.main, "digest.json"), "w", encoding="utf-8") as fp:
             json.dump(payload, fp, sort_keys=True, indent=4, separators=(",", ":"))

--- a/dash/development/build_process.py
+++ b/dash/development/build_process.py
@@ -97,7 +97,7 @@ class BuildProcess:
             logger.info("bundles in %s %s", folder, copies)
 
             for copy in copies:
-                payload[f"SHA256 ({copy})"] = compute_hash(self._concat(folder, copy)) 
+                payload[f"SHA256 ({copy})"] = compute_hash(self._concat(folder, copy))
 
         with open(self._concat(self.main, "digest.json"), "w", encoding="utf-8") as fp:
             json.dump(payload, fp, sort_keys=True, indent=4, separators=(",", ":"))

--- a/dash/long_callback/managers/__init__.py
+++ b/dash/long_callback/managers/__init__.py
@@ -73,7 +73,7 @@ class BaseLongCallbackManager(ABC):
                 # Call cache function
                 hash_dict[f"cache_key_{i}"] = cache_item()
 
-        return hashlib.sha1(str(hash_dict).encode("utf-8")).hexdigest()
+        return hashlib.sha256(str(hash_dict).encode("utf-8")).hexdigest()
 
     def register(self, key, fn, progress):
         self.func_registry[key] = self.make_job_fn(fn, progress, key)
@@ -102,6 +102,6 @@ class BaseLongCallbackManager(ABC):
     def hash_function(fn, callback_id=""):
         fn_source = inspect.getsource(fn)
         fn_str = fn_source
-        return hashlib.sha1(
+        return hashlib.sha256(
             callback_id.encode("utf-8") + fn_str.encode("utf-8")
         ).hexdigest()


### PR DESCRIPTION
This PR resolves [2697](https://github.com/plotly/dash/issues/2697), and is mostly a find and replace of hashlib.md5 and hashlib.sha1 with hashlib.sha256.  I did not replace one instance of sha1 in testing.  sha256 is slightly slower than md5, but testing did not show a measurable change in performance for creating callback ids.  Further, though they are generally extremely unlikely, sha256 has a reduced risk of collisions. 

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] swapped hashing algorithms md5 and sha1 to sha256
- [x] I have run the tests locally and one test did indeed fail (test_inin027_multi_page_without_pages_folder). Apparently this is not an issue as the tests ran fine for others locally and in the CI. 
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
   -  [x] tested performance of create_callback_id for md5, sha256, blake2b, and sha512.  There was no measurable impact to performance, even when creating ids for thousands of components, despite md5 being known to be somewhat faster. This means hashing ids is a negligible portion of the total runtime associated with creating callbacks. 
   -  [x] tested that switching to sha256 solves the compatibility issue in my deployment environment, by simply overloading the method in the current dash release.  
   -  Both additional tests exist here: [dash_md5_patch_testing](https://github.com/caplinje-NOAA/dash_md5_patch_testing)
   

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
