### PR TITLE
feat: expose the closeMenuOnSelect option in dropdown component

### DIFF
--- a/components/dash-core-components/src/components/Dropdown.react.js
+++ b/components/dash-core-components/src/components/Dropdown.react.js
@@ -146,6 +146,11 @@ Dropdown.propTypes = {
     disabled: PropTypes.bool,
 
     /**
+     * If false, the menu of the dropdown will not close once a value is selected.
+     */
+    closeMenuOnSelect: PropTypes.bool,
+
+    /**
      * height of each option. Can be increased when label lengths would wrap around
      */
     optionHeight: PropTypes.number,
@@ -232,6 +237,7 @@ Dropdown.defaultProps = {
     searchable: true,
     optionHeight: 35,
     maxHeight: 200,
+    closeMenuOnSelect: true,
     persisted_props: ['value'],
     persistence_type: 'local',
 };

--- a/components/dash-core-components/src/fragments/Dropdown.react.js
+++ b/components/dash-core-components/src/fragments/Dropdown.react.js
@@ -33,6 +33,7 @@ const RDProps = [
     'maxHeight',
     'style',
     'className',
+    'closeMenuOnSelect'
 ];
 
 const Dropdown = props => {
@@ -46,6 +47,7 @@ const Dropdown = props => {
         style,
         loading_state,
         value,
+        closeMenuOnSelect,
     } = props;
     const [optionsCheck, setOptionsCheck] = useState(null);
     const persistentOptions = useRef(null);
@@ -158,6 +160,7 @@ const Dropdown = props => {
                 value={value}
                 onChange={onChange}
                 onInputChange={onInputChange}
+                closeMenuOnSelect={closeMenuOnSelect}
                 backspaceRemoves={clearable}
                 deleteRemoves={clearable}
                 inputProps={{autoComplete: 'off'}}


### PR DESCRIPTION
This feature have been requested multiple time by memebers of my team at work. I checked a bit on the web and multiple Threads on your forum mentioned it without providing any solution: 
- https://community.plotly.com/t/dash-dropdown-select-multi-keep-options-open-after-selection/34576
- https://community.plotly.com/t/keep-the-dcc-dropdown-multi-true-open-when-choosing-a-value-from-options/72542

That's my first contribution to dash so i'm still a bit lost with everything in the repository but I simply tried to expose what is available in the react-select options. I only made changes to the JS exposed options but I'm unsure if I should modify anything from the python side. 

I'll move forward with the contributor check list once I'm sure I didn't do anything stupid. 

Thanks for your help. 

## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
