### PR TITLE
Fix loading selector with children starting at the same digit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED]
+
+## Fixed
+- [#3278](https://github.com/plotly/dash/pull/3278) Fix loading selector with children starting at the same digit. Fix [#3276](https://github.com/plotly/dash/issues/3276)
+
 ## [3.0.3] - 2025-04-14
 
 ## Fixed

--- a/components/dash-core-components/src/components/Loading.react.js
+++ b/components/dash-core-components/src/components/Loading.react.js
@@ -31,8 +31,9 @@ const coveringSpinner = {
 
 const loadingSelector = (componentPath, targetComponents) => state => {
     let stringPath = JSON.stringify(componentPath);
-    // Remove the last ] for easy match
-    stringPath = stringPath.substring(0, stringPath.length - 1);
+    // Remove the last ] for easy match and add `,` to make sure only children
+    // trigger the loading. See issue: https://github.com/plotly/dash/issues/3276
+    stringPath = stringPath.substring(0, stringPath.length - 1) + ',';
     const loadingChildren = toPairs(state.loading).reduce(
         (acc, [path, load]) => {
             if (path.startsWith(stringPath) && load.length) {


### PR DESCRIPTION
Fixes #3276 

The loading selector was catching element at the same level, add a `,` to the check in order to only get the children.