### PR TITLE
Deprecate plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2985](https://github.com/plotly/dash/pull/2985) Deprecate dynamic component loader.
 - [#2985](https://github.com/plotly/dash/pull/2985) Deprecate `run_server`, use `run` instead.
 - [#2899](https://github.com/plotly/dash/pull/2899) Deprecate `dcc.LogoutButton`, can be replaced with a `html.Button` or `html.A`. eg: `html.A(href=os.getenv('DASH_LOGOUT_URL'))` on a Dash Enterprise instance.
+- [#2995](https://github.com/plotly/dash/pull/2995) Deprecate `Dash.__init__` keywords:
+  - The `plugins` keyword will be removed.
+  - Old `long_callback_manager` keyword will be removed, can use `background_callback_manager` instead.
 
 ## [2.18.0] - 2024-09-04
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -547,6 +547,13 @@ class Dash:
 
         self._assets_files = []
         self._long_callback_count = 0
+        if long_callback_manager:
+            warnings.warn(
+                DeprecationWarning(
+                    "`long_callback_manager` is deprecated and will be remove in dash 3.0, "
+                    "use `background_callback_manager` instead."
+                )
+            )
         self._background_manager = background_callback_manager or long_callback_manager
 
         self.logger = logging.getLogger(__name__)

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -550,7 +550,7 @@ class Dash:
         if long_callback_manager:
             warnings.warn(
                 DeprecationWarning(
-                    "`long_callback_manager` is deprecated and will be remove in dash 3.0, "
+                    "`long_callback_manager` is deprecated and will be remove in Dash 3.0, "
                     "use `background_callback_manager` instead."
                 )
             )

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -566,8 +566,8 @@ class Dash:
         ):
             warnings.warn(
                 DeprecationWarning(
-                    "plugins will be removed from Dash init in dash 3.0 and will be replaced by"
-                    " a new system."
+                    "The `plugins` keyword will be removed from Dash init in Dash 3.0 "
+                    "and replaced by a new hook system."
                 )
             )
             for plugin in plugins:

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -557,6 +557,12 @@ class Dash:
         if plugins is not None and isinstance(
             plugins, patch_collections_abc("Iterable")
         ):
+            warnings.warn(
+                DeprecationWarning(
+                    "plugins will be removed from Dash init in dash 3.0 and will be replaced by"
+                    " a new system."
+                )
+            )
             for plugin in plugins:
                 plugin.plug(self)
 


### PR DESCRIPTION
Deprecate the `plugins` keyword from the Dash `__init__`, will be removed in dash 3.0 in favor of a system that allows auto activation from pip installed package.

I don't think the system was much used, the only documentation is from the `Dash.__init__` docstring. 