### PR TITLE
Remove werkzeug upperbound

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,5 +1,5 @@
 Flask>=1.0.4,<3.1
-Werkzeug
+Werkzeug>=3.0.6
 plotly>=5.0.0
 dash_html_components==2.0.0
 dash_core_components==2.0.0

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,5 +1,5 @@
 Flask>=1.0.4,<3.1
-Werkzeug<3.1
+Werkzeug
 plotly>=5.0.0
 dash_html_components==2.0.0
 dash_core_components==2.0.0


### PR DESCRIPTION
`werkzeug>=3.1` is compatible within the set flask boundaries. Removing the boundaries for `werkzeug` would allow for more flexible installations on deployed apps without triggering vulnerabilities.
