### PR TITLE
Added API to reverse direction of slider

### DIFF
--- a/components/dash-core-components/src/components/Slider.react.js
+++ b/components/dash-core-components/src/components/Slider.react.js
@@ -157,6 +157,11 @@ Slider.propTypes = {
     verticalHeight: PropTypes.number,
 
     /**
+     * If the value is true, it means the component is rendered reverse.
+     */
+    reverse: PropTypes.bool,
+
+    /**
      * Additional CSS class for the root DOM node
      */
     className: PropTypes.string,
@@ -208,6 +213,7 @@ Slider.defaultProps = {
     persisted_props: ['value'],
     persistence_type: 'local',
     verticalHeight: 400,
+    reverse: false,
 };
 
 export const propTypes = Slider.propTypes;

--- a/components/dash-core-components/src/fragments/Slider.react.js
+++ b/components/dash-core-components/src/fragments/Slider.react.js
@@ -27,6 +27,7 @@ const sliderProps = [
     'included',
     'tooltip',
     'vertical',
+    'reverse',
     'id',
 ];
 


### PR DESCRIPTION
Solves #3442 
## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] Extended the Slider API to allow reverse rendering. 

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
