### PR TITLE
Fix ignored props from test package getting in the way of html build

### DIFF
--- a/@plotly/dash-generator-test-component-typescript/_dash_prop_typing.py
+++ b/@plotly/dash-generator-test-component-typescript/_dash_prop_typing.py
@@ -1,0 +1,1 @@
+ignore_props = ['ignored_prop']

--- a/@plotly/dash-generator-test-component-typescript/package.json
+++ b/@plotly/dash-generator-test-component-typescript/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build:js": "webpack --mode production",
     "setup": "python setup.py sdist",
-    "build:py_and_r": "dash-generate-components ./src/components dash_generator_test_component_typescript && cp base/** dash_generator_test_component_typescript/ && dash-generate-components ./src/components dash_generator_test_component_typescript --r-prefix 'dgtc_ts'",
+    "build:py_and_r": "dash-generate-components ./src/components dash_generator_test_component_typescript -t _dash_prop_typing && cp base/** dash_generator_test_component_typescript/",
     "build": "run-s build:js build:py_and_r setup",
     "test": "jest"
   },


### PR DESCRIPTION
The `dash_prop_typing` file from the test package `@plotly/dash-generator-test-component` somehow was getting in the html build and overriding the default value.
