### PR TITLE
reworking dash debug tools interface

### DIFF
--- a/dash/dash-renderer/src/components/error/GlobalErrorContainer.react.js
+++ b/dash/dash-renderer/src/components/error/GlobalErrorContainer.react.js
@@ -11,14 +11,16 @@ class UnconnectedGlobalErrorContainer extends Component {
     render() {
         const {config, error, children} = this.props;
         return (
-            <div id='_dash-global-error-container'>
+            <div id='_dash-global-error-container' style={{
+            position: 'absolute', maxHeight: '100vh', height: '100vh', maxWidth: '100vw', width: '100vw', overflow: 'hidden'}}
+            className='display-dash-debug'
+            >
+                <div id='_dash-app-content'>{children}</div>
                 <DebugMenu
                     config={config}
                     error={error}
                     hotReload={Boolean(config.hot_reload)}
-                >
-                    <div id='_dash-app-content'>{children}</div>
-                </DebugMenu>
+                />
             </div>
         );
     }

--- a/dash/dash-renderer/src/components/error/GlobalErrorContainer.react.js
+++ b/dash/dash-renderer/src/components/error/GlobalErrorContainer.react.js
@@ -12,7 +12,7 @@ class UnconnectedGlobalErrorContainer extends Component {
         const {config, error, children} = this.props;
         return (
             <div id='_dash-global-error-container' style={{
-            position: 'absolute', maxHeight: '100vh', height: '100vh', maxWidth: '100vw', width: '100vw', overflow: 'hidden'}}
+            position: 'absolute', maxHeight: '100vh', height: '100vh', maxWidth: '100vw', width: '100vw'}}
             className='display-dash-debug'
             >
                 <div id='_dash-app-content'>{children}</div>

--- a/dash/dash-renderer/src/components/error/menu/DebugMenu.css
+++ b/dash/dash-renderer/src/components/error/menu/DebugMenu.css
@@ -271,4 +271,17 @@
     .display-debug-toggle::before {
         content: 'show dash tools ';
     }
+
+    .debug-tool-holder {
+        bottom: 0px;
+        right: 0;
+        width: 300px;
+    }
+}
+
+.debug-tool-holder {
+    bottom: -40px;
+    position: absolute;
+    width: 100%;
+    height: 100%;
 }

--- a/dash/dash-renderer/src/components/error/menu/DebugMenu.css
+++ b/dash/dash-renderer/src/components/error/menu/DebugMenu.css
@@ -25,6 +25,7 @@
     border-radius: 0px;
     letter-spacing: normal;
     gap: 6px;
+    color: inherit;
 }
 
 .dash-debug-menu__popup {

--- a/dash/dash-renderer/src/components/error/menu/DebugMenu.css
+++ b/dash/dash-renderer/src/components/error/menu/DebugMenu.css
@@ -1,6 +1,5 @@
 .dash-debug-menu {
     transition: 0.3s;
-    position: fixed;
     bottom: 35px;
     right: 35px;
     display: flex;
@@ -32,8 +31,8 @@
     display: flex;
     flex-direction: column;
     position: absolute;
-    bottom: 100%;
-    right: 0;
+    bottom: 40px;
+    right: 10px;
     gap: 8px;
     max-height: calc(100vh - 75px);
     justify-content: flex-end;
@@ -112,20 +111,16 @@
 .dash-debug-menu__outer {
     transition: 0.3s;
     box-sizing: border-box;
-    position: fixed;
-    bottom: 8px;
-    right: 8px;
+    height: 35px;
     display: flex;
-    color: black;
     flex-direction: column;
     font-family: Verdana, sans-serif !important;
     font-size: 14px;
     justify-content: center;
     align-items: center;
-    z-index: 10000;
     border-radius: 5px;
     padding: 5px;
-    background-color: #f5f6fa;
+    background-color: #393a3f5c;
     box-shadow:
         0px 0.8px 0.8px 0px rgba(0, 0, 0, 0.04),
         0px 2.3px 2px 0px rgba(0, 0, 0, 0.03);
@@ -189,15 +184,14 @@
     cursor: pointer;
     font-family: Verdana, sans-serif !important;
     font-weight: bold;
-    color: black;
 }
 
 .dash-debug-menu__button.dash-debug-menu__button--selected {
     color: #7f4bc4;
     box-shadow: 0 2px #0071c2;
 }
-.dash-debug-menu__button.dash-debug-menu__button--selected:hover {
-    color: #5806c4;
+.dash-debug-menu__button:not(.dash-debug-menu__button--selected):hover {
+    color: #ad6fff;
 }
 
 .dash-debug-alert {
@@ -233,4 +227,48 @@
 .dash-debug-disconnected {
     font-size: 14px;
     margin-left: 3px;
+}
+
+#_dash-app-content {
+    height: 100%;
+    max-height: 100%;
+    overflow: auto;
+    width: 100%;
+}
+
+.display-dash-debug {
+    .display-debug-toggle {
+        position: absolute;
+        right: 20px;
+        bottom: 2.5px;
+        z-index: 10000;
+
+        .test-devtools-error-count {
+            display: none;
+        }
+    }
+
+    .display-debug-toggle::before {
+        content: 'hide dash tools';
+    }
+
+    .dash-debug-menu__outer {
+        bottom: 0;
+        position: absolute;
+        width: 100%;
+    }
+}
+
+.hide-dash-debug-console {
+    .dash-debug-menu__outer {
+        display: none;
+    }
+
+    .display-debug-toggle .test-devtools-error-count {
+        display: initial;
+    }
+
+    .display-debug-toggle::before {
+        content: 'show dash tools ';
+    }
 }

--- a/dash/dash-renderer/src/components/error/menu/DebugMenu.react.js
+++ b/dash/dash-renderer/src/components/error/menu/DebugMenu.react.js
@@ -89,6 +89,44 @@ class DebugMenu extends Component {
             opened: false,
             popup: 'errors'
         };
+
+        // Bind the resize listener to the instance
+        this.resizeListener = this.resizeListener.bind(this);
+
+        // Add the resize event listener
+        window.addEventListener('resize', this.resizeListener);
+
+
+    }
+
+    resizeListener() {
+        const el = window.document.querySelector('#_dash-global-error-container')
+        if (el && !el.classList.contains('hide-dash-debug-console')) {
+            // Recalculate size on resize
+            this.calcSize();
+        }
+    }
+
+    calcSize() {
+        const totalHeight = window.innerHeight;
+        const clearance = 40; // Desired clearance in pixels
+        const usableHeight = totalHeight - clearance;
+
+        // Assuming the original content height is the full window height
+        const originalHeight = totalHeight;
+        const scaleFactor = usableHeight / originalHeight;
+
+        // Apply scaling using transform
+        const contentElement = document.querySelector('#_dash-app-content');
+        if (contentElement) {
+            contentElement.style.transform = `scale(1, ${scaleFactor})`;
+            contentElement.style.transformOrigin = 'left top'; // Scale from the top
+        }
+    }
+
+    componentDidMount() {
+        // Trigger the resize event manually when the component mounts
+        this.resizeListener();
     }
 
     render() {
@@ -136,12 +174,35 @@ class DebugMenu extends Component {
             />
         );
 
+        const toggleDebugTools = () => {
+            const el = window.document.querySelector('#_dash-global-error-container')
+            if (el) {
+                el.classList.toggle('hide-dash-debug-console')
+                if (el.classList.contains('hide-dash-debug-console')) {
+                    const contentElement = document.querySelector('#_dash-app-content');
+                    contentElement.style = ''
+                } else {
+                    this.calcSize()
+                }
+            }
+        }
+
         return (
             <div>
                 <div className={classes('dash-debug-menu__outer')}>
                     {popupContent}
                     {menuContent}
                 </div>
+                <button
+                    className='display-debug-toggle'
+                    onClick={toggleDebugTools}
+                    >
+                    {errCount > 0 ? (
+                        <span className='test-devtools-error-count dash-debug-menu__error-count'>
+                            {errCount}
+                        </span>
+                    ) : null}
+                </button>
                 {this.props.children}
             </div>
         );

--- a/dash/dash-renderer/src/components/error/menu/DebugMenu.react.js
+++ b/dash/dash-renderer/src/components/error/menu/DebugMenu.react.js
@@ -117,10 +117,13 @@ class DebugMenu extends Component {
         const scaleFactor = usableHeight / originalHeight;
 
         // Apply scaling using transform
-        const contentElement = document.querySelector('#_dash-app-content');
+        const contentElement = document.querySelector('body');
         if (contentElement) {
             contentElement.style.transform = `scale(1, ${scaleFactor})`;
             contentElement.style.transformOrigin = 'left top'; // Scale from the top
+            contentElement.style.height = '100vh';
+            contentElement.style.width = '100vw';
+            contentElement.style.overflowX = 'hidden';
         }
     }
 
@@ -179,8 +182,10 @@ class DebugMenu extends Component {
             if (el) {
                 el.classList.toggle('hide-dash-debug-console')
                 if (el.classList.contains('hide-dash-debug-console')) {
-                    const contentElement = document.querySelector('#_dash-app-content');
-                    contentElement.style = ''
+                    const contentElement = document.querySelector('body');
+                    contentElement.style.transform = ''
+                    contentElement.style.transformsOrigin = ''
+                    contentElement.style.overflowX = ''
                 } else {
                     this.calcSize()
                 }
@@ -188,7 +193,7 @@ class DebugMenu extends Component {
         }
 
         return (
-            <div>
+            <div className='debug-tool-holder'>
                 <div className={classes('dash-debug-menu__outer')}>
                     {popupContent}
                     {menuContent}


### PR DESCRIPTION
A couple of things to note here:
- I removed color declarations in order to allow app definitions to take precedence over the colors.
- I adjusted the color on the toolbar itself to have some alpha in order to allow the app background to get added to
- the toolbar is now toggle-able, when hidden error count goes to the toggle button
- the toolbar is now a footer
- when the toolbar is shown, the app is scaled dynamically based upon the screen size and given 40px for the toolbar to display
- when the toolbar is not shown, the app is full size, and the toggle button is placed on top with a zIndex of 10000
- the toolbar no longer needs zIndex as it has been given space in the page

The main thing that needs to get worked on here is the toggle button:
- obviously the button needs to be styled
- when the screen size is narrow, the toolbar and button collide, need to implement some sort of way to implement a selection for the tool to display and the other info to display (dash version)


@marthacryan @ndrezn