### PR TITLE
fix errors tab selected by default

### DIFF
--- a/dash/dash-renderer/src/components/error/menu/DebugMenu.react.js
+++ b/dash/dash-renderer/src/components/error/menu/DebugMenu.react.js
@@ -168,7 +168,7 @@ const Debug = ({error, hotReload, config, children}) => {
     const errors = concat(error.frontEnd, error.backEnd);
 
     useEffect(() => {
-        if (error !== null && popup !== 'errors') {
+        if (errors.length && popup !== 'errors') {
             setPopup('errors');
         }
     }, [error]);


### PR DESCRIPTION
The errors tab in the devtools reverted to being "open" by default, fix the check.