### PR TITLE
Add dash subcomponents receive additional parameters passed by the pa…

### DIFF
--- a/@plotly/dash-test-components/src/components/AddPropsComponent.js
+++ b/@plotly/dash-test-components/src/components/AddPropsComponent.js
@@ -1,0 +1,23 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const AddPropsComponent = (props) => {
+    const {children, id} = props;
+
+
+    return (
+        <div id={id}>
+            {React.cloneElement(children, {
+                receive: `Element #${id} pass`,
+                id: id,
+            })}
+        </div>
+    );
+};
+
+AddPropsComponent.propTypes = {
+    id: PropTypes.string,
+    children: PropTypes.node,
+};
+
+export default AddPropsComponent;

--- a/@plotly/dash-test-components/src/components/ReceivePropsComponent.js
+++ b/@plotly/dash-test-components/src/components/ReceivePropsComponent.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ReceivePropsComponent = (props) => {
+    const {id, text, receive} = props;
+
+    return (
+        <div id={id}>
+            {receive || text}
+        </div>
+    );
+}
+ReceivePropsComponent.propTypes = {
+    id: PropTypes.string,
+    text: PropTypes.string,
+    receive: PropTypes.string,
+}
+
+export default ReceivePropsComponent;

--- a/@plotly/dash-test-components/src/index.js
+++ b/@plotly/dash-test-components/src/index.js
@@ -7,6 +7,8 @@ import MyPersistedComponentNested from './components/MyPersistedComponentNested'
 import StyledComponent from './components/StyledComponent';
 import WidthComponent from './components/WidthComponent';
 import ComponentAsProp from './components/ComponentAsProp';
+import AddPropsComponent from "./components/AddPropsComponent";
+import ReceivePropsComponent from "./components/ReceivePropsComponent";
 
 export {
     AsyncComponent,
@@ -18,4 +20,6 @@ export {
     StyledComponent,
     WidthComponent,
     ComponentAsProp,
+    AddPropsComponent,
+    ReceivePropsComponent
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Added
 
+- [#2819](https://github.com/plotly/dash/pull/2819) Add dash subcomponents receive additional parameters passed by the parent component. Fixes [#2814](https://github.com/plotly/dash/issues/2814).
 - [#2826](https://github.com/plotly/dash/pull/2826) When using Pages, allows for `app.title` and (new) `app.description` to be used as defaults for the page title and description. Fixes [#2811](https://github.com/plotly/dash/issues/2811).
 - [#2795](https://github.com/plotly/dash/pull/2795) Allow list of components to be passed as layout.
 - [#2760](https://github.com/plotly/dash/pull/2760) New additions to dcc.Loading resolving multiple issues:

--- a/dash/dash-renderer/src/TreeContainer.js
+++ b/dash/dash-renderer/src/TreeContainer.js
@@ -237,7 +237,7 @@ class BaseTreeContainer extends Component {
         );
     }
 
-    getComponent(_dashprivate_layout, children, loading_state, setProps) {
+    getComponent(_dashprivate_layout, children, loading_state, setProps, _dashextra_controlProps) {
         const {_dashprivate_config, _dashprivate_dispatch, _dashprivate_error} =
             this.props;
 
@@ -262,7 +262,7 @@ class BaseTreeContainer extends Component {
             ],
             _dashprivate_config
         );
-        let props = dissoc('children', _dashprivate_layout.props);
+        let props = mergeRight(_dashextra_controlProps, dissoc('children', _dashprivate_layout.props));
 
         for (let i = 0; i < childrenProps.length; i++) {
             const childrenProp = childrenProps[i];
@@ -476,9 +476,16 @@ class BaseTreeContainer extends Component {
 
     render() {
         const {
+            _dashprivate_error,
             _dashprivate_layout,
             _dashprivate_loadingState,
-            _dashprivate_path
+            _dashprivate_loadingStateHash,
+            _dashprivate_path,
+            _dashprivate_config,
+            _dashprivate_dispatch,
+            _dashprivate_graphs,
+            _dashprivate_loadingMap,
+            ..._dashextra_controlProps
         } = this.props;
 
         const layoutProps = this.getLayoutProps();
@@ -492,7 +499,8 @@ class BaseTreeContainer extends Component {
             _dashprivate_layout,
             children,
             _dashprivate_loadingState,
-            this.setProps
+            this.setProps,
+            _dashextra_controlProps
         );
     }
 }

--- a/dash/dash-renderer/src/TreeContainer.js
+++ b/dash/dash-renderer/src/TreeContainer.js
@@ -16,6 +16,7 @@ import {
     map,
     mapObjIndexed,
     mergeRight,
+    omit,
     pick,
     pickBy,
     propOr,
@@ -237,7 +238,7 @@ class BaseTreeContainer extends Component {
         );
     }
 
-    getComponent(_dashprivate_layout, children, loading_state, setProps, _dashextra_controlProps) {
+    getComponent(_dashprivate_layout, children, loading_state, setProps, _extraProps) {
         const {_dashprivate_config, _dashprivate_dispatch, _dashprivate_error} =
             this.props;
 
@@ -262,7 +263,7 @@ class BaseTreeContainer extends Component {
             ],
             _dashprivate_config
         );
-        let props = mergeRight(_dashextra_controlProps, dissoc('children', _dashprivate_layout.props));
+        let props = mergeRight(_extraProps, dissoc('children', _dashprivate_layout.props));
 
         for (let i = 0; i < childrenProps.length; i++) {
             const childrenProp = childrenProps[i];
@@ -476,17 +477,25 @@ class BaseTreeContainer extends Component {
 
     render() {
         const {
-            _dashprivate_error,
             _dashprivate_layout,
             _dashprivate_loadingState,
-            _dashprivate_loadingStateHash,
-            _dashprivate_path,
-            _dashprivate_config,
-            _dashprivate_dispatch,
-            _dashprivate_graphs,
-            _dashprivate_loadingMap,
-            ..._dashextra_controlProps
+            _dashprivate_path
         } = this.props;
+        
+        const _extraProps = omit(
+            [
+                '_dashprivate_error', 
+                '_dashprivate_layout',
+                '_dashprivate_loadingState',
+                '_dashprivate_loadingStateHash',
+                '_dashprivate_path',
+                '_dashprivate_config',
+                '_dashprivate_dispatch',
+                '_dashprivate_graphs',
+                '_dashprivate_loadingMap'
+            ],
+            this.props
+        );
 
         const layoutProps = this.getLayoutProps();
 
@@ -500,7 +509,7 @@ class BaseTreeContainer extends Component {
             children,
             _dashprivate_loadingState,
             this.setProps,
-            _dashextra_controlProps
+            _extraProps
         );
     }
 }

--- a/dash/dash-renderer/src/TreeContainer.js
+++ b/dash/dash-renderer/src/TreeContainer.js
@@ -238,7 +238,13 @@ class BaseTreeContainer extends Component {
         );
     }
 
-    getComponent(_dashprivate_layout, children, loading_state, setProps, _extraProps) {
+    getComponent(
+        _dashprivate_layout,
+        children,
+        loading_state,
+        setProps,
+        _extraProps
+    ) {
         const {_dashprivate_config, _dashprivate_dispatch, _dashprivate_error} =
             this.props;
 
@@ -263,7 +269,10 @@ class BaseTreeContainer extends Component {
             ],
             _dashprivate_config
         );
-        let props = mergeRight(_extraProps, dissoc('children', _dashprivate_layout.props));
+        let props = mergeRight(
+            _extraProps,
+            dissoc('children', _dashprivate_layout.props)
+        );
 
         for (let i = 0; i < childrenProps.length; i++) {
             const childrenProp = childrenProps[i];
@@ -481,10 +490,10 @@ class BaseTreeContainer extends Component {
             _dashprivate_loadingState,
             _dashprivate_path
         } = this.props;
-        
+
         const _extraProps = omit(
             [
-                '_dashprivate_error', 
+                '_dashprivate_error',
                 '_dashprivate_layout',
                 '_dashprivate_loadingState',
                 '_dashprivate_loadingStateHash',

--- a/tests/integration/renderer/test_add_receive_props.py
+++ b/tests/integration/renderer/test_add_receive_props.py
@@ -9,54 +9,54 @@ def test_rdarp001_add_receive_props(dash_duo):
         [
             AddPropsComponent(
                 ReceivePropsComponent(
-                    id='test-receive1',
-                    text='receive component1',
+                    id="test-receive1",
+                    text="receive component1",
                 ),
-                id='test-add'
+                id="test-add",
             ),
             ReceivePropsComponent(
-                id='test-receive2',
-                text='receive component2',
+                id="test-receive2",
+                text="receive component2",
             ),
             html.Button(
-                'load no pass props',
-                id='load-no-pass-props',
+                "load no pass props",
+                id="load-no-pass-props",
             ),
-            html.Pre('load-no-pass-props-output'),
-            html.Div(id='load-no-pass-props-output'),
+            html.Pre("load-no-pass-props-output"),
+            html.Div(id="load-no-pass-props-output"),
             html.Button(
-                'load pass props',
-                id='load-pass-props',
+                "load pass props",
+                id="load-pass-props",
             ),
-            html.Pre('load-pass-props-output'),
-            html.Div(id='load-pass-props-output')
+            html.Pre("load-pass-props-output"),
+            html.Div(id="load-pass-props-output"),
         ]
     )
 
     @app.callback(
-        Output('load-no-pass-props-output', 'children'),
-        Input('load-no-pass-props', 'n_clicks'),
+        Output("load-no-pass-props-output", "children"),
+        Input("load-no-pass-props", "n_clicks"),
     )
     def load_no_pass_props(n_clicks):
         if n_clicks:
             return ReceivePropsComponent(
-                id='test-receive-no-pass',
-                text='receive component no pass',
+                id="test-receive-no-pass",
+                text="receive component no pass",
             )
         return no_update
 
     @app.callback(
-        Output('load-pass-props-output', 'children'),
-        Input('load-pass-props', 'n_clicks'),
+        Output("load-pass-props-output", "children"),
+        Input("load-pass-props", "n_clicks"),
     )
     def load_pass_props(n_clicks):
         if n_clicks:
             return AddPropsComponent(
                 ReceivePropsComponent(
-                    id='test-receive-pass',
-                    text='receive component pass',
+                    id="test-receive-pass",
+                    text="receive component pass",
                 ),
-                id='test-add-pass'
+                id="test-add-pass",
             )
         return no_update
 
@@ -66,7 +66,9 @@ def test_rdarp001_add_receive_props(dash_duo):
 
     clicker_no_pass = dash_duo.wait_for_element("#load-no-pass-props")
     clicker_no_pass.click()
-    dash_duo.wait_for_text_to_equal("#test-receive-no-pass", "receive component no pass")
+    dash_duo.wait_for_text_to_equal(
+        "#test-receive-no-pass", "receive component no pass"
+    )
     clicker_pass = dash_duo.wait_for_element("#load-pass-props")
     clicker_pass.click()
     dash_duo.wait_for_text_to_equal("#test-receive-pass", "Element #test-add-pass pass")

--- a/tests/integration/renderer/test_add_receive_props.py
+++ b/tests/integration/renderer/test_add_receive_props.py
@@ -1,9 +1,9 @@
-from dash import Dash, html
+from dash import Dash, html, Input, Output, no_update
 
 from dash_test_components import AddPropsComponent, ReceivePropsComponent
 
 
-def test_dvui001_add_receive_props(dash_duo):
+def test_rdarp001_add_receive_props(dash_duo):
     app = Dash(__name__)
     app.layout = html.Div(
         [
@@ -18,14 +18,55 @@ def test_dvui001_add_receive_props(dash_duo):
                 id='test-receive2',
                 text='receive component2',
             ),
+            html.Button(
+                'load no pass props',
+                id='load-no-pass-props',
+            ),
+            html.Pre('load-no-pass-props-output'),
+            html.Div(id='load-no-pass-props-output'),
+            html.Button(
+                'load pass props',
+                id='load-pass-props',
+            ),
+            html.Pre('load-pass-props-output'),
+            html.Div(id='load-pass-props-output')
         ]
     )
 
-    dash_duo.start_server(
-        app,
-        debug=True,
-        use_reloader=False,
-        use_debugger=True,
-        dev_tools_hot_reload=False,
-        dev_tools_props_check=False,
+    @app.callback(
+        Output('load-no-pass-props-output', 'children'),
+        Input('load-no-pass-props', 'n_clicks'),
     )
+    def load_no_pass_props(n_clicks):
+        if n_clicks:
+            return ReceivePropsComponent(
+                id='test-receive-no-pass',
+                text='receive component no pass',
+            )
+        return no_update
+
+    @app.callback(
+        Output('load-pass-props-output', 'children'),
+        Input('load-pass-props', 'n_clicks'),
+    )
+    def load_pass_props(n_clicks):
+        if n_clicks:
+            return AddPropsComponent(
+                ReceivePropsComponent(
+                    id='test-receive-pass',
+                    text='receive component pass',
+                ),
+                id='test-add-pass'
+            )
+        return no_update
+
+    dash_duo.start_server(app)
+    dash_duo.wait_for_text_to_equal("#test-receive1", "Element #test-add pass")
+    dash_duo.wait_for_text_to_equal("#test-receive2", "receive component2")
+
+    clicker_no_pass = dash_duo.wait_for_element("#load-no-pass-props")
+    clicker_no_pass.click()
+    dash_duo.wait_for_text_to_equal("#test-receive-no-pass", "receive component no pass")
+    clicker_pass = dash_duo.wait_for_element("#load-pass-props")
+    clicker_pass.click()
+    dash_duo.wait_for_text_to_equal("#test-receive-pass", "Element #test-add-pass pass")

--- a/tests/integration/renderer/test_add_receive_props.py
+++ b/tests/integration/renderer/test_add_receive_props.py
@@ -1,0 +1,31 @@
+from dash import Dash, html
+
+from dash_test_components import AddPropsComponent, ReceivePropsComponent
+
+
+def test_dvui001_add_receive_props(dash_duo):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            AddPropsComponent(
+                ReceivePropsComponent(
+                    id='test-receive1',
+                    text='receive component1',
+                ),
+                id='test-add'
+            ),
+            ReceivePropsComponent(
+                id='test-receive2',
+                text='receive component2',
+            ),
+        ]
+    )
+
+    dash_duo.start_server(
+        app,
+        debug=True,
+        use_reloader=False,
+        use_debugger=True,
+        dev_tools_hot_reload=False,
+        dev_tools_props_check=False,
+    )


### PR DESCRIPTION
When we develop dash components based on react components in Dash, some react components themselves inject additional parameters into child elements, which are very useful in many scenarios. However, when we develop this react component into a dash component, the dash component will lose this additional injection parameter. I hope to still receive this additional injected parameter in dash. Closes #2814 