### PR TITLE
Allow jupyterlab v4 in dependency constraints

### DIFF
--- a/@plotly/dash-jupyterlab/package.json
+++ b/@plotly/dash-jupyterlab/package.json
@@ -33,9 +33,9 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^2.0.0 || ^3.0.0",
-    "@jupyterlab/notebook": "^2.0.0 || ^3.0.0",
-    "@jupyterlab/console": "^2.0.0 || ^3.0.0"
+    "@jupyterlab/application": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "@jupyterlab/notebook": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "@jupyterlab/console": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
     "prettier": "2.0.5",

--- a/@plotly/dash-jupyterlab/package.json
+++ b/@plotly/dash-jupyterlab/package.json
@@ -34,14 +34,15 @@
   },
   "dependencies": {
     "@jupyterlab/application": "^2.0.0 || ^3.0.0 || ^4.0.0",
-    "@jupyterlab/notebook": "^2.0.0 || ^3.0.0 || ^4.0.0",
-    "@jupyterlab/console": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "@jupyterlab/console": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "@jupyterlab/notebook": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "devDependencies": {
+    "@types/json-schema": "^7.0.15",
+    "mkdirp": "^0.5.1",
     "prettier": "2.0.5",
     "rimraf": "3.0.2",
-    "typescript": "3.9.3",
-    "mkdirp": "^0.5.1"
+    "typescript": "5.6.2"
   },
   "jupyterlab": {
     "extension": true

--- a/@plotly/dash-jupyterlab/tsconfig.json
+++ b/@plotly/dash-jupyterlab/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "lib": ["es2015", "dom"],
+    "lib": ["es2018", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",
     "noEmitOnError": true,
@@ -10,7 +10,7 @@
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": false,
-    "target": "es2015",
+    "target": "es2018",
     "types": [],
     "esModuleInterop": true
   },


### PR DESCRIPTION
Fixes https://github.com/plotly/dash/issues/2804 and https://github.com/plotly/dash/issues/2998

The current `dash` extension for `jupyterlab` cannot be installed with `jupyerlab v4`. In practice, it means that the backend is not able to communicate with the juperlab frontend to retrieve the base URL when using the `jupyter_dash.infer_jupyter_proxy_config()` method. I made it work by simply changing the dependency constraints and it is now working. 
