### PR TITLE
Update extract-meta.js

### DIFF
--- a/dash/extract-meta.js
+++ b/dash/extract-meta.js
@@ -97,7 +97,7 @@ const isUnionLiteral = typeObj =>
 
 function logError(error, filePath) {
     if (filePath) {
-        process.stderr.write(`Error with path ${filePath}`);
+        process.stderr.write(`Error with path ${filePath}\n`);
     }
     process.stderr.write(error + '\n');
     if (error instanceof Error) {
@@ -157,7 +157,7 @@ function parseJSX(filepath) {
         docstringWarning(doc);
         return doc;
     } catch (error) {
-        logError(error);
+        logError(error, filepath);
     }
 }
 


### PR DESCRIPTION
Added file path to the logging when an error occurs upon iterating over the props of components to fetch docs. Also added newline character after file path log statement so the path log is printed on its own line.

When building a component library, I came across a very cryptic error message during the building of the metadata. A little bit of digging showed that the problem was with the props defined in one of the components in the library, but no clue which one.

To improve the error message, I provided the file path parameter to the  `logError()` function to show the file where the error occurs. Then I noticed that the file path log statement is not properly printed: 

```
Error with path src\lib\components\core\sidebar\NavMenu.jsTypeError: Cannot convert undefined or null to object
```

The reason: the file path log statement did not have a newline character at the end. So I added that. The improved log statement is: 
```
Error with path src\lib\components\core\sidebar\NavMenu.js
TypeError: Cannot convert undefined or null to object
```

## Contributor Checklist
- [ ] I tried running tests locally, but my pc crashed. I tested manually with the component library I was working on
- [x] No tests added

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
