### PR TITLE
Add very basic update notifications

### DIFF
--- a/dash/dash-renderer/src/components/error/FrontEnd/FrontEndError.react.js
+++ b/dash/dash-renderer/src/components/error/FrontEnd/FrontEndError.react.js
@@ -59,7 +59,10 @@ class FrontEndError extends Component {
         /* eslint-enable no-inline-comments */
 
         return collapsed ? (
-            <div className='dash-error-card__list-item'>{errorHeader}</div>
+            <div className='dash-error-card__list-item'>
+                {errorHeader}
+                <button onClick={this.props.onDismiss}>x</button>
+            </div>
         ) : (
             <div className={cardClasses}>
                 {errorHeader}

--- a/dash/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
+++ b/dash/dash-renderer/src/components/error/FrontEnd/FrontEndErrorContainer.react.js
@@ -3,15 +3,60 @@ import './FrontEndError.css';
 import PropTypes from 'prop-types';
 import {FrontEndError} from './FrontEndError.react';
 
+const DAY_IN_MS = 86400000;
+
+function compareVersions(v1, v2) {
+    const v1Parts = v1.split('.').map(Number);
+    const v2Parts = v2.split('.').map(Number);
+
+    for (let i = 0; i < Math.max(v1Parts.length, v2Parts.length); i++) {
+        const part1 = v1Parts[i] || 0;
+        const part2 = v2Parts[i] || 0;
+
+        if (part1 > part2) return 1;
+        if (part1 < part2) return -1;
+    }
+
+    return 0;
+}
+
 class FrontEndErrorContainer extends Component {
     constructor(props) {
         super(props);
+
+        const {config} = props;
+
+        if (!localStorage.getItem('noNotifications')) {
+            fetch('http://127.0.0.1:8080/sample', {
+                method: 'POST',
+                body: JSON.stringify({
+                    dash_version: config.dash_version
+                }),
+                headers: {
+                    'Content-Type': 'application/json'
+                }
+            }).then(response => {
+                response.json().then(body => {
+                    this.setState({...this.state, notificationInfo: body});
+                });
+            });
+        }
+
+        this.state = {
+            dismissed: [false * this.props.errors.length],
+            notificationInfo: []
+        };
     }
 
     render() {
-        const {errors, connected, errorsOpened, clickHandler} = this.props;
+        const {errors, errorsOpened} = this.props;
+        const {dismissed, notificationInfo} = this.state;
         const errorsLength = errors.length;
-        if (errorsLength === 0 || !errorsOpened) {
+
+        if (
+            (errorsLength === 0 || !errorsOpened) &&
+            notificationInfo.length === 0
+        ) {
             return null;
         }
 
@@ -19,29 +64,125 @@ class FrontEndErrorContainer extends Component {
         let cardClasses = 'dash-error-card dash-error-card--container';
 
         const errorElements = errors.map((error, i) => {
-            return <FrontEndError e={error} isListItem={true} key={i} />;
+            if (dismissed[i]) {
+                return null;
+            }
+            return (
+                <FrontEndError
+                    e={error}
+                    isListItem={true}
+                    key={i}
+                    onDismiss={() => {
+                        dismissed[i] = true;
+                        this.setState({dismissed: dismissed});
+                    }}
+                />
+            );
         });
+
+        const setDontShowAgain = i => {
+            // Set local storage to record the last dismissed notification
+            localStorage.setItem('noNotifications', true);
+
+            dismissed[errorsLength + i] = true;
+            this.setState({dismissed: dismissed});
+        };
+
+        const setRemindMeLater = i => {
+            // Set local storage to record the last dismissed notification
+            localStorage.setItem('lastDismissed', Date.now());
+
+            dismissed[errorsLength + i] = true;
+            this.setState({dismissed: dismissed});
+        };
+
+        const setSkipThisVersion = i => {
+            // Set local storage to record the last dismissed version
+            localStorage.setItem(
+                'lastDismissedVersion',
+                notificationInfo[i].version
+            );
+
+            dismissed[errorsLength + i] = true;
+            this.setState({dismissed: dismissed});
+        };
+
+        const notificationElements = notificationInfo.map((notification, i) => {
+            const wasDismissedInLastDay =
+                Date.now() - localStorage.getItem('lastDismissed') < DAY_IN_MS;
+            const lastDismissedVersion = localStorage.getItem(
+                'lastDismissedVersion'
+            );
+            const hasDismissedVersion =
+                lastDismissedVersion !== null &&
+                compareVersions(lastDismissedVersion, notification.version) ==
+                    0;
+            if (
+                dismissed[errorsLength + i] ||
+                wasDismissedInLastDay ||
+                hasDismissedVersion ||
+                localStorage.getItem('noNotifications')
+            ) {
+                return null;
+            }
+            return (
+                <div
+                    key={`notification-${i}`}
+                    className='dash-error-card__list-item'
+                    style={{
+                        display: 'flex',
+                        flexDirection: 'column'
+                    }}
+                >
+                    <p>{notification.message}</p>
+                    <div className='dash-notification__buttons'>
+                        {notification.buttons.map(button => {
+                            switch (button) {
+                                case 'dont_show_again':
+                                    return (
+                                        <button
+                                            onClick={() => setDontShowAgain(i)}
+                                        >
+                                            Don't Show Again
+                                        </button>
+                                    );
+                                case 'remind_me_later':
+                                    return (
+                                        <button
+                                            onClick={() => setRemindMeLater(i)}
+                                        >
+                                            Remind Me Later
+                                        </button>
+                                    );
+                                case 'skip_this_version':
+                                    return (
+                                        <button
+                                            onClick={() =>
+                                                setSkipThisVersion(i)
+                                            }
+                                        >
+                                            Skip This Version
+                                        </button>
+                                    );
+                                default:
+                                    return null;
+                            }
+                        })}
+                    </div>
+                </div>
+            );
+        });
+
         if (inAlertsTray) {
             cardClasses += ' dash-error-card--alerts-tray';
         }
+
         return (
             <div className={cardClasses}>
-                <div className='dash-error-card__topbar'>
-                    <div className='dash-error-card__message'>
-                        🛑 Errors (
-                        <strong className='test-devtools-error-count'>
-                            {errorsLength}
-                        </strong>
-                        ){connected ? null : '\u00a0 🚫 Server Unavailable'}
-                    </div>
-                    <div
-                        className='dash-fe-error__icon-x'
-                        onClick={() => clickHandler()}
-                    >
-                        ×
-                    </div>
+                <div className='dash-error-card__list'>
+                    {errorElements}
+                    {notificationElements}
                 </div>
-                <div className='dash-error-card__list'>{errorElements}</div>
             </div>
         );
     }
@@ -53,7 +194,8 @@ FrontEndErrorContainer.propTypes = {
     connected: PropTypes.bool,
     inAlertsTray: PropTypes.any,
     errorsOpened: PropTypes.any,
-    clickHandler: PropTypes.func
+    clickHandler: PropTypes.func,
+    config: PropTypes.object
 };
 
 FrontEndErrorContainer.propTypes = {

--- a/dash/dash-renderer/src/components/error/GlobalErrorContainer.react.js
+++ b/dash/dash-renderer/src/components/error/GlobalErrorContainer.react.js
@@ -12,7 +12,11 @@ class UnconnectedGlobalErrorContainer extends Component {
         const {config, error, children} = this.props;
         return (
             <div id='_dash-global-error-container'>
-                <DebugMenu error={error} hotReload={Boolean(config.hot_reload)}>
+                <DebugMenu
+                    config={config}
+                    error={error}
+                    hotReload={Boolean(config.hot_reload)}
+                >
                     <div id='_dash-app-content'>{children}</div>
                 </DebugMenu>
             </div>

--- a/dash/dash-renderer/src/components/error/GlobalErrorOverlay.css
+++ b/dash/dash-renderer/src/components/error/GlobalErrorOverlay.css
@@ -10,12 +10,8 @@
 
 .dash-error-card {
     box-sizing: border-box;
-    background: #ffffff;
     display: inline-block;
     /* shadow-1 */
-    box-shadow: 0px 6px 16px rgba(80, 103, 132, 0.165),
-        0px 2px 6px rgba(80, 103, 132, 0.12),
-        0px 0px 1px rgba(80, 103, 132, 0.32);
     border-radius: 4px;
     position: fixed;
     top: 16px;
@@ -23,8 +19,7 @@
     animation: dash-error-card-animation 0.5s;
     padding: 24px;
     text-align: left;
-    background-color: white;
-
+    background: transparent;
 }
 .dash-error-card--alerts-tray {
     position: absolute;

--- a/dash/dash-renderer/src/components/error/GlobalErrorOverlay.react.js
+++ b/dash/dash-renderer/src/components/error/GlobalErrorOverlay.react.js
@@ -11,7 +11,7 @@ export default class GlobalErrorOverlay extends Component {
     }
 
     render() {
-        const {visible, error, errorsOpened, clickHandler} = this.props;
+        const {visible, error, errorsOpened, clickHandler, config} = this.props;
 
         let frontEndErrors;
         if (errorsOpened) {
@@ -23,6 +23,7 @@ export default class GlobalErrorOverlay extends Component {
                     connected={error.backEndConnected}
                     errorsOpened={errorsOpened}
                     clickHandler={clickHandler}
+                    config={config}
                 />
             );
         }
@@ -44,5 +45,6 @@ GlobalErrorOverlay.propTypes = {
     visible: PropTypes.bool,
     error: PropTypes.object,
     errorsOpened: PropTypes.any,
-    clickHandler: PropTypes.func
+    clickHandler: PropTypes.func,
+    config: PropTypes.object
 };

--- a/dash/dash-renderer/src/components/error/menu/DebugMenu.react.js
+++ b/dash/dash-renderer/src/components/error/menu/DebugMenu.react.js
@@ -53,7 +53,7 @@ class DebugMenu extends Component {
     }
     render() {
         const {opened, errorsOpened, callbackGraphOpened} = this.state;
-        const {error, hotReload} = this.props;
+        const {error, hotReload, config} = this.props;
 
         const errCount = error.frontEnd.length + error.backEnd.length;
         const connected = error.backEndConnected;
@@ -148,6 +148,7 @@ class DebugMenu extends Component {
                     visible={errCount > 0}
                     errorsOpened={errorsOpened}
                     clickHandler={toggleErrors}
+                    config={config}
                 >
                     {this.props.children}
                 </GlobalErrorOverlay>
@@ -159,7 +160,8 @@ class DebugMenu extends Component {
 DebugMenu.propTypes = {
     children: PropTypes.object,
     error: PropTypes.object,
-    hotReload: PropTypes.bool
+    hotReload: PropTypes.bool,
+    config: PropTypes.object
 };
 
 export {DebugMenu};

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -766,6 +766,7 @@ class Dash:
             "update_title": self.config.update_title,
             "children_props": ComponentRegistry.children_props,
             "serve_locally": self.config.serve_locally,
+            "dash_version": __version__,
         }
         if not self.config.serve_locally:
             config["plotlyjs_url"] = self._plotlyjs_url


### PR DESCRIPTION
**Warning: Very much in-progress**

This PR adds the ability to notify dash developers of new versions of dash through the developer tools. It mostly updates the errors section of the dash developer tools frontend. The only change to python is adding an additional config passed from the python side to send the dash python version to the frontend.

The notification prompts the developer to upgrade their version of dash and has 3 options for actions:
* Don't show again -> sets a boolean flag in local storage if the user clicks. 
* Remind me later -> sets a field in local storage to the time that this button is clicked. The frontend then uses that to determine whether to show the notification again.
* Skip this version -> sets a field in local storage to the version that was received from the server. The frontend then uses that to determine whether to show the notification again. 

Todos:
- [ ] Add style to UI (There is currently no style applied to the buttons / very little applied to the notification)
- [ ] Update dev tools menu options - create separate button for toggling notifications? 
- [ ] Code cleanup - clean up handling of button clicks, clean up names of directories and files that assume notifications are errors, etc. 
- [ ] Swap in actual server information for notifications

<details> <summary>A couple of sample files to help test </summary>
Server: 

```
from flask import Flask, request
from flask_cors import CORS

app = Flask(__name__)
CORS(app)
@app.route('/sample', methods=['POST'])
def index():
    # Get contents of post request
    data = request.json
    if data['dash_version'] == current_version:
        return []
    else: 
        return [{
            'message': 'A new version of dash is available! Run `pip install dash --upgrade` to upgrade.',
            'buttons': ['dont_show_again', 'remind_me_later', 'skip_this_version'],
            'version': current_version
        }]
   

if __name__ == '__main__':
    # on port 8080
    app.run(debug=True, port=8080)
```

Dash app that adds errors to show how errors fit with these notifications:

```
## generic dash app
import dash
import dash_core_components as dcc
import dash_html_components as html
from dash.dependencies import Input, Output

app = dash.Dash(__name__)

app.layout = html.Div([
    dcc.Input(id='input', value='initial value', type='text'),
    html.Div(id='output')
])

@app.callback(
    Output(component_id='output', component_property='children'),
    [Input(component_id='input', component_property='value')]
)
def update_value(input_data):
    # Throw a sample error
    raise ValueError('This is a sample error')
    return 'Input: "{}"'.format(input_data)

if __name__ == '__main__':
    app.run_server(debug=True)
```
</details>