### PR TITLE
Add plotly run command

### DIFF
--- a/dash/__main__.py
+++ b/dash/__main__.py
@@ -1,0 +1,3 @@
+from ._cli import cli
+
+cli()

--- a/dash/_cli.py
+++ b/dash/_cli.py
@@ -1,0 +1,172 @@
+import argparse
+import importlib
+import sys
+from typing import Any, Dict
+
+from dash import Dash
+
+
+def load_app(app_path: str) -> Dash:
+    """
+    Load a Dash app instance from a string like "module:variable".
+
+    :param app_path: The import path to the Dash app instance.
+    :return: The loaded Dash app instance.
+    """
+    if ":" not in app_path:
+        raise ValueError(
+            f"Invalid app path: '{app_path}'. "
+            'The path must be in the format "module:variable".'
+        )
+
+    module_str, app_str = app_path.split(":", 1)
+
+    if not module_str or not app_str:
+        raise ValueError(
+            f"Invalid app path: '{app_path}'. "
+            'Both module and variable names are required in "module:variable".'
+        )
+
+    try:
+        module = importlib.import_module(module_str)
+    except ImportError as e:
+        raise ImportError(f"Could not import module '{module_str}'.") from e
+
+    try:
+        app_instance = getattr(module, app_str)
+    except AttributeError as e:
+        raise AttributeError(
+            f"Could not find variable '{app_str}' in module '{module_str}'."
+        ) from e
+
+    if not isinstance(app_instance, Dash):
+        raise TypeError(f"'{app_path}' did not resolve to a Dash app instance.")
+
+    return app_instance
+
+
+def create_parser() -> argparse.ArgumentParser:
+    """Create the argument parser for the Plotly CLI."""
+    parser = argparse.ArgumentParser(
+        description="A command line interface for Plotly Dash."
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    # --- `run` command ---
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Run a Dash app.",
+        description="Run a local development server for a Dash app.",
+    )
+
+    run_parser.add_argument(
+        "app", help='The Dash app to run, in the format "module:variable".'
+    )
+
+    # Server options
+    run_parser.add_argument(
+        "--host",
+        type=str,
+        help='Host IP used to serve the application (Default: "127.0.0.1").',
+    )
+    run_parser.add_argument(
+        "--port",
+        "-p",
+        type=int,
+        help='Port used to serve the application (Default: "8050").',
+    )
+    run_parser.add_argument(
+        "--proxy",
+        type=str,
+        help='Proxy configuration string, e.g., "http://0.0.0.0:8050::https://my.domain.com".',
+    )
+
+    # Debug flag (supports --debug and --no-debug)
+    # Note: Requires Python 3.9+
+    run_parser.add_argument(
+        "--debug",
+        "-d",
+        action=argparse.BooleanOptionalAction,
+        help="Enable/disable Flask debug mode and dev tools.",
+    )
+
+    # Dev Tools options
+    dev_tools_group = run_parser.add_argument_group("dev tools options")
+    dev_tools_group.add_argument(
+        "--dev-tools-ui",
+        action=argparse.BooleanOptionalAction,
+        help="Enable/disable the dev tools UI.",
+    )
+    dev_tools_group.add_argument(
+        "--dev-tools-props-check",
+        action=argparse.BooleanOptionalAction,
+        help="Enable/disable component prop validation.",
+    )
+    dev_tools_group.add_argument(
+        "--dev-tools-serve-dev-bundles",
+        action=argparse.BooleanOptionalAction,
+        help="Enable/disable serving of dev bundles.",
+    )
+    dev_tools_group.add_argument(
+        "--dev-tools-hot-reload",
+        action=argparse.BooleanOptionalAction,
+        help="Enable/disable hot reloading.",
+    )
+    dev_tools_group.add_argument(
+        "--dev-tools-hot-reload-interval",
+        type=float,
+        help="Interval in seconds for hot reload polling (Default: 3).",
+    )
+    dev_tools_group.add_argument(
+        "--dev-tools-hot-reload-watch-interval",
+        type=float,
+        help="Interval in seconds for server-side file watch polling (Default: 0.5).",
+    )
+    dev_tools_group.add_argument(
+        "--dev-tools-hot-reload-max-retry",
+        type=int,
+        help="Max number of failed hot reload requests before failing (Default: 8).",
+    )
+    dev_tools_group.add_argument(
+        "--dev-tools-silence-routes-logging",
+        action=argparse.BooleanOptionalAction,
+        help="Enable/disable silencing of Werkzeug's route logging.",
+    )
+    dev_tools_group.add_argument(
+        "--dev-tools-disable-version-check",
+        action=argparse.BooleanOptionalAction,
+        help="Enable/disable the Dash version upgrade check.",
+    )
+    dev_tools_group.add_argument(
+        "--dev-tools-prune-errors",
+        action=argparse.BooleanOptionalAction,
+        help="Enable/disable pruning of tracebacks to user code only.",
+    )
+
+    return parser
+
+
+def cli():
+    """The main entry point for the Plotly CLI."""
+    sys.path.insert(0, ".")
+    parser = create_parser()
+    args = parser.parse_args()
+
+    try:
+        if args.command == "run":
+            app = load_app(args.app)
+
+            # Collect arguments to pass to the app.run() method.
+            # Only include arguments that were actually provided on the CLI
+            # or have a default value in the parser.
+            run_options: Dict[str, Any] = {
+                key: value
+                for key, value in vars(args).items()
+                if value is not None and key not in ["command", "app"]
+            }
+
+            app.run(**run_options)
+
+    except (ValueError, ImportError, AttributeError, TypeError) as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,8 @@ import os
 from setuptools import setup, find_packages
 
 main_ns = {}
-exec(open("dash/version.py", encoding="utf-8").read(), main_ns)  # pylint: disable=exec-used, consider-using-with
+# pylint: disable=exec-used, consider-using-with
+exec(open("dash/version.py", encoding="utf-8").read(), main_ns)
 
 
 def read_req_file(req_type):
@@ -21,10 +22,10 @@ setup(
     include_package_data=True,
     license="MIT",
     description=(
-        "A Python framework for building reactive web-apps. "
-        "Developed by Plotly."
+        "A Python framework for building reactive web-apps. " "Developed by Plotly."
     ),
-    long_description=io.open("README.md", encoding="utf-8").read(),  # pylint: disable=consider-using-with
+    # pylint: disable=consider-using-with
+    long_description=io.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     install_requires=read_req_file("install"),
     python_requires=">=3.8",
@@ -34,14 +35,14 @@ setup(
         "testing": read_req_file("testing"),
         "celery": read_req_file("celery"),
         "diskcache": read_req_file("diskcache"),
-        "compress": read_req_file("compress")
+        "compress": read_req_file("compress"),
     },
     entry_points={
         "console_scripts": [
-            "dash-generate-components = "
-            "dash.development.component_generator:cli",
+            "dash-generate-components = dash.development.component_generator:cli",
             "renderer = dash.development.build_process:renderer",
-            "dash-update-components = dash.development.update_components:cli"
+            "dash-update-components = dash.development.update_components:cli",
+            "plotly = dash._cli:cli",
         ],
         "pytest11": ["dash = dash.testing.plugin"],
     },
@@ -78,16 +79,18 @@ setup(
     ],
     data_files=[
         # like `jupyter nbextension install --sys-prefix`
-        ("share/jupyter/nbextensions/dash", [
-            "dash/nbextension/main.js",
-        ]),
+        (
+            "share/jupyter/nbextensions/dash",
+            [
+                "dash/nbextension/main.js",
+            ],
+        ),
         # like `jupyter nbextension enable --sys-prefix`
-        ("etc/jupyter/nbconfig/notebook.d", [
-            "dash/nbextension/dash.json"
-        ]),
+        ("etc/jupyter/nbconfig/notebook.d", ["dash/nbextension/dash.json"]),
         # Place jupyterlab extension in extension directory
-        ("share/jupyter/lab/extensions", [
-            "dash/labextension/dist/dash-jupyterlab.tgz"
-        ]),
+        (
+            "share/jupyter/lab/extensions",
+            ["dash/labextension/dist/dash-jupyterlab.tgz"],
+        ),
     ],
 )


### PR DESCRIPTION
Add a command to run dash app from the terminal.

The command can be run two methods:
- `plotly run app:app --debug`
- `python -m dash run app:app --debug`

The arguments follow `Dash.run`, run help:
```
$ plotly run --help
usage: plotly run [-h] [--host HOST] [--port PORT] [--proxy PROXY] [--debug | --no-debug | -d] [--dev-tools-ui | --no-dev-tools-ui] [--dev-tools-props-check | --no-dev-tools-props-check]
                  [--dev-tools-serve-dev-bundles | --no-dev-tools-serve-dev-bundles] [--dev-tools-hot-reload | --no-dev-tools-hot-reload] [--dev-tools-hot-reload-interval DEV_TOOLS_HOT_RELOAD_INTERVAL]
                  [--dev-tools-hot-reload-watch-interval DEV_TOOLS_HOT_RELOAD_WATCH_INTERVAL] [--dev-tools-hot-reload-max-retry DEV_TOOLS_HOT_RELOAD_MAX_RETRY]
                  [--dev-tools-silence-routes-logging | --no-dev-tools-silence-routes-logging] [--dev-tools-disable-version-check | --no-dev-tools-disable-version-check] [--dev-tools-prune-errors | --no-dev-tools-prune-errors]
                  app

Run a local development server for a Dash app.

positional arguments:
  app                   The Dash app to run, in the format "module:variable".

options:
  -h, --help            show this help message and exit
  --host HOST           Host IP used to serve the application (Default: "127.0.0.1").
  --port PORT, -p PORT  Port used to serve the application (Default: "8050").
  --proxy PROXY         Proxy configuration string, e.g., "http://0.0.0.0:8050::https://my.domain.com".
  --debug, --no-debug, -d
                        Enable/disable Flask debug mode and dev tools.

dev tools options:
  --dev-tools-ui, --no-dev-tools-ui
                        Enable/disable the dev tools UI.
  --dev-tools-props-check, --no-dev-tools-props-check
                        Enable/disable component prop validation.
  --dev-tools-serve-dev-bundles, --no-dev-tools-serve-dev-bundles
                        Enable/disable serving of dev bundles.
  --dev-tools-hot-reload, --no-dev-tools-hot-reload
                        Enable/disable hot reloading.
  --dev-tools-hot-reload-interval DEV_TOOLS_HOT_RELOAD_INTERVAL
                        Interval in seconds for hot reload polling (Default: 3).
  --dev-tools-hot-reload-watch-interval DEV_TOOLS_HOT_RELOAD_WATCH_INTERVAL
                        Interval in seconds for server-side file watch polling (Default: 0.5).
  --dev-tools-hot-reload-max-retry DEV_TOOLS_HOT_RELOAD_MAX_RETRY
                        Max number of failed hot reload requests before failing (Default: 8).
  --dev-tools-silence-routes-logging, --no-dev-tools-silence-routes-logging
                        Enable/disable silencing of Werkzeug's route logging.
  --dev-tools-disable-version-check, --no-dev-tools-disable-version-check
                        Enable/disable the Dash version upgrade check.
  --dev-tools-prune-errors, --no-dev-tools-prune-errors
                        Enable/disable pruning of tracebacks to user code only.

```
