### PR TITLE
Undeprecate plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#3025](https://github.com/plotly/dash/pull/3025) Fix no output callback with error handler setting the response to NoUpdate and triggering an error.
 - [#3034](https://github.com/plotly/dash/pull/3034) Remove whitespace from `metadata.json` files to reduce package size.
 - [#3009](https://github.com/plotly/dash/pull/3009) Performance improvement on (pattern-matching) callbacks.
+- [3028](https://github.com/plotly/dash/pull/3028) Fix jupyterlab v4 support.
 
 ## [2.18.1] - 2024-09-12
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -564,12 +564,6 @@ class Dash:
         if plugins is not None and isinstance(
             plugins, patch_collections_abc("Iterable")
         ):
-            warnings.warn(
-                DeprecationWarning(
-                    "The `plugins` keyword will be removed from Dash init in Dash 3.0 "
-                    "and replaced by a new hook system."
-                )
-            )
             for plugin in plugins:
                 plugin.plug(self)
 


### PR DESCRIPTION
- Remove deprecation on `Dash(plugins)` keyword, I missed that it was used by our dash-embedded. New system is called hooks #3029 
- Add missing changelog from #3028