### PR TITLE
Api exposure callbacks

### DIFF
--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -72,6 +72,7 @@ class NoUpdate:
 GLOBAL_CALLBACK_LIST = []
 GLOBAL_CALLBACK_MAP = {}
 GLOBAL_INLINE_SCRIPTS = []
+GLOBAL_API_PATHS = {}
 
 
 # pylint: disable=too-many-locals
@@ -87,6 +88,7 @@ def callback(
     cache_args_to_ignore: Optional[list] = None,
     cache_ignore_triggered=True,
     on_error: Optional[Callable[[Exception], Any]] = None,
+    api_path: Optional[str] = None,
     **_kwargs,
 ) -> Callable[..., Any]:
     """
@@ -178,6 +180,7 @@ def callback(
     )
     callback_map = _kwargs.pop("callback_map", GLOBAL_CALLBACK_MAP)
     callback_list = _kwargs.pop("callback_list", GLOBAL_CALLBACK_LIST)
+    callback_api_paths = _kwargs.pop("callback_api_paths", GLOBAL_API_PATHS)
 
     if background:
         background_spec: Any = {
@@ -217,12 +220,14 @@ def callback(
         callback_list,
         callback_map,
         config_prevent_initial_callbacks,
+        callback_api_paths,
         *_args,
         **_kwargs,
         background=background_spec,
         manager=manager,
         running=running,
         on_error=on_error,
+        api_path=api_path,
     )
 
 
@@ -585,7 +590,12 @@ def _prepare_response(
 
 # pylint: disable=too-many-branches,too-many-statements
 def register_callback(
-    callback_list, callback_map, config_prevent_initial_callbacks, *_args, **_kwargs
+    callback_list,
+    callback_map,
+    config_prevent_initial_callbacks,
+    callback_api_paths,
+    *_args,
+    **_kwargs,
 ):
     (
         output,
@@ -638,6 +648,10 @@ def register_callback(
 
     # pylint: disable=too-many-locals
     def wrap_func(func):
+        if _kwargs.get("api_path"):
+            api_path = _kwargs.get("api_path")
+            callback_api_paths[api_path] = func
+
         if background is None:
             background_key = None
         else:

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -88,7 +88,7 @@ def callback(
     cache_args_to_ignore: Optional[list] = None,
     cache_ignore_triggered=True,
     on_error: Optional[Callable[[Exception], Any]] = None,
-    api_path: Optional[str] = None,
+    api_endpoint: Optional[str] = None,
     **_kwargs,
 ) -> Callable[..., Any]:
     """
@@ -227,7 +227,7 @@ def callback(
         manager=manager,
         running=running,
         on_error=on_error,
-        api_path=api_path,
+        api_endpoint=api_endpoint,
     )
 
 
@@ -648,9 +648,9 @@ def register_callback(
 
     # pylint: disable=too-many-locals
     def wrap_func(func):
-        if _kwargs.get("api_path"):
-            api_path = _kwargs.get("api_path")
-            callback_api_paths[api_path] = func
+        if _kwargs.get("api_endpoint"):
+            api_endpoint = _kwargs.get("api_endpoint")
+            callback_api_paths[api_endpoint] = func
 
         if background is None:
             background_key = None

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -809,7 +809,6 @@ class Dash(ObsoleteChecker):
             return _parse_body_async
 
         for path, func in self.callback_api_paths.items():
-            print(path)
             if asyncio.iscoroutinefunction(func):
                 self._add_url(path, make_parse_body_async(func), ["POST"])
             else:


### PR DESCRIPTION
This PR strives to allow callbacks to be exposed by the underlying server as an API by simply passing the callback a `api_endpoint`. The api will accept a body with the functional arguments provided as `kwargs`.