### PR TITLE
🐛 add missing useEffect dependency to dcc.Loading component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2900](https://github.com/plotly/dash/pull/2900) Allow strings in layout list. Fixes [#2890](https://github.com/plotly/dash/issues/2890)
 - [#2908](https://github.com/plotly/dash/pull/2908) Fix when environment variables are ignored by Dash.run() at runtime. Fixes [#2902](https://github.com/plotly/dash/issues/2902)
 - [#2915](https://github.com/plotly/dash/pull/2915) Fix 'AttributeError' when layout is a function that returns a list of components. Fixes [#2905](https://github.com/plotly/dash/issues/2905)
+- [#2956](https://github.com/plotly/dash/pull/2956) Add missing useEffect dependency to dcc.Loading component.
 
 ## [2.17.1] - 2024-06-12
 

--- a/components/dash-core-components/src/components/Loading.react.js
+++ b/components/dash-core-components/src/components/Loading.react.js
@@ -122,7 +122,7 @@ const Loading = ({
                 }
             }
         }
-    }, [delay_hide, delay_show, loading_state, display]);
+    }, [delay_hide, delay_show, loading_state, display, showSpinner]);
 
     const Spinner = showSpinner && getSpinner(spinnerType);
 


### PR DESCRIPTION
This PR adds a missing dependency to the `useEffect` in the dcc.Loading component. This fixes a bug where it is possible for the loading spinner to be left enabled, even though loading has finished.

Fixes https://github.com/plotly/notebook-to-app/issues/1674

Note: I haven't been able to write a integration test that covers this code change precisely. The bug does not normally make an appearance - it's only in rare React race conditions that it is possible to get the "infinite loading bars".

@gvwilson since this affects internal projects, I'd love to get your team's eyes on this so we could maybe do a patch release?

## Contributor Checklist

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
