### PR TITLE
Fix pattern matching in side updates (running/progress/set_props)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2859](https://github.com/plotly/dash/pull/2859) Fix base patch operators. fixes [#2855](https://github.com/plotly/dash/issues/2855)
 - [#2856](https://github.com/plotly/dash/pull/2856) Fix multiple consecutive calls with same id to set_props only keeping the last props. Fixes [#2852](https://github.com/plotly/dash/issues/2852)
 - [#2867](https://github.com/plotly/dash/pull/2867) Fix clientside no output callback. Fixes [#2866](https://github.com/plotly/dash/issues/2866)
+- [#2876](https://github.com/plotly/dash/pull/2876) Fix pattern matching in callback running argument. Fixes [#2863](https://github.com/plotly/dash/issues/2863)
 
 ## [2.17.0] - 2024-05-03
 

--- a/dash/dash-renderer/src/actions/patternMatching.ts
+++ b/dash/dash-renderer/src/actions/patternMatching.ts
@@ -1,0 +1,91 @@
+import {keys, equals, dissoc, toPairs} from 'ramda';
+import {ICallbackPayload} from '../types/callbacks';
+
+/**
+ * Deserialize pattern matching ids that come in one of the form:
+ * - '{"type":"component","index":["MATCH"]}.children'
+ * - '{"type":"component","index":["MATCH"]}'
+ *
+ * @param id The raw object as a string id.
+ * @returns The id object.
+ */
+export function parsePMCId(id: string): [any, string | undefined] {
+    let componentId, propName;
+    const index = id.lastIndexOf('}');
+    if (index + 2 < id.length) {
+        propName = id.substring(index + 2);
+        componentId = JSON.parse(id.substring(0, index + 1));
+    } else {
+        componentId = JSON.parse(id);
+    }
+    return [componentId, propName];
+}
+
+/**
+ * Get all the associated ids for an id.
+ *
+ * @param id Id to get all the pmc ids from.
+ * @param state State of the store.
+ * @param triggerKey Key to remove from the equality comparison.
+ * @returns
+ */
+export function getAllPMCIds(id: any, state: any, triggerKey: string) {
+    const keysOfIds = keys(id);
+    const idKey = keysOfIds.join(',');
+    return state.paths.objs[idKey]
+        .map((obj: any) =>
+            keysOfIds.reduce((acc, key, i) => {
+                acc[key] = obj.values[i];
+                return acc;
+            }, {} as any)
+        )
+        .filter((obj: any) =>
+            equals(dissoc(triggerKey, obj), dissoc(triggerKey, id))
+        );
+}
+
+/**
+ * Replace the pattern matching ids with the actual trigger value
+ * for MATCH, all the ids for ALL and smaller than the trigger value
+ * for ALLSMALLER.
+ *
+ * @param id The parsed id in dictionary format.
+ * @param cb Original callback info.
+ * @param index Index of the dependency in case there is more than one changed id.
+ * @param getState Function to get the state of the redux store.
+ * @returns List of replaced ids.
+ */
+export function replacePMC(
+    id: any,
+    cb: ICallbackPayload,
+    index: number,
+    getState: any
+): any[] {
+    let extras: any = [];
+    const replaced: any = {};
+    toPairs(id).forEach(([key, value]) => {
+        if (extras.length) {
+            // All done.
+            return;
+        }
+        if (Array.isArray(value)) {
+            const triggerValue = (cb.parsedChangedPropsIds[index] ||
+                cb.parsedChangedPropsIds[0])[key];
+            if (value.includes('MATCH')) {
+                replaced[key] = triggerValue;
+            } else if (value.includes('ALL')) {
+                extras = getAllPMCIds(id, getState(), key);
+            } else if (value.includes('ALLSMALLER')) {
+                extras = getAllPMCIds(id, getState(), key).filter(
+                    (obj: any) => obj[key] < triggerValue
+                );
+            }
+        } else {
+            replaced[key] = value;
+        }
+    });
+    if (extras.length) {
+        return extras;
+    }
+    return [replaced];
+}

--- a/dash/dash-renderer/src/types/callbacks.ts
+++ b/dash/dash-renderer/src/types/callbacks.ts
@@ -72,6 +72,7 @@ export interface IStoredCallback extends IExecutedCallback {
 
 export interface ICallbackPayload {
     changedPropIds: any[];
+    parsedChangedPropsIds: any[];
     inputs: any[];
     output: string;
     outputs: any[];

--- a/dash/dash-renderer/src/types/callbacks.ts
+++ b/dash/dash-renderer/src/types/callbacks.ts
@@ -107,3 +107,7 @@ export type CallbackResponseData = {
     cancel?: ICallbackProperty[];
     sideUpdate?: any;
 };
+
+export type SideUpdateOutput = {
+    [key: string]: any;
+};

--- a/tests/integration/callbacks/test_wildcards.py
+++ b/tests/integration/callbacks/test_wildcards.py
@@ -2,6 +2,7 @@ import pytest
 import re
 from selenium.webdriver.common.keys import Keys
 import json
+import time
 
 from dash.testing import wait
 import dash
@@ -552,3 +553,65 @@ def test_cbwc007_pmc_update_subtree_ordering(dash_duo):
     dash_duo.wait_for_text_to_equal(
         "#selected-values", "['option0-2', 'option1-2', 'option2-2']"
     )
+
+
+def test_cbwc008_running_match(dash_duo):
+    app = dash.Dash()
+
+    app.layout = [
+        html.Div(
+            [
+                html.Button(
+                    "Test1",
+                    id={"component": "button", "index": "1"},
+                ),
+                html.Button(
+                    "Test2",
+                    id={"component": "button", "index": "2"},
+                ),
+            ],
+            id="buttons",
+        ),
+        html.Div(html.Div(id={"component": "output", "index": "1"}), id="output1"),
+        html.Div(html.Div(id={"component": "output", "index": "2"}), id="output2"),
+    ]
+
+    @app.callback(
+        Output({"component": "output", "index": MATCH}, "children"),
+        Input({"component": "button", "index": MATCH}, "n_clicks"),
+        running=[
+            (
+                Output({"component": "button", "index": MATCH}, "children"),
+                "running",
+                "finished",
+            ),
+            (Output({"component": "button", "index": ALL}, "disabled"), True, False),
+        ],
+        prevent_initial_call=True,
+    )
+    def on_click(_) -> str:
+        time.sleep(1)
+        return "done"
+
+    dash_duo.start_server(app)
+
+    for i in range(1, 3):
+        dash_duo.find_element(f"#buttons button:nth-child({i})").click()
+        dash_duo.wait_for_text_to_equal(f"#buttons button:nth-child({i})", "running")
+        # verify all the buttons were disabled.
+        assert dash_duo.find_element("#buttons button:nth-child(1)").get_attribute(
+            "disabled"
+        )
+        assert dash_duo.find_element("#buttons button:nth-child(2)").get_attribute(
+            "disabled"
+        )
+
+        dash_duo.wait_for_text_to_equal(f"#output{i}", "done")
+        dash_duo.wait_for_text_to_equal(f"#buttons button:nth-child({i})", "finished")
+
+        assert not dash_duo.find_element("#buttons button:nth-child(1)").get_attribute(
+            "disabled"
+        )
+        assert not dash_duo.find_element("#buttons button:nth-child(2)").get_attribute(
+            "disabled"
+        )

--- a/tests/integration/renderer/test_request_hooks.py
+++ b/tests/integration/renderer/test_request_hooks.py
@@ -95,6 +95,7 @@ def test_rdrh001_request_hooks(dash_duo):
         "output": "output-1.children",
         "outputs": {"id": "output-1", "property": "children"},
         "changedPropIds": ["input.value"],
+        "parsedChangedPropsIds": ["input.value"],
         "inputs": [{"id": "input", "property": "value", "value": "fire request hooks"}],
     }
 
@@ -102,6 +103,7 @@ def test_rdrh001_request_hooks(dash_duo):
         "output": "output-1.children",
         "outputs": {"id": "output-1", "property": "children"},
         "changedPropIds": ["input.value"],
+        "parsedChangedPropsIds": ["input.value"],
         "inputs": [{"id": "input", "property": "value", "value": "fire request hooks"}],
     }
 

--- a/tests/integration/test_patch.py
+++ b/tests/integration/test_patch.py
@@ -1,10 +1,13 @@
 import json
 
+import flaky
+
 from selenium.webdriver.common.keys import Keys
 
 from dash import Dash, html, dcc, Input, Output, State, ALL, Patch
 
 
+@flaky.flaky(max_runs=3)
 def test_pch001_patch_operations(dash_duo):
 
     app = Dash(__name__)


### PR DESCRIPTION
Fix #2863

Fixes for cases where the given id has a `MATCH`, `ALL`, `ALLSMALLER` wildcard in callback `running` argument, progress for background callbacks and `set_props`.
 