### PR TITLE
Add callback on_error handler

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -414,7 +414,7 @@ max-bool-expr=5
 max-branches=15
 
 # Maximum number of locals for function / method body
-max-locals=20
+max-locals=25
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -475,6 +475,8 @@ def register_callback(
             else:
                 try:
                     output_value = _invoke_callback(func, *func_args, **func_kwargs)
+                except PreventUpdate as err:
+                    raise err
                 except Exception as err:  # pylint: disable=broad-exception-caught
                     if on_error:
                         output_value = on_error(err)

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -16,7 +16,7 @@ import hashlib
 import base64
 import traceback
 from urllib.parse import urlparse
-from typing import Dict, Optional, Union
+from typing import Any, Callable, Dict, Optional, Union
 
 import flask
 
@@ -369,6 +369,10 @@ class Dash:
 
     :param description:  Sets a default description for meta tags on Dash pages (use_pages=True).
 
+    :param on_error: Global callback error handler to call when
+        an exception is raised. Receives the exception object as first argument.
+        The callback_context can be used to access the original callback inputs,
+        states and output.
     """
 
     _plotlyjs_url: str
@@ -409,6 +413,7 @@ class Dash:
         hooks: Union[RendererHooks, None] = None,
         routing_callback_inputs: Optional[Dict[str, Union[Input, State]]] = None,
         description=None,
+        on_error: Optional[Callable[[Exception], Any]] = None,
         **obsolete,
     ):
         _validate.check_obsolete(obsolete)
@@ -520,6 +525,7 @@ class Dash:
         self._layout = None
         self._layout_is_function = False
         self.validation_layout = None
+        self._on_error = on_error
         self._extra_components = []
 
         self._setup_dev_tools()
@@ -1377,6 +1383,7 @@ class Dash:
                     outputs_list=outputs_list,
                     long_callback_manager=self._background_manager,
                     callback_context=g,
+                    app_on_error=self._on_error,
                 )
             )
         )

--- a/dash/long_callback/managers/__init__.py
+++ b/dash/long_callback/managers/__init__.py
@@ -39,7 +39,7 @@ class BaseLongCallbackManager(ABC):
     def make_job_fn(self, fn, progress, key=None):
         raise NotImplementedError
 
-    def call_job_fn(self, key, job_fn, args, context, on_error=None):
+    def call_job_fn(self, key, job_fn, args, context):
         raise NotImplementedError
 
     def get_progress(self, key):

--- a/dash/long_callback/managers/__init__.py
+++ b/dash/long_callback/managers/__init__.py
@@ -39,7 +39,7 @@ class BaseLongCallbackManager(ABC):
     def make_job_fn(self, fn, progress, key=None):
         raise NotImplementedError
 
-    def call_job_fn(self, key, job_fn, args, context):
+    def call_job_fn(self, key, job_fn, args, context, on_error=None):
         raise NotImplementedError
 
     def get_progress(self, key):

--- a/dash/long_callback/managers/celery_manager.py
+++ b/dash/long_callback/managers/celery_manager.py
@@ -90,7 +90,7 @@ CeleryLongCallbackManager requires extra dependencies which can be installed doi
         self.handle.backend.delete(key)
 
     def call_job_fn(self, key, job_fn, args, context, on_error=None):
-        task = job_fn.delay(key, self._make_progress_key(key), args, context)
+        task = job_fn.delay(key, self._make_progress_key(key), args, context, on_error)
         return task.task_id
 
     def get_progress(self, key):

--- a/tests/integration/callbacks/test_callback_error.py
+++ b/tests/integration/callbacks/test_callback_error.py
@@ -12,10 +12,12 @@ def test_cber001_error_handler(dash_duo):
         html.Button("start-global", id="start-global"),
         html.Div(id="output"),
         html.Div(id="output-global"),
+        html.Div(id="error-message"),
     ]
 
     def on_callback_error(err):
-        set_props("output", {"children": f"callback: {err}"})
+        set_props("error-message", {"children": f"message: {err}"})
+        return f"callback: {err}"
 
     @app.callback(
         Output("output", "children"),
@@ -38,6 +40,7 @@ def test_cber001_error_handler(dash_duo):
     dash_duo.find_element("#start-local").click()
 
     dash_duo.wait_for_text_to_equal("#output", "callback: local error")
+    dash_duo.wait_for_text_to_equal("#error-message", "message: local error")
 
     dash_duo.find_element("#start-global").click()
     dash_duo.wait_for_text_to_equal("#output-global", "global: global error")

--- a/tests/integration/callbacks/test_callback_error.py
+++ b/tests/integration/callbacks/test_callback_error.py
@@ -1,0 +1,43 @@
+from dash import Dash, html, Input, Output
+
+
+def test_cber001_error_handler(dash_duo):
+    def global_callback_error_handler(err):
+        return f"global: {err}"
+
+    app = Dash(on_error=global_callback_error_handler)
+
+    app.layout = [
+        html.Button("start", id="start-local"),
+        html.Button("start-global", id="start-global"),
+        html.Div(id="output"),
+        html.Div(id="output-global"),
+    ]
+
+    def on_callback_error(err):
+        return f"callback: {err}"
+
+    @app.callback(
+        Output("output", "children"),
+        Input("start-local", "n_clicks"),
+        on_error=on_callback_error,
+        prevent_initial_call=True,
+    )
+    def on_start(_):
+        raise Exception("local error")
+
+    @app.callback(
+        Output("output-global", "children"),
+        Input("start-global", "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def on_start_global(_):
+        raise Exception("global error")
+
+    dash_duo.start_server(app)
+    dash_duo.find_element("#start-local").click()
+
+    dash_duo.wait_for_text_to_equal("#output", "callback: local error")
+
+    dash_duo.find_element("#start-global").click()
+    dash_duo.wait_for_text_to_equal("#output-global", "global: global error")

--- a/tests/integration/callbacks/test_callback_error.py
+++ b/tests/integration/callbacks/test_callback_error.py
@@ -1,9 +1,9 @@
-from dash import Dash, html, Input, Output
+from dash import Dash, html, Input, Output, set_props
 
 
 def test_cber001_error_handler(dash_duo):
     def global_callback_error_handler(err):
-        return f"global: {err}"
+        set_props("output-global", {"children": f"global: {err}"})
 
     app = Dash(on_error=global_callback_error_handler)
 
@@ -15,7 +15,7 @@ def test_cber001_error_handler(dash_duo):
     ]
 
     def on_callback_error(err):
-        return f"callback: {err}"
+        set_props("output", {"children": f"callback: {err}"})
 
     @app.callback(
         Output("output", "children"),

--- a/tests/integration/long_callback/app_bg_on_error.py
+++ b/tests/integration/long_callback/app_bg_on_error.py
@@ -1,4 +1,4 @@
-from dash import Dash, Input, Output, html
+from dash import Dash, Input, Output, html, set_props
 from tests.integration.long_callback.utils import get_long_callback_manager
 
 long_callback_manager = get_long_callback_manager()
@@ -6,8 +6,7 @@ handle = long_callback_manager.handle
 
 
 def global_error_handler(err):
-
-    return f"global: {err}"
+    set_props("global-output", {"children": f"global: {err}"})
 
 
 app = Dash(
@@ -23,7 +22,7 @@ app.layout = [
 
 
 def callback_on_error(err):
-    return f"callback: {err}"
+    set_props("cb-output", {"children": f"callback: {err}"})
 
 
 @app.callback(

--- a/tests/integration/long_callback/app_bg_on_error.py
+++ b/tests/integration/long_callback/app_bg_on_error.py
@@ -1,0 +1,51 @@
+from dash import Dash, Input, Output, html
+from tests.integration.long_callback.utils import get_long_callback_manager
+
+long_callback_manager = get_long_callback_manager()
+handle = long_callback_manager.handle
+
+
+def global_error_handler(err):
+
+    return f"global: {err}"
+
+
+app = Dash(
+    __name__, long_callback_manager=long_callback_manager, on_error=global_error_handler
+)
+
+app.layout = [
+    html.Button("callback on_error", id="start-cb-onerror"),
+    html.Div(id="cb-output"),
+    html.Button("global on_error", id="start-global-onerror"),
+    html.Div(id="global-output"),
+]
+
+
+def callback_on_error(err):
+    return f"callback: {err}"
+
+
+@app.callback(
+    Output("cb-output", "children"),
+    Input("start-cb-onerror", "n_clicks"),
+    prevent_initial_call=True,
+    background=True,
+    on_error=callback_on_error,
+)
+def on_click(_):
+    raise Exception("callback error")
+
+
+@app.callback(
+    Output("global-output", "children"),
+    Input("start-global-onerror", "n_clicks"),
+    prevent_initial_call=True,
+    background=True,
+)
+def on_click_global(_):
+    raise Exception("global error")
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/tests/integration/long_callback/test_basic_long_callback018.py
+++ b/tests/integration/long_callback/test_basic_long_callback018.py
@@ -7,7 +7,7 @@ def test_lcbc018_background_callback_on_error(dash_duo, manager):
 
         dash_duo.find_element("#start-cb-onerror").click()
 
-        dash_duo.wait_for_text_to_equal("#cb-output", "callback: callback error")
+        dash_duo.wait_for_contains_text("#cb-output", "callback error")
 
         dash_duo.find_element("#start-global-onerror").click()
-        dash_duo.wait_for_text_to_equal("#global-output", "global: global error")
+        dash_duo.wait_for_contains_text("#global-output", "global error")

--- a/tests/integration/long_callback/test_basic_long_callback018.py
+++ b/tests/integration/long_callback/test_basic_long_callback018.py
@@ -1,7 +1,7 @@
 from tests.integration.long_callback.utils import setup_long_callback_app
 
 
-def test_lcbc017_long_callback_set_props(dash_duo, manager):
+def test_lcbc018_background_callback_on_error(dash_duo, manager):
     with setup_long_callback_app(manager, "app_bg_on_error") as app:
         dash_duo.start_server(app)
 

--- a/tests/integration/long_callback/test_basic_long_callback018.py
+++ b/tests/integration/long_callback/test_basic_long_callback018.py
@@ -1,0 +1,13 @@
+from tests.integration.long_callback.utils import setup_long_callback_app
+
+
+def test_lcbc017_long_callback_set_props(dash_duo, manager):
+    with setup_long_callback_app(manager, "app_bg_on_error") as app:
+        dash_duo.start_server(app)
+
+        dash_duo.find_element("#start-cb-onerror").click()
+
+        dash_duo.wait_for_text_to_equal("#cb-output", "callback: callback error")
+
+        dash_duo.find_element("#start-global-onerror").click()
+        dash_duo.wait_for_text_to_equal("#global-output", "global: global error")

--- a/tests/integration/long_callback/utils.py
+++ b/tests/integration/long_callback/utils.py
@@ -18,8 +18,14 @@ class TestDiskCacheManager(DiskcacheManager):
         super().__init__(cache=cache, cache_by=cache_by, expire=expire)
         self.running_jobs = []
 
-    def call_job_fn(self, key, job_fn, args, context, on_error=None):
-        pid = super().call_job_fn(key, job_fn, args, context, on_error=on_error)
+    def call_job_fn(
+        self,
+        key,
+        job_fn,
+        args,
+        context,
+    ):
+        pid = super().call_job_fn(key, job_fn, args, context)
         self.running_jobs.append(pid)
         return pid
 

--- a/tests/integration/long_callback/utils.py
+++ b/tests/integration/long_callback/utils.py
@@ -18,8 +18,8 @@ class TestDiskCacheManager(DiskcacheManager):
         super().__init__(cache=cache, cache_by=cache_by, expire=expire)
         self.running_jobs = []
 
-    def call_job_fn(self, key, job_fn, args, context):
-        pid = super().call_job_fn(key, job_fn, args, context)
+    def call_job_fn(self, key, job_fn, args, context, on_error=None):
+        pid = super().call_job_fn(key, job_fn, args, context, on_error=on_error)
         self.running_jobs.append(pid)
         return pid
 
@@ -135,8 +135,9 @@ def setup_long_callback_app(manager_name, app_name):
             # Sleep for a couple of intervals
             time.sleep(2.0)
 
-            for job in manager.running_jobs:
-                manager.terminate_job(job)
+            if hasattr(manager, "running_jobs"):
+                for job in manager.running_jobs:
+                    manager.terminate_job(job)
 
             shutil.rmtree(cache_directory, ignore_errors=True)
             os.environ.pop("LONG_CALLBACK_MANAGER")


### PR DESCRIPTION
Add two error handler to call when a callback raise an exception, the return value of the handler is instead used as output. The callback context can be used to differentiate the erroring callbacks and access the original inputs and states.

A global error handler can be added with a function reference to the Dash constructor:  eg:  `app = Dash(on_error=handler)`.
And a local handler for particular callback can be added to individual callback: eg: `@callback(..., on_error=handler)`.

The signature of the handler function is: `def func(error: Exception) -> None`. `set_props` can be used to set extra props or the original output.

Example:
```python
def global_callback_error_handler(err):
    set_props("output-global": {"children": "error: {err}")

app = Dash(on_error=global_callback_error_handler)

app.layout = [
    html.Button("start", id="start-local"),
    html.Button("start-global", id="start-global"),
    html.Div(id="output"),
    html.Div(id="output-global"),
]

def on_callback_error(err):
    set_props("output": {"children": "callback error: {err}")

@app.callback(
    Output("output", "children"),
    Input("start-local", "n_clicks"),
    on_error=on_callback_error,
    prevent_initial_call=True,
)
def on_start(_):
    raise Exception("local error")

@app.callback(
    Output("output-global", "children"),
    Input("start-global", "n_clicks"),
    prevent_initial_call=True,
)
def on_start_global(_):
    raise Exception("global error")
```

Partially based of #2829 to catch exception and call a function instead of a decorator pattern and also works with background callbacks.

Closes #2348 