### PR TITLE
Allow strings in layout list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - [#2892](https://github.com/plotly/dash/pull/2860) Fix ensures dcc.Dropdown menu maxHeight option works with Datatable. Fixes [#2529](https://github.com/plotly/dash/issues/2529) [#2225](https://github.com/plotly/dash/issues/2225)
 - [#2896](https://github.com/plotly/dash/pull/2896) The tabIndex parameter of Div can accept number or string type. Fixes [#2891](https://github.com/plotly/dash/issues/2891)
+- [#2900](https://github.com/plotly/dash/pull/2900) Allow strings in layout list. Fixes [#2890](https://github.com/plotly/dash/issues/2890)
 
 ## [2.17.1] - 2024-06-12
 

--- a/dash/_validate.py
+++ b/dash/_validate.py
@@ -445,7 +445,7 @@ def validate_layout(layout, layout_value):
                 _validate(component)
             else:
                 raise exceptions.NoLayoutException(
-                    "List of components as layout must be a list of strings and components only."
+                    "Only strings and components are allowed in a list layout."
                 )
     else:
         _validate(layout_value)

--- a/dash/_validate.py
+++ b/dash/_validate.py
@@ -439,11 +439,13 @@ def validate_layout(layout, layout_value):
 
     if isinstance(layout_value, (list, tuple)):
         for component in layout_value:
+            if isinstance(component, (str,)):
+                continue
             if isinstance(component, (Component,)):
                 _validate(component)
             else:
                 raise exceptions.NoLayoutException(
-                    "List of components as layout must be a list of components only."
+                    "List of components as layout must be a list of strings and components only."
                 )
     else:
         _validate(layout_value)

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -433,6 +433,8 @@ def test_inin028_layout_as_list(dash_duo):
     app = Dash()
 
     app.layout = [
+        "string1",
+        "string2",
         html.Div("one", id="one"),
         html.Div("two", id="two"),
         html.Button("direct", id="direct"),
@@ -457,6 +459,9 @@ def test_inin028_layout_as_list(dash_duo):
         return f"Clicked {n_clicks} times"
 
     dash_duo.start_server(app)
+
+    dash_duo.wait_for_contains_text("#react-entry-point", "string1")
+    dash_duo.wait_for_contains_text("#react-entry-point", "string2")
 
     dash_duo.wait_for_text_to_equal("#one", "one")
     dash_duo.wait_for_text_to_equal("#two", "two")


### PR DESCRIPTION
Fixes #2890.

The problem was that strings were not allowed when the page layout was defined as a list. The issue only happens the first time—and not the second one after a refresh—because the layout validation using `validate_layout()` is only done the first time the page is accessed, resulting in the error `dash.exceptions.NoLayoutException: List of components as layout must be a list of components only.`

The solution is simply to allow strings to be included when the page layout is a list.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Allows strings if layout is a list
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
