### PR TITLE
Bugfix: Graph component becomes unresponsive if an invalid figure is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Fixed
 
 - [#3080](https://github.com/plotly/dash/pull/3080) Fix docstring generation for components using single-line or nonstandard-indent leading comments
+- [#3103](https://github.com/plotly/dash/pull/3103) Fix Graph component becomes unresponsive if an invalid figure is passed
 
 ## [2.18.2] - 2024-11-04
 

--- a/components/dash-core-components/src/fragments/Graph.react.js
+++ b/components/dash-core-components/src/fragments/Graph.react.js
@@ -173,9 +173,9 @@ class PlotlyGraph extends Component {
         configClone.typesetMath = mathjax;
 
         const figureClone = {
-            data: figure.data,
-            layout: this.getLayout(figure.layout, responsive),
-            frames: figure.frames,
+            data: figure?.data,
+            layout: this.getLayout(figure?.layout, responsive),
+            frames: figure?.frames,
             config: configClone,
         };
 


### PR DESCRIPTION
This PR fixes a bug where a `Graph` with an invalid figure prop (for example, `figure=None`) would remain broken even after being updated to a valid figure.

See the integration test for an example Dash app that is fixed here.

Fixes https://github.com/plotly/notebook-to-app/issues/2065

## Contributor Checklist

- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
