### PR TITLE
The tabIndex parameter of Div can accept number or string type

### DIFF
--- a/components/dash-html-components/scripts/generate-components.js
+++ b/components/dash-html-components/scripts/generate-components.js
@@ -56,7 +56,8 @@ const NUMERIC_PROPERTIES = [
     'cols',
     'colSpan',
     'size',
-    'step'
+    'step',
+    'tabIndex'
 ];
 
 const PROP_TYPES = {

--- a/components/dash-html-components/tests/test_div_tabIndex.py
+++ b/components/dash-html-components/tests/test_div_tabIndex.py
@@ -1,0 +1,53 @@
+from dash import Dash, Input, Output, State, html
+
+
+def test_dt001_div_tabindex_accept_string_and_number_type(dash_duo):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            html.Div(id="string-div", tabIndex="1"),
+            html.Div(id="number-div", tabIndex=1),
+            html.Button("string", id="trigger-string"),
+            html.Button("number", id="trigger-number"),
+            html.Pre(id="output-string-result"),
+            html.Pre(id="output-number-result"),
+        ],
+        style={"padding": 50},
+    )
+
+    @app.callback(
+        Output("output-string-result", "children"),
+        Input("trigger-string", "n_clicks"),
+        State("string-div", "tabIndex"),
+        prevent_initial_call=True,
+    )
+    def show_div_tabindex_string_type(n_clicks, tabindex):
+        if n_clicks:
+            if isinstance(tabindex, str):
+                return "success"
+        return "fail"
+
+    @app.callback(
+        Output("output-number-result", "children"),
+        Input("trigger-number", "n_clicks"),
+        State("number-div", "tabIndex"),
+        prevent_initial_call=True,
+    )
+    def show_div_tabindex_number_type(n_clicks, tabindex):
+        if n_clicks:
+            if isinstance(tabindex, int):
+                return "success"
+        return "fail"
+
+    dash_duo.start_server(app)
+
+    dash_duo.wait_for_element("#trigger-string").click()
+    dash_duo.wait_for_element("#trigger-number").click()
+    dash_duo.wait_for_text_to_equal(
+        "#output-string-result",
+        "success",
+    )
+    dash_duo.wait_for_text_to_equal(
+        "#output-number-result",
+        "success",
+    )


### PR DESCRIPTION
*Start with a description of this PR. Then edit the list below to the items that make sense for your PR scope, and check off the boxes as you go!*

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] The tabIndex parameter of Div can accept number or string type
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
