### PR TITLE
fix cookie transpiling

### DIFF
--- a/dash/dash-renderer/babel.config.js
+++ b/dash/dash-renderer/babel.config.js
@@ -1,10 +1,15 @@
 module.exports = {
     presets: [
         '@babel/preset-typescript',
-        '@babel/preset-env',
+        ['@babel/preset-env', {
+            "targets": {
+                "browsers": ["last 10 years and not dead"]
+            }
+        }],
         '@babel/preset-react'
     ],
     plugins: [
         '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-transform-optional-chaining',
     ],
 };

--- a/dash/dash-renderer/package-lock.json
+++ b/dash/dash-renderer/package-lock.json
@@ -34,6 +34,7 @@
         "@babel/cli": "^7.28.0",
         "@babel/core": "^7.28.0",
         "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-transform-optional-chaining": "^7.27.1",
         "@babel/preset-env": "^7.27.2",
         "@babel/preset-react": "^7.27.1",
         "@babel/preset-typescript": "^7.27.1",

--- a/dash/dash-renderer/package.json
+++ b/dash/dash-renderer/package.json
@@ -46,6 +46,7 @@
     "@babel/cli": "^7.28.0",
     "@babel/core": "^7.28.0",
     "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-transform-optional-chaining": "^7.27.1",
     "@babel/preset-env": "^7.27.2",
     "@babel/preset-react": "^7.27.1",
     "@babel/preset-typescript": "^7.27.1",
@@ -74,12 +75,12 @@
     "mocha": "^10.4.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.8.8",
+    "rimraf": "^5.0.5",
     "style-loader": "^3.3.3",
     "ts-loader": "^9.5.2",
     "typescript": "^5.8.3",
     "webpack": "^5.101.0",
     "webpack-cli": "^5.1.4",
-    "rimraf": "^5.0.5",
     "whatwg-fetch": "^3.6.20"
   },
   "files": [

--- a/dash/dash-renderer/webpack.base.config.js
+++ b/dash/dash-renderer/webpack.base.config.js
@@ -16,7 +16,7 @@ const defaults = {
             },
             {
                 test: /\.jsx?$/,
-                include: /node_modules[\\\/](cytoscape-fcose|ramda|react-cytoscapejs|react-redux)[\\\/]/,
+                include: /node_modules[\\\/](cytoscape-fcose|ramda|react-cytoscapejs|react-redux|cookie)[\\\/]/,
                 use: {
                     loader: 'babel-loader',
                     options: {
@@ -24,6 +24,9 @@ const defaults = {
                         configFile: false,
                         presets: [
                             '@babel/preset-env'
+                        ],
+                        plugins: [
+                            '@babel/plugin-transform-optional-chaining'
                         ]
                     }
                 }


### PR DESCRIPTION
The new cookie version required more babel transform options and was failing the es-check when running from `dash/dash-renderer`.

