### PR TITLE
Deprecate LogoutButton

### DIFF
--- a/components/dash-core-components/tests/integration/location/test_location_logout.py
+++ b/components/dash-core-components/tests/integration/location/test_location_logout.py
@@ -5,7 +5,8 @@ import pytest
 import time
 
 
-def test_llgo001_location_logout(dash_dcc):
+@pytest.mark.parametrize("add_initial_logout_button", [False, True])
+def test_llgo001_location_logout(dash_dcc, add_initial_logout_button):
     app = Dash(__name__)
 
     @app.server.route("/_logout", methods=["POST"])
@@ -14,9 +15,14 @@ def test_llgo001_location_logout(dash_dcc):
         rep.set_cookie("logout-cookie", "", 0)
         return rep
 
-    app.layout = html.Div(
-        [html.H2("Logout test"), dcc.Location(id="location"), html.Div(id="content")]
-    )
+    layout_children = [
+        html.H2("Logout test"),
+        dcc.Location(id="location"),
+        html.Div(id="content"),
+    ]
+    if add_initial_logout_button:
+        layout_children.append(dcc.LogoutButton())
+    app.layout = html.Div(layout_children)
 
     @app.callback(Output("content", "children"), [Input("location", "pathname")])
     def on_location(location_path):

--- a/components/dash-core-components/tests/integration/location/test_location_logout.py
+++ b/components/dash-core-components/tests/integration/location/test_location_logout.py
@@ -1,6 +1,7 @@
 from dash.exceptions import PreventUpdate
 from dash import Dash, Input, Output, dcc, html
 import flask
+import pytest
 import time
 
 
@@ -33,15 +34,19 @@ def test_llgo001_location_logout(dash_dcc):
 
             return dcc.LogoutButton(id="logout-btn", logout_url="/_logout")
 
-    dash_dcc.start_server(app)
-    time.sleep(1)
-    dash_dcc.percy_snapshot("Core Logout button")
+    with pytest.warns(
+        DeprecationWarning,
+        match="LogoutButton is deprecated, use a different component type instead",
+    ):
+        dash_dcc.start_server(app)
+        time.sleep(1)
+        dash_dcc.percy_snapshot("Core Logout button")
 
-    assert dash_dcc.driver.get_cookie("logout-cookie")["value"] == "logged-in"
+        assert dash_dcc.driver.get_cookie("logout-cookie")["value"] == "logged-in"
 
-    dash_dcc.wait_for_element("#logout-btn").click()
-    dash_dcc.wait_for_text_to_equal("#content", "Logged out")
+        dash_dcc.wait_for_element("#logout-btn").click()
+        dash_dcc.wait_for_text_to_equal("#content", "Logged out")
 
-    assert not dash_dcc.driver.get_cookie("logout-cookie")
+        assert not dash_dcc.driver.get_cookie("logout-cookie")
 
-    assert dash_dcc.get_logs() == []
+        assert dash_dcc.get_logs() == []


### PR DESCRIPTION
PR will output a `DeprecationWarning` when the `LogoutButton` is used (#2894).

I tried making the changes from https://github.com/plotly/dash/issues/2894#issuecomment-2176661569, but it seems that it only validates the initial page layout and not the components used in callbacks.

As seen in the modified test in this PR, the test doesn't output a `DeprecationWarning` and fails when the LogoutButton is in the callback but not in the initial page layout. On the other hand, it passes when `LogoutButton` is in the initial page layout.

I'm assuming we would also want to show a `DeprecationWarning` if `LogoutButton` is used in a callback. What would be a good way to approach this? Or would it be simpler to remove the `LogoutButton` component entirely?

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Outputs DeprecationWarning if LogoutButton is used in layout
   -  [ ] Outputs DeprecationWarning if LogoutButton is used in callback
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
