### PR TITLE
Fix the client-side callback with multiple Outputs return single no_update

### DIFF
--- a/dash/dash-renderer/src/actions/callbacks.ts
+++ b/dash/dash-renderer/src/actions/callbacks.ts
@@ -226,8 +226,16 @@ function refErr(errors: any, paths: any) {
 const getVals = (input: any) =>
     Array.isArray(input) ? pluck('value', input) : input.value;
 
-const zipIfArray = (a: any, b: any) =>
-    Array.isArray(a) ? zip(a, b) : [[a, b]];
+const zipIfArray = (a: any, b: any) => {
+    if (Array.isArray(a)) {
+        // For client-side callbacks with multiple Outputs, only return a single dash_clientside.no_update
+        if (b?.description === 'Return to prevent updating an Output.') {
+            return zip(a, [b]);
+        }
+        return zip(a, b);
+    }
+    return [[a, b]];
+};
 
 function cleanOutputProp(property: string) {
     return property.split('@')[0];

--- a/tests/integration/clientside/test_clientside_multiple_output_return_single_no_update.py
+++ b/tests/integration/clientside/test_clientside_multiple_output_return_single_no_update.py
@@ -1,0 +1,46 @@
+from dash import (
+    Dash,
+    Input,
+    Output,
+    html,
+    clientside_callback,
+)
+
+
+def test_cmorsnu001_clientside_multiple_output_return_single_no_update(dash_duo):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            html.Button("trigger", id="trigger-demo"),
+            html.Div("demo1", id="output-demo1"),
+            html.Div("demo2", id="output-demo2"),
+        ],
+        style={"padding": 50},
+    )
+
+    clientside_callback(
+        """(n_clicks) => {
+            try {
+                return window.dash_clientside.no_update;
+            } catch (e) {
+                return [null, null];
+            }
+        }""",
+        Output("output-demo1", "children"),
+        Output("output-demo2", "children"),
+        Input("trigger-demo", "n_clicks"),
+        prevent_initial_call=True,
+    )
+
+    dash_duo.start_server(app)
+
+    trigger_clicker = dash_duo.wait_for_element("#trigger-demo")
+    trigger_clicker.click()
+    dash_duo.wait_for_text_to_equal(
+        "#output-demo1",
+        "demo1",
+    )
+    dash_duo.wait_for_text_to_equal(
+        "#output-demo2",
+        "demo2",
+    )


### PR DESCRIPTION
Fix the error triggered when only a single no_update is returned for client-side callback functions with multiple Outputs, Closes #3366 .