### PR TITLE
Allow `npm run lint` to work through and display all errors

### DIFF
--- a/dash/dash-renderer/package.json
+++ b/dash/dash-renderer/package.json
@@ -16,7 +16,7 @@
     "postbuild": "es-check es2015 ../deps/*.js build/*.js",
     "test": "karma start karma.conf.js --single-run",
     "format": "run-s private::format.*",
-    "lint": "run-s private::lint.*"
+    "lint": "run-s private::lint.* --continue-on-error"
   },
   "author": "chriddyp",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "format": "run-s private::format.*",
     "initialize": "run-s private::initialize.*",
     "prepare": "husky install",
-    "lint": "run-s private::lint.*",
+    "lint": "run-s private::lint.* --continue-on-error",
     "setup-tests.py": "run-s private::test.py.deploy-*",
     "setup-tests.R": "run-s private::test.R.deploy-*",
     "citest.integration": "run-s setup-tests.py private::test.integration-*",


### PR DESCRIPTION
allowing `npm run lint` to go through all linting steps providing all the errors that need to be fixed, not just the first encountered failing test