### PR TITLE
Remove whitespace in metadata.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#3011](https://github.com/plotly/dash/pull/3011) Fixed an exception error caused by assigning `None` to array properties with `exact` or `shape` element types. Fixes [#3010](https://github.com/plotly/dash/issues/3010)
 - [#2991](https://github.com/plotly/dash/pull/2991) Add support for URL decoding of the search parameter for pages.
 - [#3025](https://github.com/plotly/dash/pull/3025) Fix no output callback with error handler setting the response to NoUpdate and triggering an error.
+- [#3034](https://github.com/plotly/dash/pull/3034) Remove whitespace from `metadata.json` files to reduce package size
 
 ## [2.18.1] - 2024-09-12
 

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -138,7 +138,7 @@ def generate_components(
     with open(
         os.path.join(project_shortname, "metadata.json"), "w", encoding="utf-8"
     ) as f:
-        json.dump(metadata, f, indent=2)
+        json.dump(metadata, f, separators=(",", ":"))
 
     generate_imports(project_shortname, components)
 


### PR DESCRIPTION
Any reason we need `metadata.json` files to be human-readable? In some cases this is a large fraction of the total package size, eg https://github.com/snehilvj/dash-mantine-components/pull/347 (cc @AnnMarieW)

### optionals

- [x] I have added entry in the `CHANGELOG.md`
