### PR TITLE
implementing `callback_fallback` 

### DIFF
--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -53,6 +53,7 @@ class NoUpdate:
 GLOBAL_CALLBACK_LIST = []
 GLOBAL_CALLBACK_MAP = {}
 GLOBAL_INLINE_SCRIPTS = []
+GLOBAL_CALLBACK_FALLBACK = None
 
 
 # pylint: disable=too-many-locals
@@ -145,6 +146,7 @@ def callback(
     )
     callback_map = _kwargs.pop("callback_map", GLOBAL_CALLBACK_MAP)
     callback_list = _kwargs.pop("callback_list", GLOBAL_CALLBACK_LIST)
+    callback_fallback = _kwargs.pop("callback_fallback", GLOBAL_CALLBACK_FALLBACK)
 
     if background:
         long_spec = {
@@ -185,6 +187,7 @@ def callback(
         long=long_spec,
         manager=manager,
         running=running,
+        callback_fallback=callback_fallback
     )
 
 
@@ -291,6 +294,7 @@ def register_callback(  # pylint: disable=R0914
     long = _kwargs.get("long")
     manager = _kwargs.get("manager")
     running = _kwargs.get("running")
+    callback_fallback = _kwargs.get('callback_fallback')
     if running is not None:
         if not isinstance(running[0], (list, tuple)):
             running = [running]
@@ -316,6 +320,7 @@ def register_callback(  # pylint: disable=R0914
         dynamic_creator=allow_dynamic_callbacks,
         running=running,
     )
+
 
     # pylint: disable=too-many-locals
     def wrap_func(func):
@@ -495,7 +500,9 @@ def register_callback(  # pylint: disable=R0914
             return jsonResponse
 
         callback_map[callback_id]["callback"] = add_context
-
+        if callback_fallback:
+            callback_map[callback_id]['callback'] = callback_fallback(insert_output)(
+                callback_map[callback_id]['callback'])
         return func
 
     return wrap_func

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -16,7 +16,7 @@ import hashlib
 import base64
 import traceback
 from urllib.parse import urlparse
-from typing import Dict, Optional, Union
+from typing import Dict, Optional, Union, Callable
 
 import flask
 
@@ -408,6 +408,7 @@ class Dash:
         hooks: Union[RendererHooks, None] = None,
         routing_callback_inputs: Optional[Dict[str, Union[Input, State]]] = None,
         description=None,
+        callback_fallback: Optional[Union[Callable, None]] = None,
         **obsolete,
     ):
         _validate.check_obsolete(obsolete)
@@ -480,6 +481,9 @@ class Dash:
             "Invalid config key. Some settings are only available "
             "via the Dash constructor"
         )
+        self.callback_fallback=callback_fallback
+
+        _callback.GLOBAL_CALLBACK_FALLBACK = self.callback_fallback
 
         _get_paths.CONFIG = self.config
         _pages.CONFIG = self.config


### PR DESCRIPTION
implementing `callback_fallback` on `Dash` and `callback` to allow for universal error handling of callbacks.

This manipulates a new variable in `_callback` `GLOBAL_CALLBACK_FALLBACK` in order to pass the configuration to all other callbacks from the `Dash()` registration
