### PR TITLE
Add note on params that only work with background callbacks

### DIFF
--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -118,12 +118,14 @@ def callback(
             the app layout. The second element is the value that the property
             should be set to while the callback is running, and the third element
             is the value the property should be set to when the callback completes.
+            This parameter only applies to background callbacks (`background=True`).
         :param cancel:
             A list of `Input` dependency objects that reference a property of a
             component in the app's layout.  When the value of this property changes
             while a callback is running, the callback is canceled.
             Note that the value of the property is not significant, any change in
             value will result in the cancellation of the running job (if any).
+            This parameter only applies to background callbacks (`background=True`).
         :param progress:
             An `Output` dependency grouping that references properties of
             components in the app's layout. When provided, the decorated function
@@ -132,21 +134,25 @@ def callback(
             function should call in order to provide updates to the app on its
             current progress. This function accepts a single argument, which
             correspond to the grouping of properties specified in the provided
-            `Output` dependency grouping
+            `Output` dependency grouping. This parameter only applies to background
+            callbacks (`background=True`).
         :param progress_default:
             A grouping of values that should be assigned to the components
             specified by the `progress` argument when the callback is not in
             progress. If `progress_default` is not provided, all the dependency
             properties specified in `progress` will be set to `None` when the
-            callback is not running.
+            callback is not running. This parameter only applies to background
+            callbacks (`background=True`).
         :param cache_args_to_ignore:
             Arguments to ignore when caching is enabled. If callback is configured
             with keyword arguments (Input/State provided in a dict),
             this should be a list of argument names as strings. Otherwise,
             this should be a list of argument indices as integers.
+            This parameter only applies to background callbacks (`background=True`).
         :param cache_ignore_triggered:
             Whether to ignore which inputs triggered the callback when creating
-            the cache.
+            the cache. This parameter only applies to background callbacks
+            (`background=True`).
         :param interval:
             Time to wait between the background callback update requests.
         :param on_error:

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -118,7 +118,6 @@ def callback(
             the app layout. The second element is the value that the property
             should be set to while the callback is running, and the third element
             is the value the property should be set to when the callback completes.
-            This parameter only applies to background callbacks (`background=True`).
         :param cancel:
             A list of `Input` dependency objects that reference a property of a
             component in the app's layout.  When the value of this property changes


### PR DESCRIPTION
@T4rk1n do you know if there are any other params that only apply to background callbacks.

This PR relates to this issue https://github.com/plotly/ddk-dash-docs/issues/3318
which is specifically related to the `cancel` param, but I think it's the same for the rest of these. 


---

*Start with a description of this PR. Then edit the list below to the items that make sense for your PR scope, and check off the boxes as you go!*

## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
