### PR TITLE
Evaluate HOST, PORT, and PROXY env vars when Dash.run() is invoked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2898](https://github.com/plotly/dash/pull/2898) Fix error thrown when using non-existent components in callback running keyword. Fixes [#2897](https://github.com/plotly/dash/issues/2897).
 - [#2892](https://github.com/plotly/dash/pull/2860) Fix ensures dcc.Dropdown menu maxHeight option works with Datatable. Fixes [#2529](https://github.com/plotly/dash/issues/2529) [#2225](https://github.com/plotly/dash/issues/2225)
 - [#2896](https://github.com/plotly/dash/pull/2896) The tabIndex parameter of Div can accept number or string type. Fixes [#2891](https://github.com/plotly/dash/issues/2891)
+- [#2908](https://github.com/plotly/dash/pull/2908) Fix when environment variables are ignored by Dash.run() at runtime. Fixes [#2902](https://github.com/plotly/dash/issues/2902)
 
 ## [2.17.1] - 2024-06-12
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -2109,6 +2109,12 @@ class Dash:
             dev_tools_prune_errors,
         )
 
+        # Evaluate the env variables at runtime
+
+        host = os.getenv("HOST", host)
+        port = os.getenv("PORT", port)
+        proxy = os.getenv("DASH_PROXY", proxy)
+
         # Verify port value
         try:
             port = int(port)

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1981,8 +1981,8 @@ class Dash:
 
     def run(
         self,
-        host=None,
-        port=None,
+        host="127.0.0.1",
+        port="8050",
         proxy=None,
         debug=None,
         jupyter_mode: JupyterDisplayMode = None,

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1981,9 +1981,9 @@ class Dash:
 
     def run(
         self,
-        host=os.getenv("HOST", "127.0.0.1"),
-        port=os.getenv("PORT", "8050"),
-        proxy=os.getenv("DASH_PROXY", None),
+        host=None,
+        port=None,
+        proxy=None,
         debug=None,
         jupyter_mode: JupyterDisplayMode = None,
         jupyter_width="100%",


### PR DESCRIPTION
Fixes #2902 

Made the changes as proposed in #2902. Nothing major, just re-evaluates environment variables when `Dash.run()` is invoked.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Evaluate the environment variable after Dash.run() is called
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
