### PR TITLE
Fixes hash_function and error handler missing call for multi

### DIFF
--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -507,7 +507,7 @@ def register_callback(
                             if not multi:
                                 output_value = NoUpdate()
                             else:
-                                output_value = [NoUpdate for _ in output_spec]
+                                output_value = [NoUpdate() for _ in output_spec]
                     else:
                         raise err
 

--- a/dash/long_callback/managers/__init__.py
+++ b/dash/long_callback/managers/__init__.py
@@ -107,8 +107,11 @@ class BaseLongCallbackManager(ABC):
 
     @staticmethod
     def hash_function(fn, callback_id=""):
-        fn_source = inspect.getsource(fn)
-        fn_str = fn_source
+        try:
+            fn_source = inspect.getsource(fn)
+            fn_str = fn_source
+        except OSError:  # pylint: disable=too-broad-exception
+            fn_str = getattr(fn, "__name__", "")
         return hashlib.sha256(
             callback_id.encode("utf-8") + fn_str.encode("utf-8")
         ).hexdigest()


### PR DESCRIPTION
- Fix #1885, fallback on function name if the source is not available.
- Fix missing `NoUpdate()` for multi output callbacks error handler.