### PR TITLE
Fix component as props used in the same container getting the same key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Fixed
 - [#3278](https://github.com/plotly/dash/pull/3278) Fix loading selector with children starting at the same digit. Fix [#3276](https://github.com/plotly/dash/issues/3276)
 - [#3280](https://github.com/plotly/dash/pull/3280) Remove flask typing import not available in earlier versions.
+- [#3284](https://github.com/plotly/dash/pull/3284) Fix component as props having the same key when used in the same container.
 
 ## [3.0.3] - 2025-04-14
 

--- a/dash/dash-renderer/src/wrapper/DashWrapper.tsx
+++ b/dash/dash-renderer/src/wrapper/DashWrapper.tsx
@@ -28,7 +28,8 @@ import {
     createElement,
     getComponentLayout,
     isDryComponent,
-    checkRenderTypeProp
+    checkRenderTypeProp,
+    stringifyPath
 } from './wrapping';
 import Registry from '../registry';
 import isSimpleComponent from '../isSimpleComponent';
@@ -158,18 +159,13 @@ function DashWrapper({
     };
 
     const createContainer = useCallback(
-        (container, containerPath, _childNewRender, key = undefined) => {
+        (container, containerPath, _childNewRender) => {
             if (isSimpleComponent(renderComponent)) {
                 return renderComponent;
             }
             return (
                 <DashWrapper
-                    key={
-                        (container &&
-                            container.props &&
-                            stringifyId(container.props.id)) ||
-                        key
-                    }
+                    key={stringifyPath(containerPath)}
                     _dashprivate_error={_dashprivate_error}
                     componentPath={containerPath}
                     _passedComponent={container}
@@ -192,8 +188,7 @@ function DashWrapper({
                                 ...childrenPath,
                                 i
                             ]),
-                            _childNewRender,
-                            i
+                            _childNewRender
                         );
                     }
                     return n;

--- a/dash/dash-renderer/src/wrapper/DashWrapper.tsx
+++ b/dash/dash-renderer/src/wrapper/DashWrapper.tsx
@@ -165,7 +165,11 @@ function DashWrapper({
             }
             return (
                 <DashWrapper
-                    key={stringifyPath(containerPath)}
+                    key={
+                        container?.props?.id
+                            ? stringifyId(container.props.id)
+                            : stringifyPath(containerPath)
+                    }
                     _dashprivate_error={_dashprivate_error}
                     componentPath={containerPath}
                     _passedComponent={container}


### PR DESCRIPTION
When a component as prop is rendered with the same react `key` and rendered inside the same container, (eg: https://github.com/mantinedev/mantine/blob/87639c2b706884f9809fe1f68dc7a6cbe74abfe3/packages/%40mantine/core/src/components/Switch/Switch.tsx#L224) it will not re-render. This PR change the key to always be the component path which is unique in all cases.
