### PR TITLE
 is a Valid Prop

### DIFF
--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -37,21 +37,11 @@ from ._utils import (
 from . import _validate
 from .long_callback.managers import BaseLongCallbackManager
 from ._callback_context import context_value
+from ._no_update import NoUpdate
 
 
 def _invoke_callback(func, *args, **kwargs):  # used to mark the frame for the debugger
     return func(*args, **kwargs)  # %% callback invoked %%
-
-
-class NoUpdate:
-    def to_plotly_json(self):  # pylint: disable=no-self-use
-        return {"_dash_no_update": "_dash_no_update"}
-
-    @staticmethod
-    def is_no_update(obj):
-        return isinstance(obj, NoUpdate) or (
-            isinstance(obj, dict) and obj == {"_dash_no_update": "_dash_no_update"}
-        )
 
 
 GLOBAL_CALLBACK_LIST = []

--- a/dash/_no_update.py
+++ b/dash/_no_update.py
@@ -1,0 +1,9 @@
+class NoUpdate:
+    def to_plotly_json(self):  # pylint: disable=no-self-use
+        return {"_dash_no_update": "_dash_no_update"}
+
+    @staticmethod
+    def is_no_update(obj):
+        return isinstance(obj, NoUpdate) or (
+            isinstance(obj, dict) and obj == {"_dash_no_update": "_dash_no_update"}
+        )

--- a/dash/_validate.py
+++ b/dash/_validate.py
@@ -215,8 +215,6 @@ def fail_callback_output(output_value, output):
     valid_children = (str, int, float, type(None), Component, NoUpdate)
     valid_props = (str, int, float, type(None), tuple, MutableSequence, NoUpdate)
 
-    print("================================")
-
     def _raise_invalid(bad_val, outer_val, path, index=None, toplevel=False):
         bad_type = type(bad_val).__name__
         outer_id = f"(id={outer_val.id:s})" if getattr(outer_val, "id", False) else ""
@@ -264,7 +262,6 @@ def fail_callback_output(output_value, output):
         return isinstance(val, valid_props)
 
     def _can_serialize(val):
-        print("checking ability to serialize")
         if not (_valid_child(val) or _valid_prop(val)):
             return False
         try:
@@ -276,7 +273,6 @@ def fail_callback_output(output_value, output):
     def _validate_value(val, index=None):
         # val is a Component
         if isinstance(val, Component):
-            print("Is Component")
             unserializable_items = []
             # pylint: disable=protected-access
             for p, j in val._traverse_with_paths():
@@ -337,7 +333,6 @@ def fail_callback_output(output_value, output):
 
     if isinstance(output_value, list):
         for i, val in enumerate(output_value):
-            print(val)
             _validate_value(val, index=i)
     else:
         _validate_value(output_value)

--- a/dash/_validate.py
+++ b/dash/_validate.py
@@ -6,6 +6,7 @@ from keyword import iskeyword
 import flask
 
 from ._grouping import grouping_len, map_grouping
+from ._no_update import NoUpdate
 from .development.base_component import Component
 from . import exceptions
 from ._utils import (
@@ -211,8 +212,10 @@ def validate_multi_return(output_lists, output_values, callback_id):
 
 
 def fail_callback_output(output_value, output):
-    valid_children = (str, int, float, type(None), Component)
-    valid_props = (str, int, float, type(None), tuple, MutableSequence)
+    valid_children = (str, int, float, type(None), Component, NoUpdate)
+    valid_props = (str, int, float, type(None), tuple, MutableSequence, NoUpdate)
+
+    print("================================")
 
     def _raise_invalid(bad_val, outer_val, path, index=None, toplevel=False):
         bad_type = type(bad_val).__name__
@@ -261,6 +264,7 @@ def fail_callback_output(output_value, output):
         return isinstance(val, valid_props)
 
     def _can_serialize(val):
+        print("checking ability to serialize")
         if not (_valid_child(val) or _valid_prop(val)):
             return False
         try:
@@ -272,6 +276,7 @@ def fail_callback_output(output_value, output):
     def _validate_value(val, index=None):
         # val is a Component
         if isinstance(val, Component):
+            print("Is Component")
             unserializable_items = []
             # pylint: disable=protected-access
             for p, j in val._traverse_with_paths():
@@ -332,6 +337,7 @@ def fail_callback_output(output_value, output):
 
     if isinstance(output_value, list):
         for i, val in enumerate(output_value):
+            print(val)
             _validate_value(val, index=i)
     else:
         _validate_value(output_value)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,69 @@
+from types import SimpleNamespace
+
+import dash_bootstrap_components as dbc
+import plotly.graph_objects as go
+from dash import html, Dash, dcc, Input, Output, no_update, callback, dash_table
+
+
+app = Dash()
+
+app.layout = html.Div(
+        [
+            dbc.Alert(id="alert", is_open=False, duration=4000),
+            dcc.DatePickerRange(
+                id="date_picker",
+                start_date="2021-01-01",
+                end_date="2021-01-31",
+            ),
+            dcc.Graph(id="figcontainer"),
+            dash_table.DataTable(id="table"),
+        ]
+    )
+
+
+@callback(
+    Output(component_id="figcontainer", component_property="figure"),
+    Output(component_id="table", component_property="data"),
+    Output(component_id="alert", component_property="is_open"),
+    Output(component_id="alert", component_property="children"),
+    Input(component_id="date_picker", component_property="start_date"),
+    Input(component_id="date_picker", component_property="end_date"),
+)
+def update_graph(start, end):
+    df = get_bookings_in_interval(start, end)
+    # if there is no data, keep previous states and use alert
+    if type(df) is AssertionError:
+        return no_update, no_update, True, df
+
+    fig = go.Figure()
+
+    return (
+        fig.to_dict(),
+        {},
+        no_update,
+        no_update,
+    )
+
+mock_response = SimpleNamespace(
+    status_code=404,
+)
+
+# either returns a df or an AssertionError
+def get_bookings_in_interval(start, end):
+    df = None
+    try:
+        data = mock_response
+        assert data.status_code == 200, "Failed to fetch bookings"
+        parsed_data = dict(data.json())
+        assert len(parsed_data["bookings"]) > 0, "No items in Response"
+        # do something
+
+    except AssertionError as e:
+        print(e)
+        return e
+
+    return data
+
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
Solves #3090.

I was able to reproduce the error using a minimal example inferred by code provided by the issue author:

```python
from types import SimpleNamespace

import dash_bootstrap_components as dbc
import plotly.graph_objects as go
from dash import html, Dash, dcc, Input, Output, no_update, callback, dash_table


app = Dash()

app.layout = html.Div(
        [
            dbc.Alert(id="alert", is_open=False, duration=4000),
            dcc.DatePickerRange(
                id="date_picker",
                start_date="2021-01-01",
                end_date="2021-01-31",
            ),
            dcc.Graph(id="figcontainer"),
            dash_table.DataTable(id="table"),
        ]
    )


@callback(
    Output(component_id="figcontainer", component_property="figure"),
    Output(component_id="table", component_property="data"),
    Output(component_id="alert", component_property="is_open"),
    Output(component_id="alert", component_property="children"),
    Input(component_id="date_picker", component_property="start_date"),
    Input(component_id="date_picker", component_property="end_date"),
)
def update_graph(start, end):
    df = get_bookings_in_interval(start, end)
    # if there is no data, keep previous states and use alert
    if type(df) is AssertionError:
        return no_update, no_update, True, df

    fig = go.Figure()

    return (
        fig.to_dict(),
        {},
        no_update,
        no_update,
    )

mock_response = SimpleNamespace(
    status_code=404,
)

# either returns a df or an AssertionError
def get_bookings_in_interval(start, end):
    df = None
    try:
        data = mock_response
        assert data.status_code == 200, "Failed to fetch bookings"
        parsed_data = dict(data.json())
        assert len(parsed_data["bookings"]) > 0, "No items in Response"
        # do something

    except AssertionError as e:
        print(e)
        return e

    return data


if __name__ == '__main__':
    app.run(debug=True)
```

raises

```
Traceback (most recent call last):
  File "/Users/raw/dash/dash/_callback.py", line 562, in add_context
    jsonResponse = to_json(response)
                   ^^^^^^^^^^^^^^^^^
  File "/Users/raw/dash/dash/_utils.py", line 26, in to_json
    return to_json_plotly(value)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/raw/miniconda3/envs/dash/lib/python3.12/site-packages/plotly/io/_json.py", line 171, in to_json_plotly
    return _safe(orjson.dumps(cleaned, option=opts).decode("utf8"), _swap_orjson)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Type is not JSON serializable: AssertionError

During handling of the above exception, another exception occurred:

dash.exceptions.InvalidCallbackReturnValue: The callback for `[<Output `figcontainer.figure`>, <Output `table.data`>, <Output `alert.is_open`>, <Output `alert.children`>]`
                returned a value having type `NoUpdate`     <--- Incorrectly attributes the error to `NoUpdate`
                which is not JSON serializable.


The value in question is either the only value returned,
or is in the top level of the returned list,

                and has string representation
                `<dash._no_update.NoUpdate object at 0x10a3da870>`

                In general, Dash properties can only be
                dash components, strings, dictionaries, numbers, None,
                or lists of those.
```

The apparent error was `NoUpdate` was being blamed for not being JSON serializable, even though the `AssertionError` output was to blame. The root cause ended up being `NoUpdate` was not deemed to be a valid prop by both `valid_props` and `valid_children` within `_validate.fail_callback_output`.

If the error-causing output was placed before the `NoUpdate` outputs in the return, the correct error message would have been displayed.

E.g.

```python
# ... existing code
    if type(df) is AssertionError:
        return df, no_update, no_update, True # df is `AssertionError`
```

raises

```
Traceback (most recent call last):
  File "/Users/raw/dash/dash/_callback.py", line 562, in add_context
    jsonResponse = to_json(response)
                   ^^^^^^^^^^^^^^^^^
  File "/Users/raw/dash/dash/_utils.py", line 26, in to_json
    return to_json_plotly(value)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/raw/miniconda3/envs/dash/lib/python3.12/site-packages/plotly/io/_json.py", line 171, in to_json_plotly
    return _safe(orjson.dumps(cleaned, option=opts).decode("utf8"), _swap_orjson)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Type is not JSON serializable: AssertionError

During handling of the above exception, another exception occurred:

dash.exceptions.InvalidCallbackReturnValue: The callback for `[<Output `figcontainer.figure`>, <Output `table.data`>, <Output `alert.is_open`>, <Output `alert.children`>]`
                returned a value having type `AssertionError`    <------ Here `AssertionError` is being properly blamed
                which is not JSON serializable.


The value in question is either the only value returned,
or is in the top level of the returned list,

                and has string representation
                `Failed to fetch bookings`

                In general, Dash properties can only be
                dash components, strings, dictionaries, numbers, None,
                or lists of those.
```

This PR adds `NoUpdate` to `valid_props` and `valid_children`, which results in the expected error.

One open question is the meaningful location for the `NoUpdate` definition. I made a new `_no_update` module, which seems like overkill, but I did not see a better place and importing `_callback` into `_validate` resorts in a circular dependency.

Side note: hello `NoUpdate` again, my [old friend](https://github.com/plotly/dash/pull/2800) :)