### PR TITLE
fix dropdown css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## UNRELEASED
 
 ## Fixed
-- [#2880](https://github.com/plotly/dash/pull/2860) Fix: Ensure dcc.Dropdown options maxHeight works with Datatable . Fixes [#2529](https://github.com/plotly/dash/issues/2529)  [#2225](https://github.com/plotly/dash/issues/2225)
+- [#2880](https://github.com/plotly/dash/pull/2860) Fix Ensure dcc.Dropdown options maxHeight works with Datatable . Fixes [#2529](https://github.com/plotly/dash/issues/2529)  [#2225](https://github.com/plotly/dash/issues/2225)
 - [#2860](https://github.com/plotly/dash/pull/2860) Fix dcc.Loading to apply overlay_style only to the children and not the spinner. Fixes [#2858](https://github.com/plotly/dash/issues/2858)
 - [#2854](https://github.com/plotly/dash/pull/2854) Fix dcc.Dropdown resetting empty values to null and triggering callbacks. Fixes [#2850](https://github.com/plotly/dash/issues/2850)
 - [#2859](https://github.com/plotly/dash/pull/2859) Fix base patch operators. fixes [#2855](https://github.com/plotly/dash/issues/2855)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## UNRELEASED
 
 ## Fixed
-
+- [#2880](https://github.com/plotly/dash/pull/2860) Fix: Ensure dcc.Dropdown options maxHeight works with Datatable . Fixes [#2529](https://github.com/plotly/dash/issues/2529)  [#2225](https://github.com/plotly/dash/issues/2225)
 - [#2860](https://github.com/plotly/dash/pull/2860) Fix dcc.Loading to apply overlay_style only to the children and not the spinner. Fixes [#2858](https://github.com/plotly/dash/issues/2858)
 - [#2854](https://github.com/plotly/dash/pull/2854) Fix dcc.Dropdown resetting empty values to null and triggering callbacks. Fixes [#2850](https://github.com/plotly/dash/issues/2850)
 - [#2859](https://github.com/plotly/dash/pull/2859) Fix base patch operators. fixes [#2855](https://github.com/plotly/dash/issues/2855)

--- a/components/dash-core-components/src/components/css/Dropdown.css
+++ b/components/dash-core-components/src/components/css/Dropdown.css
@@ -1,7 +1,8 @@
 .dash-dropdown .Select-menu-outer {
     z-index: 1000;
+    max-height: none;
 }
 
-.dash-dropdown .Select-menu, .Select-menu-outer {
+.dash-dropdown .Select-menu {
     max-height: none;
 }

--- a/components/dash-core-components/tests/integration/dropdown/test_visibility.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_visibility.py
@@ -50,7 +50,10 @@ def test_ddvi001_fixed_table(dash_duo):
 def test_ddvi002_maxHeight(dash_duo):
     app = Dash(__name__)
     app.layout = Div(
-        [Dropdown([str(i) for i in range(100)], "1", id="dropdown", maxHeight=800)]
+        [
+            DataTable(),  # ensure datatable css does not override maxHeight #2529
+            Dropdown([str(i) for i in range(100)], "1", id="dropdown", maxHeight=800),
+        ]
     )
 
     dash_duo.start_server(app)


### PR DESCRIPTION
closes #2529 
closes #2225

## Contributor Checklist

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [x] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows   
    -  [x] here is the show and tell thread in [Plotly Dash community](https://community.plotly.com/t/maxheight-doesnt-extend-background-height-in-dcc-dropdown/75736/6)
