### PR TITLE
Fix patch operators on the base object.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Fixed
 
 - [#2854](https://github.com/plotly/dash/pull/2854) Fix dcc.Dropdown resetting empty values to null and triggering callbacks. Fixes [#2850](https://github.com/plotly/dash/issues/2850)
+- [#2859](https://github.com/plotly/dash/pull/2859) Fix base patch operators. fixes [#2855](https://github.com/plotly/dash/issues/2855)
 
 ## [2.17.0] - 2024-05-03
 

--- a/dash/_patch.py
+++ b/dash/_patch.py
@@ -36,18 +36,18 @@ class Patch:
     def __setstate__(self, state):
         vars(self).update(state)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item) -> "Patch":
         validate_slice(item)
         return Patch(location=self._location + [item], parent=self)
 
-    def __getattr__(self, item):
+    def __getattr__(self, item) -> "Patch":
         if item == "tolist":
             # to_json fix
             raise AttributeError
         if item == "_location":
-            return self._location
+            return self._location  # type: ignore
         if item == "_operations":
-            return self._operations
+            return self._operations  # type: ignore
         return self.__getitem__(item)
 
     def __setattr__(self, key, value):
@@ -81,22 +81,32 @@ class Patch:
             self.extend(other)
         else:
             self._operations.append(_operation("Add", self._location, value=other))
+        if not self._location:
+            return self
         return _noop
 
     def __isub__(self, other):
         self._operations.append(_operation("Sub", self._location, value=other))
+        if not self._location:
+            return self
         return _noop
 
     def __imul__(self, other):
         self._operations.append(_operation("Mul", self._location, value=other))
+        if not self._location:
+            return self
         return _noop
 
     def __itruediv__(self, other):
         self._operations.append(_operation("Div", self._location, value=other))
+        if not self._location:
+            return self
         return _noop
 
     def __ior__(self, other):
         self.update(E=other)
+        if not self._location:
+            return self
         return _noop
 
     def __iter__(self):


### PR DESCRIPTION
Fix #2855, the operators `+=`,`-=`,`*=`, `/=`, `|=` on patch without a location were returning the noop object that can't be serialize, they needed to return themself instead to be used.
