### PR TITLE
skip 'undefined' when enumerating values of an optional enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - [#3080](https://github.com/plotly/dash/pull/3080) Fix docstring generation for components using single-line or nonstandard-indent leading comments
 - [#3103](https://github.com/plotly/dash/pull/3103) Fix Graph component becomes unresponsive if an invalid figure is passed
+- [#XXXX](https://github.com/plotly/dash/pull/XXXX) Fix docstring generation for TypeScript types with optional enums.
 
 ## [2.18.2] - 2024-11-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 - [#3080](https://github.com/plotly/dash/pull/3080) Fix docstring generation for components using single-line or nonstandard-indent leading comments
 - [#3103](https://github.com/plotly/dash/pull/3103) Fix Graph component becomes unresponsive if an invalid figure is passed
-- [#XXXX](https://github.com/plotly/dash/pull/XXXX) Fix docstring generation for TypeScript types with optional enums.
+- [#3162](https://github.com/plotly/dash/pull/3162) Fix docstring generation for TypeScript types with optional enums.
 
 ## [2.18.2] - 2024-11-04
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,6 +204,11 @@ We use `flake8`, `pylint`, and [`black`](https://black.readthedocs.io/en/stable/
 
 ## Tests
 
+Before running tests, make sure to set up the test environment:
+```bash
+npm run setup-tests.py # or npm run setup-tests.R
+```
+
 Our tests use Google Chrome via Selenium. You will need to install [ChromeDriver](https://chromedriver.chromium.org/getting-started) matching the version of Chrome installed on your system. Here are some helpful tips for [Mac](https://www.kenst.com/2015/03/installing-chromedriver-on-mac-osx/) and [Windows](http://jonathansoma.com/lede/foundations-2018/classes/selenium/selenium-windows-install/).
 
 We use [pytest](https://docs.pytest.org/en/latest/) as our test automation framework, plus [jest](https://jestjs.io/) for a few renderer unit tests. You can `npm run test` to run them all, but this command simply runs `pytest` with no arguments, then `cd dash-renderer && npm run test` for the renderer unit tests.

--- a/dash/development/_py_components_generation.py
+++ b/dash/development/_py_components_generation.py
@@ -583,10 +583,10 @@ def map_js_to_py_types_prop_types(type_object, indent_num):
         any=lambda: "boolean | number | string | dict | list",
         element=lambda: "dash component",
         node=lambda: "a list of or a singular dash component, string or number",
-        # React's PropTypes.oneOf
+        # React's PropTypes.oneOf, TypeScript enum & const enum, or TypeScript string literal union
         enum=lambda: (
             "a value equal to: "
-            + ", ".join(str(t["value"]) for t in type_object["value"])
+            + ", ".join(str(t["value"]) for t in type_object["value"] if t.get("value"))
         ),
         # React's PropTypes.oneOfType
         union=lambda: " | ".join(

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@lerna/filter-options": "^6.4.1",
+        "@types/react": "^19.0.8",
         "husky": "8.0.3",
         "lerna": "^6.6.2"
       }
@@ -1895,6 +1896,16 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true
     },
+    "node_modules/@types/react": {
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
+      "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -2928,6 +2939,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dargs": {
       "version": "7.0.0",
@@ -11328,6 +11346,15 @@
       "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
       "dev": true
     },
+    "@types/react": {
+      "version": "19.0.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.8.tgz",
+      "integrity": "sha512-9P/o1IGdfmQxrujGbIMDyYaaCykhLKc0NGCtYcECNUr9UAaDe4gwvV9bR6tvd5Br1SG0j+PBpbKr2UYY8CwqSw==",
+      "dev": true,
+      "requires": {
+        "csstype": "^3.0.2"
+      }
+    },
     "@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -12113,6 +12140,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true
+    },
+    "csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true
     },
     "dargs": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "devDependencies": {
     "@lerna/filter-options": "^6.4.1",
+    "@types/react": "^19.0.8",
     "husky": "8.0.3",
     "lerna": "^6.6.2"
   },

--- a/tests/unit/development/TestReactComponent.tsx
+++ b/tests/unit/development/TestReactComponent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-// A react component with all of the available proptypes to run tests over
+// A react component with a ton of TypeScript types to run tests over
 
 class Message {}
 type SomeString = "Hello"

--- a/tests/unit/development/TestReactComponent.tsx
+++ b/tests/unit/development/TestReactComponent.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+// A react component with all of the available proptypes to run tests over
+
+class Message {}
+type SomeString = "Hello"
+
+/**
+ * This is a description of the component.
+ * It's multiple lines long.
+ */
+export default function ReactComponent({
+    optionalArray,
+    optionalBool,
+    optionalFunc,
+    optionalNumber = 42,
+    optionalObject,
+    optionalString = 'hello world',
+    optionalSymbol,
+    optionalNode,
+    optionalElement,
+    optionalMessage,
+    optionalEnum,
+    optionalUnion,
+    optionalArrayOf,
+    optionalObjectOf,
+    optionalObjectWithShapeAndNestedDescription,
+    optionalAny,
+    customProp,
+    customArrayProp,
+    children,
+    id,
+}: {
+  optionalArray?: any[];
+  optionalBool?: boolean;
+  optionalFunc?: () => void;
+  optionalNumber?: number;
+  optionalObject?: object;
+  optionalString?: string;
+  optionalSymbol?: symbol;
+  optionalNode?: React.ReactNode;
+  optionalElement?: React.ReactElement;
+  optionalMessage?: Message;
+  optionalEnum?: 'News' | 'Photos';
+  optionalUnion?: string | number | Message;
+  optionalArrayOf?: number[];
+  optionalObjectOf?: { [key: string]: number };
+  optionalObjectWithShapeAndNestedDescription?: {
+      color?: string;
+      fontSize?: number;
+      figure?: {
+          data?: object[];
+          layout?: object;
+      };
+  };
+  optionalAny?: any;
+  customProp?: `${SomeString} World`;
+  customArrayProp?: Array<`${SomeString} World`>;
+  children?: React.ReactNode;
+  id?: string;
+}) {
+  return <div>{children}</div>;
+}

--- a/tests/unit/development/TestReactComponentRequired.tsx
+++ b/tests/unit/development/TestReactComponentRequired.tsx
@@ -1,11 +1,62 @@
 // A react component with a ton of TypeScript types to run tests over
 import React from 'react';
 
+class Message {}
+type SomeString = "Hello"
+
 /**
  * This is a description of the component.
  * It's multiple lines long.
  */
-export default function ReactComponent({id, children}: {id: string; children?: React.ReactNode}) {
-    <div id={id}>{children}</div>
-
+export default function ReactComponent({
+    requiredArray,
+    requiredBool,
+    requiredFunc,
+    requiredNumber = 42,
+    requiredObject,
+    requiredString = 'hello world',
+    requiredSymbol,
+    requiredNode,
+    requiredElement,
+    requiredMessage,
+    requiredEnum,
+    requiredUnion,
+    requiredArrayOf,
+    requiredObjectOf,
+    requiredObjectWithShapeAndNestedDescription,
+    requiredAny,
+    customProp,
+    customArrayProp,
+    children,
+    id,
+}: {
+  requiredArray: any[];
+  requiredBool: boolean;
+  requiredFunc: () => void;
+  requiredNumber: number;
+  requiredObject: object;
+  requiredString: string;
+  requiredSymbol: symbol;
+  requiredNode: React.ReactNode;
+  requiredElement: React.ReactElement;
+  requiredMessage: Message;
+  requiredEnum: 'News' | 'Photos';
+  requiredUnion: string | number | Message;
+  requiredArrayOf: number[];
+  requiredObjectOf: { [key: string]: number };
+  requiredObjectWithShapeAndNestedDescription: {
+      color: string;
+      fontSize: number;
+      figure: {
+          data: object[];
+          layout: object;
+      };
+  };
+  requiredAny: any;
+  customProp: `${SomeString} World`;
+  customArrayProp: Array<`${SomeString} World`>;
+  children: React.ReactNode;
+  id: string;
+}) {
+  return <div>{children}</div>;
 }

--- a/tests/unit/development/TestReactComponentRequired.tsx
+++ b/tests/unit/development/TestReactComponentRequired.tsx
@@ -1,5 +1,5 @@
+// A react component with a ton of TypeScript types to run tests over
 import React from 'react';
-// A react component with all of the available proptypes to run tests over
 
 /**
  * This is a description of the component.

--- a/tests/unit/development/TestReactComponentRequired.tsx
+++ b/tests/unit/development/TestReactComponentRequired.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+// A react component with all of the available proptypes to run tests over
+
+/**
+ * This is a description of the component.
+ * It's multiple lines long.
+ */
+export default function ReactComponent({id, children}: {id: string; children?: React.ReactNode}) {
+    <div id={id}>{children}</div>
+
+}


### PR DESCRIPTION
Update docstring generation from Typescript types to account for optional enums or string literal types.

Currently, the following error is produced when running `dash-generate-components` on a TypeScript component with an optional enum in its props type declaration: 

```
Traceback (most recent call last):
  File "<venv_path>/bin/dash-generate-components", line 10, in <module>
    sys.exit(cli())
             ^^^^^
  File "<venv_path>/lib/python3.12/site-packages/dash/development/component_generator.py", line 262, in cli
    generate_components(
  File "<venv_path>/lib/python3.12/site-packages/dash/development/component_generator.py", line 140, in generate_components
    components = generate_classes_files(project_shortname, metadata, *generator_methods)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<venv_path>/lib/python3.12/site-packages/dash/development/_py_components_generation.py", line 283, in generate_classes_files
    generator(
  File "<venv_path>/lib/python3.12/site-packages/dash/development/_py_components_generation.py", line 240, in generate_class_file
    class_string = generate_class_string(
                   ^^^^^^^^^^^^^^^^^^^^^^
  File "<venv_path>/lib/python3.12/site-packages/dash/development/_py_components_generation.py", line 110, in generate_class_string
    docstring = create_docstring(
                ^^^^^^^^^^^^^^^^^
  File "<venv_path>/lib/python3.12/site-packages/dash/development/_py_components_generation.py", line 368, in create_docstring
    args = "\n".join(
           ^^^^^^^^^^
  File "<venv_path>/lib/python3.12/site-packages/dash/development/_py_components_generation.py", line 369, in <genexpr>
    create_prop_docstring(
  File "<venv_path>/lib/python3.12/site-packages/dash/development/_py_components_generation.py", line 557, in create_prop_docstring
    py_type_name = js_to_py_type(
                   ^^^^^^^^^^^^^^
  File "<venv_path>/lib/python3.12/site-packages/dash/development/_py_components_generation.py", line 768, in js_to_py_type
    return js_to_py_types[js_type_name]()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<venv_path>/lib/python3.12/site-packages/dash/development/_py_components_generation.py", line 667, in <lambda>
    + ", ".join(str(t["value"]) for t in type_object["value"])
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<venv_path>/lib/python3.12/site-packages/dash/development/_py_components_generation.py", line 667, in <genexpr>
    + ", ".join(str(t["value"]) for t in type_object["value"])
                    ~^^^^^^^^^
KeyError: 'value'
```

## Contributor Checklist

- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
	- No, can they be run headless? It seems like it's going to take quite a while, and I can't use my computer while it's constantly popping up Chrome windows 🥴
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
	- I could use some help here. I've created two React components to test the docstring generation, but I can't figure out how the metadata is generated in the `//tests/unit/development` directory.

### optionals

- [x] I have added entry in the `CHANGELOG.md`