### PR TITLE
Add app_context to get_app, allowing to get the current app in routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Added
 - [#3395](https://github.com/plotly/dash/pull/3396) Add position argument to hooks.devtool
+- [#3403](https://github.com/plotly/dash/pull/3403) Add app_context to get_app, allowing to get the current app in routes.
 
 ## Fixed
 - [#3395](https://github.com/plotly/dash/pull/3395) Fix Components added through set_props() cannot trigger related callback functions. Fix [#3316](https://github.com/plotly/dash/issues/3316)

--- a/dash/_get_app.py
+++ b/dash/_get_app.py
@@ -1,16 +1,58 @@
+import functools
+
+from contextvars import ContextVar, copy_context
 from textwrap import dedent
 
 APP = None
 
+app_context = ContextVar("dash_app_context")
+
+
+def with_app_context(func):
+    @functools.wraps(func)
+    def wrap(self, *args, **kwargs):
+        app_context.set(self)
+        ctx = copy_context()
+        return ctx.run(func, self, *args, **kwargs)
+
+    return wrap
+
+
+def with_app_context_async(func):
+    @functools.wraps(func)
+    async def wrap(self, *args, **kwargs):
+        app_context.set(self)
+        ctx = copy_context()
+        print("copied and set")
+        return await ctx.run(func, self, *args, **kwargs)
+
+    return wrap
+
+
+def with_app_context_factory(func, app):
+    @functools.wraps(func)
+    def wrap(*args, **kwargs):
+        app_context.set(app)
+        ctx = copy_context()
+        return ctx.run(func, *args, **kwargs)
+
+    return wrap
+
 
 def get_app():
+    try:
+        ctx_app = app_context.get()
+        if ctx_app is not None:
+            return ctx_app
+    except LookupError:
+        pass
+
     if APP is None:
         raise Exception(
             dedent(
                 """
                 App object is not yet defined.  `app = dash.Dash()` needs to be run
-                before `dash.get_app()` is called and can only be used within apps that use
-                the `pages` multi-page app feature: `dash.Dash(use_pages=True)`.
+                before `dash.get_app()`.
 
                 `dash.get_app()` is used to get around circular import issues when Python files
                 within the pages/` folder need to reference the `app` object.


### PR DESCRIPTION
Modify `dash.get_app` to add contextualized app reference available during callbacks/layout/index/routes hooks.

