### PR TITLE
Deprecation notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED]
+
+## Deprecated
+
+- [#2985](https://github.com/plotly/dash/pull/2985) Deprecate dynamic component loader.
+- [#2985](https://github.com/plotly/dash/pull/2985) Deprecate `run_server`, use `run` instead.
+- [#2899](https://github.com/plotly/dash/pull/2899) Deprecate `dcc.LogoutButton`, can be replaced with a `html.Button` or `html.A`. eg: `html.A(href=os.getenv('DASH_LOGOUT_URL'))` on a Dash Enterprise instance.
+
 ## [2.18.0] - 2024-09-04
 
 ## Added

--- a/components/dash-core-components/tests/integration/location/test_location_logout.py
+++ b/components/dash-core-components/tests/integration/location/test_location_logout.py
@@ -1,58 +1,30 @@
-from dash.exceptions import PreventUpdate
 from dash import Dash, Input, Output, dcc, html
-import flask
 import pytest
 import time
 
 
 @pytest.mark.parametrize("add_initial_logout_button", [False, True])
 def test_llgo001_location_logout(dash_dcc, add_initial_logout_button):
+    # FIXME: Logout button is deprecated, remove this test for dash 3.0
     app = Dash(__name__)
-
-    @app.server.route("/_logout", methods=["POST"])
-    def on_logout():
-        rep = flask.redirect("/logged-out")
-        rep.set_cookie("logout-cookie", "", 0)
-        return rep
-
-    layout_children = [
-        html.H2("Logout test"),
-        dcc.Location(id="location"),
-        html.Div(id="content"),
-    ]
-    if add_initial_logout_button:
-        layout_children.append(dcc.LogoutButton())
-    app.layout = html.Div(layout_children)
-
-    @app.callback(Output("content", "children"), [Input("location", "pathname")])
-    def on_location(location_path):
-        if location_path is None:
-            raise PreventUpdate
-
-        if "logged-out" in location_path:
-            return "Logged out"
-        else:
-
-            @flask.after_this_request
-            def _insert_cookie(rep):
-                rep.set_cookie("logout-cookie", "logged-in")
-                return rep
-
-            return dcc.LogoutButton(id="logout-btn", logout_url="/_logout")
 
     with pytest.warns(
         DeprecationWarning,
         match="The Logout Button is no longer used with Dash Enterprise and can be replaced with a html.Button or html.A.",
     ):
-        dash_dcc.start_server(app)
-        time.sleep(1)
-        dash_dcc.percy_snapshot("Core Logout button")
+        app.layout = [
+            html.H2("Logout test"),
+            html.Div(id="content"),
+        ]
+        if add_initial_logout_button:
+            app.layout.append(dcc.LogoutButton())
+        else:
 
-        assert dash_dcc.driver.get_cookie("logout-cookie")["value"] == "logged-in"
+            @app.callback(Output("content", "children"), Input("content", "id"))
+            def on_location(location_path):
+                return dcc.LogoutButton(id="logout-btn", logout_url="/_logout")
 
-        dash_dcc.wait_for_element("#logout-btn").click()
-        dash_dcc.wait_for_text_to_equal("#content", "Logged out")
+            dash_dcc.start_server(app)
+            time.sleep(1)
 
-        assert not dash_dcc.driver.get_cookie("logout-cookie")
-
-        assert dash_dcc.get_logs() == []
+            assert dash_dcc.get_logs() == []

--- a/dash/_validate.py
+++ b/dash/_validate.py
@@ -1,8 +1,6 @@
 import sys
-from collections import defaultdict
 from collections.abc import MutableSequence
 import re
-import warnings
 from textwrap import dedent
 from keyword import iskeyword
 import flask
@@ -424,21 +422,6 @@ def validate_layout(layout, layout_value):
     component_ids = set()
 
     def _validate(value):
-        def _validate_type(comp):
-            deprecated_components = defaultdict(lambda: defaultdict(dict))
-            deprecated_components["dash_core_components"][
-                "LogoutButton"
-            ] = """
-                The Logout Button is no longer used with Dash Enterprise and can be replaced with a html.Button or html.A.
-                eg: html.A(href=os.getenv('DASH_LOGOUT_URL'))
-            """
-
-            _type = getattr(comp, "_type", "")
-            _ns = getattr(comp, "_namespace", "")
-            deprecation_message = deprecated_components[_ns][_type]
-            if deprecation_message:
-                warnings.warn(dedent(deprecation_message), DeprecationWarning)
-
         def _validate_id(comp):
             component_id = stringify_id(getattr(comp, "id", None))
             if component_id and component_id in component_ids:
@@ -449,11 +432,9 @@ def validate_layout(layout, layout_value):
                 )
             component_ids.add(component_id)
 
-        _validate_type(value)
         _validate_id(value)
 
         for component in value._traverse():  # pylint: disable=protected-access
-            _validate_type(component)
             _validate_id(component)
 
     if isinstance(layout_value, (list, tuple)):

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -2256,4 +2256,9 @@ class Dash:
 
         See `app.run` for usage information.
         """
+        warnings.warn(
+            DeprecationWarning(
+                "Dash.run_server is deprecated and will be removed in Dash 3.0"
+            )
+        )
         self.run(*args, **kwargs)

--- a/dash/development/component_loader.py
+++ b/dash/development/component_loader.py
@@ -1,6 +1,8 @@
 import collections
 import json
 import os
+import warnings
+
 
 from ._py_components_generation import (
     generate_class_file,
@@ -34,7 +36,13 @@ def load_components(metadata_path, namespace="default_namespace"):
     components -- a list of component objects with keys
     `type`, `valid_kwargs`, and `setup`.
     """
-
+    warnings.warn(
+        DeprecationWarning(
+            "Dynamic components loading has been deprecated and will be removed"
+            " in dash 3.0.\n"
+            f"Update {namespace} to generate components with dash-generate-components"
+        )
+    )
     # Register the component lib for index include.
     ComponentRegistry.registry.add(namespace)
     components = []


### PR DESCRIPTION
Add deprecation notices:

- Deprecate `Dash.run_server`, use `Dash.run` instead.
- Deprecate dynamic component loader, used by old libraries (Created during early dash 0 version, before the component generator). These components are loaded directly from the metadata json and the classes are created at runtime, preventing the use of auto complete and upcoming typing for the components.

