### PR TITLE
Keep doc-string order for shape or exact props

### DIFF
--- a/@plotly/dash-test-components/src/components/ShapeOrExactKeepOrderComponent.js
+++ b/@plotly/dash-test-components/src/components/ShapeOrExactKeepOrderComponent.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const ShapeOrExactKeepOrderComponent = (props) => {
+    const { id } = props;
+
+    return (
+        <div id={id} />
+    );
+}
+ShapeOrExactKeepOrderComponent.propTypes = {
+    id: PropTypes.string,
+    /**
+     * test prop for shape
+     */
+    shape_test_prop: PropTypes.shape({
+        /**
+         * z
+         */
+        z: PropTypes.string,
+        /**
+         * a
+         */
+        a: PropTypes.string,
+        /**
+         * y
+         */
+        y: PropTypes.string
+    }),
+    /**
+     * test prop for exact
+     */
+    exact_test_prop: PropTypes.exact({
+        /**
+         * z
+         */
+        z: PropTypes.string,
+        /**
+         * a
+         */
+        a: PropTypes.string,
+        /**
+         * y
+         */
+        y: PropTypes.string
+    }),
+}
+
+export default ShapeOrExactKeepOrderComponent;

--- a/@plotly/dash-test-components/src/index.js
+++ b/@plotly/dash-test-components/src/index.js
@@ -11,6 +11,7 @@ import ComponentAsProp from './components/ComponentAsProp';
 import DrawCounter from './components/DrawCounter';
 import AddPropsComponent from "./components/AddPropsComponent";
 import ReceivePropsComponent from "./components/ReceivePropsComponent";
+import ShapeOrExactKeepOrderComponent from "./components/ShapeOrExactKeepOrderComponent";
 
 
 export {
@@ -25,5 +26,6 @@ export {
     ComponentAsProp,
     DrawCounter,
     AddPropsComponent,
-    ReceivePropsComponent
+    ReceivePropsComponent,
+    ShapeOrExactKeepOrderComponent
 };

--- a/dash/development/_py_components_generation.py
+++ b/dash/development/_py_components_generation.py
@@ -557,7 +557,7 @@ def map_js_to_py_types_prop_types(type_object, indent_num):
                 default=prop.get("defaultValue"),
                 indent_num=indent_num + 2,
             )
-            for prop_name, prop in sorted(list(type_object["value"].items()))
+            for prop_name, prop in list(type_object["value"].items())
         )
 
     def array_of():


### PR DESCRIPTION
In developing custom components, parameters defined by `PropTypes.shape` or `PropTypes.exact` should ensure that the automatically generated `doc-string` follows the original order in the source code.

Closes #2990 

<p align="center" >
<img height=600 src="https://github.com/user-attachments/assets/74b946db-9977-4d91-bcac-23198c3289b6" />
</ p>
