### PR TITLE
allows for parents to listen to descendent updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#3264](https://github.com/plotly/dash/pull/3264) Fixed an issue where moving components inside of children would not update the `setProps` path, leading to hashes being incorrect
 - [#3265](https://github.com/plotly/dash/pull/3265) Fixed issue where the resize of graphs was cancelling others
 
+## Added
+- [#3268](https://github.com/plotly/dash/pull/3268) Added the ability for component devs to subscribe to descendent updates by setting `childrenLayoutHashes = true` on the component, eg: `Tabs.childrenLayoutHashes = true`
 
 ## [3.0.2] - 2025-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#3265](https://github.com/plotly/dash/pull/3265) Fixed issue where the resize of graphs was cancelling others
 
 ## Added
-- [#3268](https://github.com/plotly/dash/pull/3268) Added the ability for component devs to subscribe to descendent updates by setting `childrenLayoutHashes = true` on the component, eg: `Tabs.childrenLayoutHashes = true`
+- [#3268](https://github.com/plotly/dash/pull/3268) Added the ability for component devs to subscribe to descendent updates by setting `dashChildrenUpdate = true` on the component, eg: `Tabs.dashChildrenUpdate = true`
 
 ## [3.0.2] - 2025-04-01
 

--- a/components/dash-core-components/src/components/Tabs.react.js
+++ b/components/dash-core-components/src/components/Tabs.react.js
@@ -121,13 +121,6 @@ const EnhancedTab = ({
     );
 };
 
-EnhancedTab.defaultProps = {
-    loading_state: {
-        is_loading: false,
-        component_name: '',
-        prop_name: '',
-    },
-};
 
 /**
  * A Dash component that lets you render pages with tabs - the Tabs component's children

--- a/components/dash-core-components/src/components/Tabs.react.js
+++ b/components/dash-core-components/src/components/Tabs.react.js
@@ -121,7 +121,6 @@ const EnhancedTab = ({
     );
 };
 
-
 /**
  * A Dash component that lets you render pages with tabs - the Tabs component's children
  * can be dcc.Tab components, which can hold a label that will be displayed as a tab, and can in turn hold

--- a/components/dash-core-components/src/components/Tabs.react.js
+++ b/components/dash-core-components/src/components/Tabs.react.js
@@ -440,4 +440,4 @@ Tabs.propTypes = {
     persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
 };
 
-Tabs.childrenLayoutHashes = true;
+Tabs.dashChildrenUpdate = true;

--- a/components/dash-core-components/src/components/Tabs.react.js
+++ b/components/dash-core-components/src/components/Tabs.react.js
@@ -439,3 +439,5 @@ Tabs.propTypes = {
      */
     persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
 };
+
+Tabs.childrenLayoutHashes = true

--- a/components/dash-core-components/src/components/Tabs.react.js
+++ b/components/dash-core-components/src/components/Tabs.react.js
@@ -440,4 +440,4 @@ Tabs.propTypes = {
     persistence_type: PropTypes.oneOf(['local', 'session', 'memory']),
 };
 
-Tabs.childrenLayoutHashes = true
+Tabs.childrenLayoutHashes = true;

--- a/dash/dash-renderer/src/wrapper/selectors.ts
+++ b/dash/dash-renderer/src/wrapper/selectors.ts
@@ -2,7 +2,7 @@ import {DashLayoutPath, DashComponent, BaseDashProps} from '../types/component';
 import {
     getComponentLayout,
     stringifyPath,
-    checkChildrenLayoutHashes
+    checkDashChildrenUpdate
 } from './wrapping';
 import {pathOr} from 'ramda';
 
@@ -90,7 +90,7 @@ export const selectDashProps =
         const strPath = stringifyPath(componentPath);
 
         let hash;
-        if (checkChildrenLayoutHashes(c)) {
+        if (checkDashChildrenUpdate(c)) {
             hash = determineChangedProps(state, strPath);
         } else {
             hash = state.layoutHashes[strPath];

--- a/dash/dash-renderer/src/wrapper/selectors.ts
+++ b/dash/dash-renderer/src/wrapper/selectors.ts
@@ -1,6 +1,10 @@
 import {DashLayoutPath, DashComponent, BaseDashProps} from '../types/component';
-import {getComponentLayout, stringifyPath, checkChildrenLayoutHashes} from './wrapping';
-import {pathOr} from 'ramda'
+import {
+    getComponentLayout,
+    stringifyPath,
+    checkChildrenLayoutHashes
+} from './wrapping';
+import {pathOr} from 'ramda';
 
 type SelectDashProps = [DashComponent, BaseDashProps, number, object, string];
 
@@ -10,17 +14,20 @@ interface ChangedPropsRecord {
     renderType: string;
 }
 
-const previousHashes = {}
+const previousHashes = {};
 
-function determineChangedProps(state: any, strPath: string): ChangedPropsRecord {
+function determineChangedProps(
+    state: any,
+    strPath: string
+): ChangedPropsRecord {
     let combinedHash = 0;
-    let renderType = 'update'; // Default render type, adjust as needed
+    const renderType = 'update'; // Default render type, adjust as needed
     Object.entries(state.layoutHashes).forEach(([updatedPath, pathHash]) => {
         if (updatedPath.startsWith(strPath)) {
             const previousHash: any = pathOr({}, [updatedPath], previousHashes);
-            combinedHash += pathOr(0, ['hash'], pathHash)
+            combinedHash += pathOr(0, ['hash'], pathHash);
             if (previousHash !== pathHash) {
-                previousHash[updatedPath] = pathHash
+                previousHash[updatedPath] = pathHash;
             }
         }
     });
@@ -43,7 +50,7 @@ export const selectDashProps =
 
         let hash;
         if (checkChildrenLayoutHashes(c)) {
-            hash = determineChangedProps(state, strPath)
+            hash = determineChangedProps(state, strPath);
         } else {
             hash = state.layoutHashes[strPath];
         }

--- a/dash/dash-renderer/src/wrapper/wrapping.ts
+++ b/dash/dash-renderer/src/wrapper/wrapping.ts
@@ -72,3 +72,14 @@ export function checkRenderTypeProp(componentDefinition: any) {
         )
     );
 }
+
+export function checkChildrenLayoutHashes(componentDefinition: any) {
+    return (
+        'childrenLayoutHashes' in
+        pathOr(
+            {},
+            [componentDefinition?.namespace, componentDefinition?.type],
+            window as any
+        )
+    );
+}

--- a/dash/dash-renderer/src/wrapper/wrapping.ts
+++ b/dash/dash-renderer/src/wrapper/wrapping.ts
@@ -73,9 +73,9 @@ export function checkRenderTypeProp(componentDefinition: any) {
     );
 }
 
-export function checkChildrenLayoutHashes(componentDefinition: any) {
+export function checkDashChildrenUpdate(componentDefinition: any) {
     return (
-        'childrenLayoutHashes' in
+        'dashChildrenUpdate' in
         pathOr(
             {},
             [componentDefinition?.namespace, componentDefinition?.type],

--- a/tests/integration/renderer/test_descendant_listening.py
+++ b/tests/integration/renderer/test_descendant_listening.py
@@ -1,7 +1,5 @@
 from dash import dcc, html, Input, Output, Patch, Dash
 
-from dash.testing.wait import until
-
 
 def test_dcl001_descendant_tabs(dash_duo):
     app = Dash()
@@ -49,7 +47,7 @@ def test_dcl001_descendant_tabs(dash_duo):
         return True, True
 
     dash_duo.start_server(app)
-    dash_duo.wait_for_text_to_equal("#button", f"Enable Tabs")
+    dash_duo.wait_for_text_to_equal("#button", "Enable Tabs")
     dash_duo.find_element("#tab-a.tab--disabled")
     dash_duo.find_element("#button").click()
     dash_duo.find_element("#tab-a:not(.tab--disabled)")

--- a/tests/integration/renderer/test_descendant_listening.py
+++ b/tests/integration/renderer/test_descendant_listening.py
@@ -1,0 +1,57 @@
+from dash import dcc, html, Input, Output, Patch, Dash
+
+from dash.testing.wait import until
+
+
+def test_dcl001_descendant_tabs(dash_duo):
+    app = Dash()
+
+    app.layout = html.Div(
+        [
+            html.Button("Enable Tabs", id="button", n_clicks=0),
+            html.Button("Add Tabs", id="add_button", n_clicks=0),
+            dcc.Store(id="store-data", data=None),
+            dcc.Tabs(
+                [
+                    dcc.Tab(label="Tab A", value="tab-a", id="tab-a", disabled=True),
+                    dcc.Tab(label="Tab B", value="tab-b", id="tab-b", disabled=True),
+                ],
+                id="tabs",
+                value="tab-a",
+            ),
+        ]
+    )
+
+    @app.callback(Output("store-data", "data"), Input("button", "n_clicks"))
+    def update_store_data(clicks):
+        if clicks > 0:
+            return {"data": "available"}
+        return None
+
+    @app.callback(
+        Output("tabs", "children"),
+        Input("add_button", "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def add_tabs(n):
+        children = Patch()
+        children.append(dcc.Tab(label=f"{n}", value=f"{n}", id=f"test-{n}"))
+        return children
+
+    @app.callback(
+        Output("tab-a", "disabled"),
+        Output("tab-b", "disabled"),
+        Input("store-data", "data"),
+    )
+    def toggle_tabs(store_data):
+        if store_data is not None and "data" in store_data:
+            return False, False
+        return True, True
+
+    dash_duo.start_server(app)
+    dash_duo.wait_for_text_to_equal("#button", f"Enable Tabs")
+    dash_duo.find_element("#tab-a.tab--disabled")
+    dash_duo.find_element("#button").click()
+    dash_duo.find_element("#tab-a:not(.tab--disabled)")
+    dash_duo.find_element("#add_button").click()
+    dash_duo.find_element("#test-1:not(.tab--disabled)")


### PR DESCRIPTION
In Dash 3, it has become apparent that some components need to listen to updates in descendent components, and to rerender again. This PR adds this ability for component devs to subscribe to updates in descendents by placing `dashChildrenUpdate = true` on their component.

Currently, there is no limit to the scope that this will rerender for.

This fixes: https://github.com/plotly/dash/issues/3252
