### PR TITLE
Allowing defining potentially non existent components in the running keyword

### DIFF
--- a/dash/dash-renderer/src/actions/callbacks.ts
+++ b/dash/dash-renderer/src/actions/callbacks.ts
@@ -334,6 +334,11 @@ function updateComponent(component_id: any, props: any) {
     return function (dispatch: any, getState: any) {
         const paths = getState().paths;
         const componentPath = getPath(paths, component_id);
+        if (typeof componentPath === 'undefined') {
+            // Can't find the component that was defined in the running keyword,
+            // Let's skip the component to prevent the dashboard from crashing.
+            return;
+        }
         dispatch(
             updateProps({
                 props,

--- a/tests/integration/callbacks/test_basic_callback.py
+++ b/tests/integration/callbacks/test_basic_callback.py
@@ -823,3 +823,38 @@ def test_cbsc019_callback_running(dash_duo):
 
     dash_duo.wait_for_text_to_equal("#output", "done")
     dash_duo.wait_for_text_to_equal("#running", "off")
+
+
+def test_cbsc020_callback_running_non_existing_component(dash_duo):
+    lock = Lock()
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.Button("start", id="start"),
+            html.Div(id="output"),
+        ]
+    )
+
+    @app.callback(
+        Output("output", "children"),
+        Input("start", "n_clicks"),
+        running=[
+            [
+                Output("non_existent_component", "children"),
+                html.B("on", id="content"),
+                "off",
+            ]
+        ],
+        prevent_initial_call=True,
+    )
+    def on_click(_):
+        with lock:
+            pass
+        return "done"
+
+    dash_duo.start_server(app)
+    with lock:
+        dash_duo.find_element("#start").click()
+
+    dash_duo.wait_for_text_to_equal("#output", "done")


### PR DESCRIPTION
closes #2897

When using the running keyword in (regular) callbacks, the app crashes if a component is used that does not exist in the layout. Added a check to only continue with component update it the component was found in the dashboard. Full explanation in #2897. 

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Added check to only allow component updates in running if component is defined
   -  [x] Added test to verify correct behavior
- [ ] I have run the tests locally and they passed. I can't run the full test suite locally. My PC can't handle it. 
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
