### PR TITLE
Remove flask typing import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Fixed
 - [#3278](https://github.com/plotly/dash/pull/3278) Fix loading selector with children starting at the same digit. Fix [#3276](https://github.com/plotly/dash/issues/3276)
+- [#3280](https://github.com/plotly/dash/pull/3280) Remove flask typing import not available in earlier versions.
 
 ## [3.0.3] - 2025-04-14
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -22,7 +22,6 @@ from typing import Any, Callable, Dict, Optional, Union, Sequence, Literal
 
 import flask
 
-from flask.typing import RouteCallable
 from importlib_metadata import version as _get_distribution_version
 
 from dash import dcc
@@ -80,6 +79,8 @@ from ._pages import (
 )
 from ._jupyter import jupyter_dash, JupyterDisplayMode
 from .types import RendererHooks
+
+RouteCallable = Callable[..., Any]
 
 # If dash_design_kit is installed, check for version
 ddk_version = None


### PR DESCRIPTION
As report in https://github.com/plotly/dash/pull/3254#discussion_r2045770189 importing from flask.typing is not available for earlier version, instead of putting a constraint this just replace the import with a Callable.

