### PR TITLE
Fix: `None` in "wait" Methods Causing Incorrectly Passing Tests

### DIFF
--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -64,8 +64,8 @@ class contains_text:
             elem = driver.find_element(By.CSS_SELECTOR, self.selector)
             logger.debug("contains text {%s} => expected %s", elem.text, self.text)
             value = elem.get_attribute("value")
-            return str(elem.text) in self.text or (
-                value is not None and str(value) in self.text
+            return self.text in str(elem.text) or (
+                value is not None and self.text in str(value)
             )
         except WebDriverException:
             return False

--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -1,5 +1,6 @@
 # pylint: disable=too-few-public-methods
 """Utils methods for pytest-dash such wait_for wrappers."""
+
 import time
 import logging
 from selenium.common.exceptions import WebDriverException
@@ -108,7 +109,9 @@ class text_to_equal:
             elem = self._get_element(driver)
             logger.debug("text to equal {%s} => expected %s", elem.text, self.text)
             value = elem.get_attribute("value")
-            return str(elem.text) == self.text or (value is not None and str(value) == self.text)
+            return str(elem.text) == self.text or (
+                value is not None and str(value) == self.text
+            )
         except WebDriverException:
             return False
 

--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -62,10 +62,9 @@ class contains_text:
         try:
             elem = driver.find_element(By.CSS_SELECTOR, self.selector)
             logger.debug("contains text {%s} => expected %s", elem.text, self.text)
-            if value := elem.get_attribute("value") is not None:
+            if (value := elem.get_attribute("value")) is not None:
                 return self.text in str(elem.text) or self.text in str(value)
-            else:
-                return self.text in str(elem.text)
+            return self.text in str(elem.text)
         except WebDriverException:
             return False
 
@@ -108,10 +107,9 @@ class text_to_equal:
         try:
             elem = self._get_element(driver)
             logger.debug("text to equal {%s} => expected %s", elem.text, self.text)
-            if value := elem.get_attribute("value") is not None:
+            if (value := elem.get_attribute("value")) is not None:
                 return str(elem.text) == self.text or str(value) == self.text
-            else:
-                return str(elem.text) == self.text
+            return str(elem.text) == self.text
         except WebDriverException:
             return False
 

--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -63,9 +63,10 @@ class contains_text:
         try:
             elem = driver.find_element(By.CSS_SELECTOR, self.selector)
             logger.debug("contains text {%s} => expected %s", elem.text, self.text)
-            if (value := elem.get_attribute("value")) is not None:
-                return self.text in str(elem.text) or self.text in str(value)
-            return self.text in str(elem.text)
+            value = elem.get_attribute("value")
+            return str(elem.text) in self.text or (
+                value is not None and str(value) in self.text
+            )
         except WebDriverException:
             return False
 

--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -107,9 +107,8 @@ class text_to_equal:
         try:
             elem = self._get_element(driver)
             logger.debug("text to equal {%s} => expected %s", elem.text, self.text)
-            if (value := elem.get_attribute("value")) is not None:
-                return str(elem.text) == self.text or str(value) == self.text
-            return str(elem.text) == self.text
+            value = elem.get_attribute("value")
+            return str(elem.text) == self.text or (value is not None and str(value) == self.text)
         except WebDriverException:
             return False
 

--- a/dash/testing/wait.py
+++ b/dash/testing/wait.py
@@ -62,9 +62,10 @@ class contains_text:
         try:
             elem = driver.find_element(By.CSS_SELECTOR, self.selector)
             logger.debug("contains text {%s} => expected %s", elem.text, self.text)
-            return self.text in str(elem.text) or self.text in str(
-                elem.get_attribute("value")
-            )
+            if value := elem.get_attribute("value") is not None:
+                return self.text in str(elem.text) or self.text in str(value)
+            else:
+                return self.text in str(elem.text)
         except WebDriverException:
             return False
 
@@ -107,10 +108,10 @@ class text_to_equal:
         try:
             elem = self._get_element(driver)
             logger.debug("text to equal {%s} => expected %s", elem.text, self.text)
-            return (
-                str(elem.text) == self.text
-                or str(elem.get_attribute("value")) == self.text
-            )
+            if value := elem.get_attribute("value") is not None:
+                return str(elem.text) == self.text or str(value) == self.text
+            else:
+                return str(elem.text) == self.text
         except WebDriverException:
             return False
 

--- a/tests/integration/test_duo.py
+++ b/tests/integration/test_duo.py
@@ -15,6 +15,11 @@ def test_duo001_wait_for_text_error(dash_duo):
     assert err.value.args[0] == "text -> Invalid not found within 1.0s, found: Content"
 
     with pytest.raises(TimeoutException) as err:
+        dash_duo.wait_for_text_to_equal("#content", "None", timeout=1.0)
+
+    assert err.value.args[0] == "text -> None not found within 1.0s, found: Content"
+
+    with pytest.raises(TimeoutException) as err:
         dash_duo.wait_for_text_to_equal("#none", "None", timeout=1.0)
 
     assert err.value.args[0] == "text -> None not found within 1.0s, #none not found"
@@ -25,6 +30,14 @@ def test_duo001_wait_for_text_error(dash_duo):
     assert (
         err.value.args[0]
         == "text -> invalid not found inside element within 1.0s, found: Content"
+    )
+
+    with pytest.raises(TimeoutException) as err:
+        dash_duo.wait_for_contains_text("#content", "None", timeout=1.0)
+
+    assert (
+        err.value.args[0]
+        == "text -> None not found inside element within 1.0s, found: Content"
     )
 
     with pytest.raises(TimeoutException) as err:

--- a/tests/integration/test_duo.py
+++ b/tests/integration/test_duo.py
@@ -47,3 +47,18 @@ def test_duo001_wait_for_text_error(dash_duo):
         err.value.args[0]
         == "text -> none not found inside element within 1.0s, #none not found"
     )
+
+
+def test_duo002_wait_for_text_value(dash_duo):
+    app = Dash(__name__)
+    app.layout = html.Div([html.Ol([html.Li("Item", id="value-item", value="100")])])
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_text_to_equal("#value-item", "100")
+    with pytest.raises(TimeoutException) as err:
+        dash_duo.wait_for_contains_text("#value-item", "None", timeout=1.0)
+
+    assert (
+        err.value.args[0]
+        == "text -> None not found inside element within 1.0s, found: Item"
+    )


### PR DESCRIPTION
Closes #2818. This is my take on solving the issue. This method ignores the value prop if it is `None`. I think there is merit to adding a `wait_for_value_to_equal`, but this solves the immediate problem, while causing as little friction as possible.

As mentioned in #2818, there are also potential issues in the other methods in the `dash.testing.wait` namespace. Not sure if those cases need to be handled here.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Check if the value attribute is None and don't compare if it is.
   -  [x] Add tests to make sure the `None` isn't cast to a string.
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
