### PR TITLE
run async test in separate step & flaky cbsc001

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -34,6 +34,8 @@ jobs:
               - 'dash/dash-renderer/**'
               - 'dash/_callback.py'
               - 'dash/_callback_context.py'
+              - 'tests/background_callback/**'
+              - 'tests/async_tests/**'
               - 'requirements/**'
 
   build:
@@ -263,6 +265,10 @@ jobs:
           cd bgtests
           touch __init__.py
           pytest --headless --nopercyfinalize tests/background_callback -v -s
+
+      - name: Run Async Callback Tests
+        run: |
+          cd bgtests
           pytest --headless --nopercyfinalize tests/async_tests -v -s
 
   table-unit:

--- a/tests/async_tests/test_async_callbacks.py
+++ b/tests/async_tests/test_async_callbacks.py
@@ -1,6 +1,8 @@
 import json
 import time
 
+import flaky
+
 from multiprocessing import Lock, Value
 import pytest
 
@@ -27,6 +29,7 @@ from tests.integration.utils import json_engine
 from tests.utils import is_dash_async
 
 
+@flaky.flaky(max_runs=3)
 def test_async_cbsc001_simple_callback(dash_duo):
     if not is_dash_async():
         return


### PR DESCRIPTION
The async_tests fails or timeout often. Run them in a separate step and mark cbsc001 flaky.