### PR TITLE
Fix dcc.Loading spinner style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Fixed
 
-
 - [#2860](https://github.com/plotly/dash/pull/2860) Fix dcc.Loading to apply overlay_style only to the children and not the spinner. Fixes [#2858](https://github.com/plotly/dash/issues/2858)
 - [#2854](https://github.com/plotly/dash/pull/2854) Fix dcc.Dropdown resetting empty values to null and triggering callbacks. Fixes [#2850](https://github.com/plotly/dash/issues/2850)
 - [#2859](https://github.com/plotly/dash/pull/2859) Fix base patch operators. fixes [#2855](https://github.com/plotly/dash/issues/2855)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Fixed
 
 
-- [#2860](https://github.com/plotly/dash/pull/2860) Fix dcc.Loading to apply overlay_style only to the children and not the spinner.  [#2858](https://github.com/plotly/dash/issues/2858)
+- [#2860](https://github.com/plotly/dash/pull/2860) Fix dcc.Loading to apply overlay_style only to the children and not the spinner. Fixes [#2858](https://github.com/plotly/dash/issues/2858)
 - [#2854](https://github.com/plotly/dash/pull/2854) Fix dcc.Dropdown resetting empty values to null and triggering callbacks. Fixes [#2850](https://github.com/plotly/dash/issues/2850)
 - [#2859](https://github.com/plotly/dash/pull/2859) Fix base patch operators. fixes [#2855](https://github.com/plotly/dash/issues/2855)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Fixed
 
+
+- [#2860](https://github.com/plotly/dash/pull/2860) Fix dcc.Loading to apply overlay_style only to the children and not the spinner.  [#2858](https://github.com/plotly/dash/issues/2858)
 - [#2854](https://github.com/plotly/dash/pull/2854) Fix dcc.Dropdown resetting empty values to null and triggering callbacks. Fixes [#2850](https://github.com/plotly/dash/issues/2850)
 - [#2859](https://github.com/plotly/dash/pull/2859) Fix base patch operators. fixes [#2855](https://github.com/plotly/dash/issues/2855)
 

--- a/components/dash-core-components/src/components/Loading.react.js
+++ b/components/dash-core-components/src/components/Loading.react.js
@@ -127,16 +127,19 @@ const Loading = ({
 
     return (
         <div
+            style={{position: 'relative', ...parent_style}}
             className={parent_className}
-            style={
-                showSpinner
-                    ? {position: 'relative', ...parent_style}
-                    : parent_style
-            }
         >
             <div
+                className={parent_className}
                 style={
-                    showSpinner ? {visibility: 'hidden', ...overlay_style} : {}
+                    showSpinner
+                        ? {
+                              visibility: 'hidden',
+                              ...overlay_style,
+                              ...parent_style,
+                          }
+                        : parent_style
                 }
             >
                 {children}

--- a/components/dash-core-components/src/components/Loading.react.js
+++ b/components/dash-core-components/src/components/Loading.react.js
@@ -5,7 +5,6 @@ import DefaultSpinner from '../fragments/Loading/spinners/DefaultSpinner.jsx';
 import CubeSpinner from '../fragments/Loading/spinners/CubeSpinner.jsx';
 import CircleSpinner from '../fragments/Loading/spinners/CircleSpinner.jsx';
 import DotSpinner from '../fragments/Loading/spinners/DotSpinner.jsx';
-import {mergeRight} from 'ramda';
 
 const spinnerComponentOptions = {
     graph: GraphSpinner,
@@ -49,10 +48,6 @@ const Loading = ({
         justifyContent: 'center',
         alignItems: 'center',
     };
-    const hiddenContainer = mergeRight(
-        {visibility: 'hidden', position: 'relative'},
-        overlay_style
-    );
 
     /* Overrides default Loading behavior if target_components is set. By default,
      *  Loading fires when any recursive child enters loading state. This makes loading
@@ -135,11 +130,17 @@ const Loading = ({
             className={parent_className}
             style={
                 showSpinner
-                    ? mergeRight(hiddenContainer, parent_style)
+                    ? {position: 'relative', ...parent_style}
                     : parent_style
             }
         >
-            {children}
+            <div
+                style={
+                    showSpinner ? {visibility: 'hidden', ...overlay_style} : {}
+                }
+            >
+                {children}
+            </div>
             <div style={showSpinner ? coveringSpinner : {}}>
                 {showSpinner &&
                     (custom_spinner || (

--- a/components/dash-core-components/tests/integration/loading/test_loading_component.py
+++ b/components/dash-core-components/tests/integration/loading/test_loading_component.py
@@ -406,7 +406,7 @@ def test_ldcp009_loading_component_overlay_style(dash_dcc):
         dash_dcc.find_element(".loading .dash-spinner")
         # unlike the default, the content should be visible
         dash_dcc.wait_for_text_to_equal("#div-1", "content")
-        dash_dcc.wait_for_style_to_equal("#root > div", "opacity", "0.5")
+        dash_dcc.wait_for_style_to_equal("#root > div > div", "opacity", "0.5")
 
     dash_dcc.wait_for_text_to_equal("#div-1", "changed")
 


### PR DESCRIPTION
fixes #2858 

Applies `overlay_style` prop  to the `dcc.Loading` `children`  only and not to the spinner component.