### PR TITLE
Use routes_pathname_prefix for internal Alive URL in Dash app

### DIFF
--- a/dash/_jupyter.py
+++ b/dash/_jupyter.py
@@ -294,6 +294,8 @@ class JupyterDash:
         else:
             requests_pathname_prefix = "/"
 
+        routes_pathname_prefix = app.config.get("routes_pathname_prefix", "/")
+
         # FIXME Move config initialization to main dash __init__
         # low-level setter to circumvent Dash's config locking
         # normally it's unsafe to alter requests_pathname_prefix this late, but
@@ -355,7 +357,7 @@ class JupyterDash:
         self._servers[(host, port)] = server
 
         # Wait for server to start up
-        alive_url = f"http://{host}:{port}{requests_pathname_prefix}_alive_{JupyterDash.alive_token}"
+        alive_url = f"http://{host}:{port}{routes_pathname_prefix}_alive_{JupyterDash.alive_token}"
 
         def _get_error():
             try:


### PR DESCRIPTION
When running a Dash app behind a proxy, the internal alive check (used during app startup) fails if the app is initialized with only `requests_pathname_prefix`, or if `requests_pathname_prefix` differs from `routes_pathname_prefix`.

This results in a misleading error:
```
OSError: Address 'http://127.0.0.1:9090' already in use.
Try passing a different port to run.
```

This is due to the alive check attempting to construct the URL using `requests_pathname_prefix`, which may not route correctly internally.

###  Solution

This PR updates the internal alive URL construction logic to use `routes_pathname_prefix`, which is the correct prefix for server-side routing and internal endpoint resolution.

### This

- Prevents startup failures when `requests_pathname_prefix` != `routes_pathname_prefix`
- Ensures internal health check (alive check) functions correctly
- Unblocks deployment in more complex reverse-proxy setups


## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
