### PR TITLE
Fix no output callback and error handler.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#2994](https://github.com/plotly/dash/pull/2994) Keep generated doc-string order for shape or exact props. Fixes [#2990](https://github.com/plotly/dash/issues/2990)
 - [#3011](https://github.com/plotly/dash/pull/3011) Fixed an exception error caused by assigning `None` to array properties with `exact` or `shape` element types. Fixes [#3010](https://github.com/plotly/dash/issues/3010)
 - [#2991](https://github.com/plotly/dash/pull/2991) Add support for URL decoding of the search parameter for pages.
+- [#3025](https://github.com/plotly/dash/pull/3025) Fix no output callback with error handler setting the response to NoUpdate and triggering an error.
 
 ## [2.18.1] - 2024-09-12
 

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -508,7 +508,7 @@ def register_callback(
                         output_value = error_handler(err)
 
                         # If the error returns nothing, automatically puts NoUpdate for response.
-                        if output_value is None:
+                        if output_value is None and has_output:
                             output_value = NoUpdate()
                     else:
                         raise err


### PR DESCRIPTION
When  a no output callback has an error handle, it would set the output result to NoOutput and trigger an error. This fix so it only set if there is outputs.
