### PR TITLE
Add Support for TypeScript 5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Added
 
 - [#2881](https://github.com/plotly/dash/pull/2881) Add outputs_list to window.dash_clientside.callback_context. Fixes [#2877](https://github.com/plotly/dash/issues/2877).
+- [#2936](https://github.com/plotly/dash/pull/2936) Adds support for TypeScript 5.5+.
 
 ## Fixed
 

--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -37,7 +37,7 @@ if (!src.length) {
 }
 
 if (fs.existsSync('tsconfig.json')) {
-    tsconfig = ts.getParsedCommandLineOfConfigFile('tsconfig.json', {}, ts.sys);
+    tsconfig = ts.getParsedCommandLineOfConfigFile('tsconfig.json', { esModuleInterop: true }, ts.sys);
 }
 
 let failedBuild = false;
@@ -187,7 +187,7 @@ function gatherComponents(sources, components = {}) {
         return components;
     }
 
-    const program = ts.createProgram(filepaths, {...tsconfig, esModuleInterop: true});
+    const program = ts.createProgram(filepaths, tsconfig);
     const checker = program.getTypeChecker();
 
     const coerceValue = t => {

--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -37,24 +37,7 @@ if (!src.length) {
 }
 
 if (fs.existsSync('tsconfig.json')) {
-    tsconfig = JSON.parse(fs.readFileSync('tsconfig.json')).compilerOptions;
-    // Map moduleResolution to the appropriate enum.
-    switch (tsconfig.moduleResolution) {
-        case 'node':
-            tsconfig.moduleResolution = ts.ModuleResolutionKind.NodeJs;
-            break;
-        case 'node16':
-            tsconfig.moduleResolution = ts.ModuleResolutionKind.Node16;
-            break;
-        case 'nodenext':
-            tsconfig.moduleResolution = ts.ModuleResolutionKind.NodeNext;
-            break;
-        case 'classic':
-            tsconfig.moduleResolution = ts.ModuleResolutionKind.Classic;
-            break;
-        default:
-            break;
-    }
+    tsconfig = ts.getParsedCommandLineOfConfigFile('tsconfig.json', {}, ts.sys);
 }
 
 let failedBuild = false;


### PR DESCRIPTION
TypeScript 5.5 [adds a hard check](https://github.com/microsoft/TypeScript/pull/58388) to prevent `ts.createProgam` from being called on improperly parsed tsconfig files. Fortunately, the error message politely points out what function you can use to parse the tsconfig file. Hooray for [code review](https://github.com/microsoft/TypeScript/pull/58388#discussion_r1586614476)! However, this change should be broadly backwards-compatible, as this function has been present in TypeScript [since version 2.8](https://github.com/microsoft/TypeScript/pull/21410).

## Contributor Checklist

- [ ] ~I have broken down my PR scope into the following TODO tasks~ N/A
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] ~I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR~ N/A

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] ~If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows~ N/A
