### PR TITLE
Change selenium version to avoid depecration warnings

### DIFF
--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -5,7 +5,7 @@ lxml>=4.6.2
 percy>=2.0.2
 pytest>=6.0.2
 requests[security]>=2.21.0
-selenium>=3.141.0,<=4.2.0
+selenium>=3.141.0,<=4.6.1
 waitress>=1.4.4
 multiprocess>=0.70.12
 psutil>=5.8.0


### PR DESCRIPTION
Some tools depending on Dash have been facing the same deprecation warning from issue #2590, which can be solved by modifying the selenium upper range version to 4.6.1, as found in https://stackoverflow.com/questions/75382508/deprecationwarning-httpresponse-getheader-is-deprecated-and-will-be-removed-i. I've tested the change in python versions 3.8.x, 3.9.x, 3.10.x, 3.11.x and 3.12.x and no problem has been found.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Change selenium version range
   -  [x] Run tests from python 3.8 to 3.12 to check if this change could break the tests
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
