### PR TITLE
JupyterDash Fix - Alive Check

### DIFF
--- a/dash/_jupyter.py
+++ b/dash/_jupyter.py
@@ -354,7 +354,7 @@ class JupyterDash:
         self._servers[(host, port)] = server
 
         # Wait for server to start up
-        alive_url = f"http://{host}:{port}/_alive_{JupyterDash.alive_token}"
+        alive_url = f"http://{host}:{port}{requests_pathname_prefix}_alive_{JupyterDash.alive_token}"
 
         def _get_error():
             try:


### PR DESCRIPTION
This PR fixes an issue with the JupyterDash alive check routine. Namely, you must use the `requests_pathname_prefix` variable as part of the URL.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] Fix alive check
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
