### PR TITLE
exclude fencedframe

### DIFF
--- a/components/dash-html-components/scripts/extract-elements.js
+++ b/components/dash-html-components/scripts/extract-elements.js
@@ -21,7 +21,8 @@ function extractElements($) {
         'image', 'dir', 'tt', 'applet', 'noembed', 'bgsound', 'menu', 'menuitem',
         'noframes',
         // experimental, don't add yet
-        'portal'
+        'portal',
+        'fencedframe'
     ];
     // `<section>` is for some reason missing from the reference tables.
     const addElements = [


### PR DESCRIPTION
New `fencedframe` element is not supported.