### PR TITLE
Fallback on long callback function names if source cannot be found

### DIFF
--- a/dash/long_callback/managers/__init__.py
+++ b/dash/long_callback/managers/__init__.py
@@ -55,7 +55,11 @@ class BaseLongCallbackManager(ABC):
         raise NotImplementedError
 
     def build_cache_key(self, fn, args, cache_args_to_ignore):
-        fn_source = inspect.getsource(fn)
+        try:
+            fn_source = inspect.getsource(fn)
+            fn_str = fn_source
+        except OSError:  # pylint: disable=too-broad-exception
+            fn_str = getattr(fn, "__name__", "")
 
         if not isinstance(cache_args_to_ignore, (list, tuple)):
             cache_args_to_ignore = [cache_args_to_ignore]
@@ -68,7 +72,7 @@ class BaseLongCallbackManager(ABC):
                     arg for i, arg in enumerate(args) if i not in cache_args_to_ignore
                 ]
 
-        hash_dict = dict(args=args, fn_source=fn_source)
+        hash_dict = dict(args=args, fn_source=fn_str)
 
         if self.cache_by is not None:
             # Caching enabled


### PR DESCRIPTION
Additional patch to #2922 to fully fix #1885 
- Adds patch made in #2922 to similar code, to make long callbacks fully work in compiled binaries (eg. Pyinstaller).
