### PR TITLE
Bugfix: `v4.0.0rc3` feedback

### DIFF
--- a/components/dash-core-components/jest.config.js
+++ b/components/dash-core-components/jest.config.js
@@ -33,5 +33,5 @@ module.exports = {
     // Disable caching to ensure TypeScript type changes are always picked up
     cache: false,
     // Limit workers in CI to prevent out-of-memory errors
-    maxWorkers: process.env.CI ? 2 : undefined,
+    maxWorkers: 2,
 };

--- a/components/dash-core-components/src/components/Input.tsx
+++ b/components/dash-core-components/src/components/Input.tsx
@@ -11,7 +11,12 @@ import React, {
 import uniqid from 'uniqid';
 import fastIsNumeric from 'fast-isnumeric';
 import LoadingElement from '../utils/_LoadingElement';
-import {PersistedProps, PersistenceTypes} from '../types';
+import {
+    HTMLInputTypes,
+    InputProps,
+    PersistedProps,
+    PersistenceTypes,
+} from '../types';
 import './css/input.css';
 
 const isNumeric = (val: unknown): val is number => fastIsNumeric(val);
@@ -19,238 +24,6 @@ const convert = (val: unknown) => (isNumeric(val) ? +val : NaN);
 
 const isEquivalent = (v1: number, v2: number) =>
     v1 === v2 || (isNaN(v1) && isNaN(v2));
-
-export enum HTMLInputTypes {
-    // Only allowing the input types with wide browser compatibility
-    'text' = 'text',
-    'number' = 'number',
-    'password' = 'password',
-    'email' = 'email',
-    'range' = 'range',
-    'search' = 'search',
-    'tel' = 'tel',
-    'url' = 'url',
-    'hidden' = 'hidden',
-}
-
-type InputProps = {
-    /**
-     * The value of the input
-     */
-    value?: string | number;
-    /**
-     * If true, changes to input will be sent back to the Dash server only on enter or when losing focus.
-     * If it's false, it will send the value back on every change.
-     * If a number, it will not send anything back to the Dash server until the user has stopped
-     * typing for that number of seconds.
-     */
-    debounce?: boolean | number;
-    /**
-     * A hint to the user of what can be entered in the control . The placeholder text must not contain carriage returns or line-feeds. Note: Do not use the placeholder attribute instead of a <label> element, their purposes are different. The <label> attribute describes the role of the form element (i.e. it indicates what kind of information is expected), and the placeholder attribute is a hint about the format that the content should take. There are cases in which the placeholder attribute is never displayed to the user, so the form must be understandable without it.
-     */
-    placeholder?: string | number;
-    /**
-     * Number of times the `Enter` key was pressed while the input had focus.
-     */
-    n_submit?: number;
-    /**
-     * Last time that `Enter` was pressed.
-     */
-    n_submit_timestamp?: number;
-    /**
-     * Provides a hint to the browser as to the type of data that might be
-     * entered by the user while editing the element or its contents.
-     */
-    inputMode?: /**
-     * Alphanumeric, non-prose content such as usernames and passwords.
-     */
-    | 'verbatim'
-        /**
-         * Latin-script input in the user's preferred language with typing aids such as text prediction enabled. For human-to-computer communication such as search boxes.
-         */
-        | 'latin'
-        /**
-         * As latin, but for human names.
-         */
-        | 'latin-name'
-        /**
-         * As latin, but with more aggressive typing aids. For human-to-human communication such as instant messaging or email.
-         */
-        | 'latin-prose'
-        /**
-         * As latin-prose, but for the user's secondary languages.
-         */
-        | 'full-width-latin'
-        /**
-         * Kana or romaji input, typically hiragana input, using full-width characters, with support for converting to kanji. Intended for Japanese text input.
-         */
-        | 'kana'
-        /**
-         * Katakana input, using full-width characters, with support for converting to kanji. Intended for Japanese text input.
-         */
-        | 'katakana'
-        /**
-         * Numeric input, including keys for the digits 0 to 9, the user's preferred thousands separator character, and the character for indicating negative numbers. Intended for numeric codes (e.g. credit card numbers). For actual numbers, prefer using type="number"
-         */
-        | 'numeric'
-        /**
-         * Telephone input, including asterisk and pound key. Use type="tel" if possible instead.
-         */
-        | 'tel'
-        /**
-         * Email input. Use type="email" if possible instead.
-         */
-        | 'email'
-        /**
-         * URL input. Use type="url" if possible instead.
-         */
-        | 'url';
-    /**
-     * This attribute indicates whether the value of the control can be automatically completed by the browser.
-     */
-    autoComplete?: string;
-    /**
-     * This attribute indicates that the user cannot modify the value of the control. The value of the attribute is irrelevant. If you need read-write access to the input value, do not add the "readonly" attribute. It is ignored if the value of the type attribute is hidden, range, color, checkbox, radio, file, or a button type (such as button or submit).
-     * readOnly is an HTML boolean attribute - it is enabled by a boolean or
-     * 'readOnly'. Alternative capitalizations `readonly` & `READONLY`
-     * are also acccepted.
-     */
-    readOnly?: boolean | 'readOnly' | 'readonly' | 'READONLY';
-    /**
-     * This attribute specifies that the user must fill in a value before submitting a form. It cannot be used when the type attribute is hidden, image, or a button type (submit, reset, or button). The :optional and :required CSS pseudo-classes will be applied to the field as appropriate.
-     * required is an HTML boolean attribute - it is enabled by a boolean or
-     * 'required'. Alternative capitalizations `REQUIRED`
-     * are also acccepted.
-     */
-    required?: boolean | 'required' | 'REQUIRED';
-    /**
-     * The element should be automatically focused after the page loaded.
-     * autoFocus is an HTML boolean attribute - it is enabled by a boolean or
-     * 'autoFocus'. Alternative capitalizations `autofocus` & `AUTOFOCUS`
-     * are also acccepted.
-     */
-    autoFocus?: boolean | 'autoFocus' | 'autofocus' | 'AUTOFOCUS';
-    /**
-     * If true, the input is disabled and can't be clicked on.
-     * disabled is an HTML boolean attribute - it is enabled by a boolean or
-     * 'disabled'. Alternative capitalizations `DISABLED`
-     */
-    disabled?: boolean | 'disabled' | 'DISABLED';
-    /**
-     * Identifies a list of pre-defined options to suggest to the user.
-     * The value must be the id of a <datalist> element in the same document.
-     * The browser displays only options that are valid values for this
-     * input element.
-     * This attribute is ignored when the type attribute's value is
-     * hidden, checkbox, radio, file, or a button type.
-     */
-    list?: string;
-    /**
-     * This Boolean attribute indicates whether the user can enter more than one value. This attribute applies when the type attribute is set to email or file, otherwise it is ignored.
-     */
-    multiple?: boolean;
-    /**
-     * Setting the value of this attribute to true indicates that the element needs to have its spelling and grammar checked. The value default indicates that the element is to act according to a default behavior, possibly based on the parent element's own spellcheck value. The value false indicates that the element should not be checked.
-     */
-    spellCheck?: boolean | 'true' | 'false';
-    /**
-     * The name of the control, which is submitted with the form data.
-     */
-    name?: string;
-    /**
-     * The minimum (numeric or date-time) value for this item, which must not be greater than its maximum (max attribute) value.
-     */
-    min?: string | number;
-    /**
-     * The maximum (numeric or date-time) value for this item, which must not be less than its minimum (min attribute) value.
-     */
-    max?: string | number;
-    /**
-     * Works with the min and max attributes to limit the increments at which a numeric or date-time value can be set. It can be the string any or a positive floating point number. If this attribute is not set to any, the control accepts only values at multiples of the step value greater than the minimum.
-     */
-    step?: string | number;
-    /**
-     * If the value of the type attribute is text, email, search, password, tel, or url, this attribute specifies the minimum number of characters (in Unicode code points) that the user can enter. For other control types, it is ignored.
-     */
-    minLength?: string | number;
-    /**
-     * If the value of the type attribute is text, email, search, password, tel, or url, this attribute specifies the maximum number of characters (in UTF-16 code units) that the user can enter. For other control types, it is ignored. It can exceed the value of the size attribute. If it is not specified, the user can enter an unlimited number of characters. Specifying a negative number results in the default behavior (i.e. the user can enter an unlimited number of characters). The constraint is evaluated only when the value of the attribute has been changed.
-     */
-    maxLength?: string | number;
-    /**
-     * A regular expression that the control's value is checked against. The pattern must match the entire value, not just some subset. Use the title attribute to describe the pattern to help the user. This attribute applies when the value of the type attribute is text, search, tel, url, email, or password, otherwise it is ignored. The regular expression language is the same as JavaScript RegExp algorithm, with the 'u' parameter that makes it treat the pattern as a sequence of unicode code points. The pattern is not surrounded by forward slashes.
-     */
-    pattern?: string;
-    /**
-     * The offset into the element's text content of the first selected character. If there's no selection, this value indicates the offset to the character following the current text input cursor position (that is, the position the next character typed would occupy).
-     */
-    selectionStart?: string;
-    /**
-     * The offset into the element's text content of the last selected character. If there's no selection, this value indicates the offset to the character following the current text input cursor position (that is, the position the next character typed would occupy).
-     */
-    selectionEnd?: string;
-    /**
-     * The direction in which selection occurred. This is "forward" if the selection was made from left-to-right in an LTR locale or right-to-left in an RTL locale, or "backward" if the selection was made in the opposite direction. On platforms on which it's possible this value isn't known, the value can be "none"; for example, on macOS, the default direction is "none", then as the user begins to modify the selection using the keyboard, this will change to reflect the direction in which the selection is expanding.
-     */
-    selectionDirection?: string;
-    /**
-     * Number of times the input lost focus.
-     */
-    n_blur?: number;
-    /**
-     * Last time the input lost focus.
-     */
-    n_blur_timestamp?: number;
-    /**
-     * The initial size of the control. This value is in pixels unless the value of the type attribute is text or password, in which case it is an integer number of characters. Starting in, this attribute applies only when the type attribute is set to text, search, tel, url, email, or password, otherwise it is ignored. In addition, the size must be greater than zero. If you do not specify a size, a default value of 20 is used.' simply states "the user agent should ensure that at least that many characters are visible", but different characters can have different widths in certain fonts. In some browsers, a certain string with x characters will not be entirely visible even if size is defined to at least x.
-     */
-    size?: string;
-    /**
-     * The input's inline styles
-     */
-    style?: React.CSSProperties;
-    /**
-     * The class of the input element
-     */
-    className?: string;
-    /**
-     * The ID of this component, used to identify dash components
-     * in callbacks. The ID needs to be unique across all of the
-     * components in an app.
-     */
-    id?: string;
-    /**
-     * Dash-assigned callback that gets fired when the value changes.
-     */
-    setProps: (props: Partial<InputProps>) => void;
-    /**
-     * Used to allow user interactions in this component to be persisted when
-     * the component - or the page - is refreshed. If `persisted` is truthy and
-     * hasn't changed from its previous value, a `value` that the user has
-     * changed while using the app will keep that change, as long as
-     * the new `value` also matches what was given originally.
-     * Used in conjunction with `persistence_type`.
-     */
-    persistence?: boolean | string | number;
-    /**
-     * Properties whose user interactions will persist after refreshing the
-     * component or the page. Since only `value` is allowed this prop can
-     * normally be ignored.
-     */
-    persisted_props?: PersistedProps[];
-    /**
-     * Where persisted user changes will be stored:
-     * memory: only kept in memory, reset on page refresh.
-     * local: window.localStorage, data is kept after the browser quit.
-     * session: window.sessionStorage, data is cleared once the browser quit.
-     */
-    persistence_type?: PersistenceTypes;
-
-    /**
-     * The type of control to render.
-     */
-    type?: HTMLInputTypes;
-};
 
 const inputProps = [
     'type',
@@ -289,12 +62,17 @@ function Input({
     type = HTMLInputTypes.text,
     inputMode = 'verbatim',
     n_blur = 0,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     n_blur_timestamp = -1,
     n_submit = 0,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     n_submit_timestamp = -1,
     debounce = false,
     step = 'any',
+    autoComplete = 'off',
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     persisted_props = [PersistedProps.value],
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     persistence_type = PersistenceTypes.local,
     disabled,
     ...props
@@ -470,6 +248,7 @@ function Input({
         type,
         inputMode,
         step,
+        autoComplete,
         disabled: disabledAsBool,
     }) as Pick<InputHTMLAttributes<HTMLInputElement>, HTMLInputProps>;
 

--- a/components/dash-core-components/src/components/RadioItems.tsx
+++ b/components/dash-core-components/src/components/RadioItems.tsx
@@ -54,7 +54,9 @@ export default function RadioItems({
                     options={sanitizedOptions}
                     selected={isNil(value) ? [] : [value]}
                     onSelectionChange={selection => {
-                        setProps({value: selection[selection.length - 1]});
+                        if (selection.length) {
+                            setProps({value: selection[selection.length - 1]});
+                        }
                     }}
                     {...stylingProps}
                 />

--- a/components/dash-core-components/src/components/css/datepickers.css
+++ b/components/dash-core-components/src/components/css/datepickers.css
@@ -8,7 +8,7 @@
     outline: none;
     width: 100%;
     font-size: inherit;
-    overflow: hidden;
+    position: relative;
     accent-color: var(--Dash-Fill-Interactive-Strong);
     outline-color: var(--Dash-Fill-Interactive-Strong);
 }
@@ -230,4 +230,9 @@
 .dash-datepicker-month-nav svg {
     width: 20px;
     height: 20px;
+}
+
+/* Override Radix's position: fixed to use position: absolute when using custom container */
+div[data-radix-popper-content-wrapper]:has(.dash-datepicker-content) {
+    position: absolute !important;
 }

--- a/components/dash-core-components/src/components/css/datepickers.css
+++ b/components/dash-core-components/src/components/css/datepickers.css
@@ -20,23 +20,23 @@
     align-items: center;
     gap: calc(var(--Dash-Spacing) * 2);
     box-sizing: border-box;
-    padding: 0 calc(var(--Dash-Spacing) * 2);
+    padding: 0 12px;
 }
 
-.dash-datepicker-input-wrapper:has(:nth-child(3)) {
-    grid-template-columns: auto 1fr auto;
+.dash-datepicker-input-wrapper:has(> :nth-child(2)) {
+    grid-template-columns: 1fr auto;
 }
 
-.dash-datepicker-input-wrapper:has(:nth-child(4)) {
-    grid-template-columns: auto 1fr auto auto;
+.dash-datepicker-input-wrapper:has(> :nth-child(3)) {
+    grid-template-columns: 1fr auto auto;
 }
 
-.dash-datepicker-input-wrapper:has(:nth-child(5)) {
-    grid-template-columns: auto auto auto 1fr auto;
+.dash-datepicker-input-wrapper:has(> :nth-child(4)) {
+    grid-template-columns: 1fr auto 1fr auto;
 }
 
-.dash-datepicker-input-wrapper:has(:nth-child(6)) {
-    grid-template-columns: auto auto auto 1fr auto auto;
+.dash-datepicker-input-wrapper:has(> :nth-child(5)) {
+    grid-template-columns: 1fr auto 1fr auto auto;
 }
 
 .dash-datepicker-input-wrapper,
@@ -55,6 +55,7 @@
     border-radius: 4px;
     padding: 0;
     background-color: inherit;
+    color: inherit;
 }
 
 .dash-datepicker-input::selection,

--- a/components/dash-core-components/src/components/css/datepickers.css
+++ b/components/dash-core-components/src/components/css/datepickers.css
@@ -32,11 +32,11 @@
 }
 
 .dash-datepicker-input-wrapper:has(> :nth-child(4)) {
-    grid-template-columns: 1fr auto 1fr auto;
+    grid-template-columns: auto auto 1fr auto;
 }
 
 .dash-datepicker-input-wrapper:has(> :nth-child(5)) {
-    grid-template-columns: 1fr auto 1fr auto auto;
+    grid-template-columns: auto auto 1fr auto auto;
 }
 
 .dash-datepicker-input-wrapper,

--- a/components/dash-core-components/src/components/css/dropdown.css
+++ b/components/dash-core-components/src/components/css/dropdown.css
@@ -212,3 +212,13 @@
     padding: calc(var(--Dash-Spacing) * 2) calc(var(--Dash-Spacing) * 3);
     box-shadow: 0 -1px 0 0 var(--Dash-Fill-Disabled) inset;
 }
+
+/* Positioning container for the dropdown */
+.dash-dropdown-wrapper {
+    position: relative;
+}
+
+/* Override Radix's position: fixed to use position: absolute when using custom container */
+div[data-radix-popper-content-wrapper]:has(.dash-dropdown-content) {
+    position: absolute !important;
+}

--- a/components/dash-core-components/src/components/css/dropdown.css
+++ b/components/dash-core-components/src/components/css/dropdown.css
@@ -19,14 +19,14 @@
     grid-template-columns: auto 1fr;
     justify-items: start;
     align-items: center;
-    gap: 8px;
+    gap: calc(var(--Dash-Spacing) * 2);
 }
 
-.dash-dropdown-grid-container:has(:nth-child(3)) {
+.dash-dropdown-grid-container:has(> :nth-child(3)) {
     grid-template-columns: auto 1fr auto;
 }
 
-.dash-dropdown-grid-container:has(:nth-child(4)) {
+.dash-dropdown-grid-container:has(> :nth-child(4)) {
     grid-template-columns: auto 1fr auto auto;
 }
 

--- a/components/dash-core-components/src/components/css/input.css
+++ b/components/dash-core-components/src/components/css/input.css
@@ -3,7 +3,7 @@
     position: relative;
     display: inline-flex;
     align-items: center;
-    width: 170px; /* default input width */
+    width: 100%;
     height: 34px;
     background: var(--Dash-Fill-Inverse-Strong);
     border-radius: var(--Dash-Spacing);

--- a/components/dash-core-components/src/components/css/sliders.css
+++ b/components/dash-core-components/src/components/css/sliders.css
@@ -185,6 +185,7 @@
     align-items: center;
     gap: 16px;
     width: 100%;
+    container-type: inline-size;
 }
 
 .dash-slider-wrapper {
@@ -208,7 +209,8 @@
 }
 
 .dash-range-slider-input {
-    width: 64px;
+    min-width: 5cqw; /* 5% of container width */
+    max-width: 15cqw; /* 15% of container width */
     text-align: center;
     -webkit-appearance: textfield;
     -moz-appearance: textfield;
@@ -230,4 +232,20 @@
 .dash-range-slider-input::-webkit-outer-spin-button {
     -webkit-appearance: none;
     margin: 0;
+}
+
+/* Hide inputs on small containers using container queries */
+/* single slider input */
+@container (max-width: 200px) {
+    .dash-slider-container .dash-range-slider-input:only-of-type {
+        display: none;
+    }
+}
+
+/* range slider inputs */
+@container (max-width: 300px) {
+    .dash-slider-container .dash-range-slider-min-input,
+    .dash-slider-container .dash-range-slider-max-input {
+        display: none;
+    }
 }

--- a/components/dash-core-components/src/components/css/tabs.css
+++ b/components/dash-core-components/src/components/css/tabs.css
@@ -32,12 +32,12 @@
 /* Tab selected state */
 .tab--selected {
     border-top: 2px solid var(--tabs-primary);
-    color: black;
-    background-color: white;
+    color: var(--Dash-Text-Primary);
+    background-color: var(--Dash-Fill-Inverse-Strong);
 }
 
 .tab--selected:hover {
-    background-color: white;
+    background-color: var(--Dash-Fill-Inverse-Strong);
 }
 
 /* Tab disabled state */

--- a/components/dash-core-components/src/fragments/DatePickerRange.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerRange.tsx
@@ -135,6 +135,12 @@ const DatePickerRange = ({
                 start_date: dateAsStr(internalStartDate),
                 end_date: dateAsStr(internalEndDate),
             });
+        } else if (!internalStartDate && !internalEndDate) {
+            // Both dates cleared - send undefined for both
+            setProps({
+                start_date: dateAsStr(internalStartDate),
+                end_date: dateAsStr(internalEndDate),
+            });
         } else if (updatemode === 'singledate' && internalStartDate) {
             // Only start changed - send just that one
             setProps({start_date: dateAsStr(internalStartDate)});

--- a/components/dash-core-components/src/fragments/DatePickerRange.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerRange.tsx
@@ -3,7 +3,6 @@ import * as Popover from '@radix-ui/react-popover';
 import {
     ArrowLeftIcon,
     ArrowRightIcon,
-    CalendarIcon,
     CaretDownIcon,
     Cross1Icon,
 } from '@radix-ui/react-icons';
@@ -333,7 +332,6 @@ const DatePickerRange = ({
                             }
                         }}
                     >
-                        <CalendarIcon className="dash-datepicker-trigger-icon" />
                         <AutosizeInput
                             inputRef={node => {
                                 startInputRef.current = node;

--- a/components/dash-core-components/src/fragments/DatePickerSingle.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerSingle.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import * as Popover from '@radix-ui/react-popover';
-import {CalendarIcon, CaretDownIcon, Cross1Icon} from '@radix-ui/react-icons';
+import {CaretDownIcon, Cross1Icon} from '@radix-ui/react-icons';
 import AutosizeInput from 'react-input-autosize';
 import uuid from 'uniqid';
 
@@ -170,7 +170,6 @@ const DatePickerSingle = ({
                             }
                         }}
                     >
-                        <CalendarIcon className="dash-datepicker-trigger-icon" />
                         <AutosizeInput
                             inputRef={node => {
                                 inputRef.current = node;

--- a/components/dash-core-components/src/fragments/Dropdown.tsx
+++ b/components/dash-core-components/src/fragments/Dropdown.tsx
@@ -289,7 +289,7 @@ const Dropdown = (props: DropdownProps) => {
         }
 
         const focusableElements = e.currentTarget.querySelectorAll(
-            'input[type="search"], input[type="checkbox"]:not([disabled])'
+            'input[type="search"], input:not([disabled])'
         ) as NodeListOf<HTMLElement>;
 
         // Don't interfere with the event if there aren't any options that the user can interact with
@@ -505,6 +505,7 @@ const Dropdown = (props: DropdownProps) => {
                                 options={displayOptions}
                                 selected={sanitizedValues}
                                 onSelectionChange={updateSelection}
+                                inputType={multi ? 'checkbox' : 'radio'}
                                 className="dash-dropdown-options"
                                 optionClassName="dash-dropdown-option"
                                 optionStyle={{

--- a/components/dash-core-components/src/fragments/Dropdown.tsx
+++ b/components/dash-core-components/src/fragments/Dropdown.tsx
@@ -264,7 +264,7 @@ const Dropdown = (props: DropdownProps) => {
                 searchInputRef.current.focus();
             }
         });
-    }, [isOpen, multi, displayOptions, sanitizedValues]);
+    }, [isOpen, multi, displayOptions]);
 
     // Handle keyboard navigation in popover
     const handleKeyDown = useCallback((e: React.KeyboardEvent) => {

--- a/components/dash-core-components/src/fragments/RangeSlider.tsx
+++ b/components/dash-core-components/src/fragments/RangeSlider.tsx
@@ -152,7 +152,7 @@ export default function RangeSlider(props: RangeSliderProps) {
         );
 
         const maxDecimalChars = Math.min(
-            String(stepValue).split('.')[1]?.length + 1 ?? 0,
+            (String(stepValue).split('.')[1]?.length ?? -1) + 1,
             3
         );
 

--- a/components/dash-core-components/src/fragments/RangeSlider.tsx
+++ b/components/dash-core-components/src/fragments/RangeSlider.tsx
@@ -45,9 +45,8 @@ export default function RangeSlider(props: RangeSliderProps) {
     // For range slider, we expect an array of values
     const [value, setValue] = useState<number[]>(propValue || []);
 
-    // Track slider dimension (width for horizontal, height for vertical) for conditional input rendering
+    // Track slider dimension (width for horizontal, height for vertical) for marks rendering
     const [sliderWidth, setSliderWidth] = useState<number | null>(null);
-    const [showInputs, setShowInputs] = useState<boolean>(value.length === 2);
 
     const sliderRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
@@ -64,22 +63,9 @@ export default function RangeSlider(props: RangeSliderProps) {
         }
     }, []);
 
-    // Dynamic dimension detection using ResizeObserver (width for horizontal, height for vertical)
+    // Dynamic dimension detection using ResizeObserver for marks rendering
     useEffect(() => {
         if (!sliderRef.current) {
-            return;
-        }
-
-        if (step === null) {
-            // If the user has explicitly disabled stepping (step=None), then
-            // the slider values are constrained to the given marks and user
-            // cannot enter arbitrary values via the input element
-            setShowInputs(false);
-            return;
-        }
-
-        if (!value || value.length > 2) {
-            setShowInputs(false);
             return;
         }
 
@@ -90,16 +76,6 @@ export default function RangeSlider(props: RangeSliderProps) {
                 const dimension = vertical ? rect.height : rect.width;
                 if (dimension > 0) {
                     setSliderWidth(dimension);
-
-                    // eslint-disable-next-line no-magic-numbers
-                    const HIDE_AT_WIDTH = value.length === 1 ? 200 : 250;
-                    // eslint-disable-next-line no-magic-numbers
-                    const SHOW_AT_WIDTH = value.length === 1 ? 300 : 450;
-                    if (showInputs && dimension < HIDE_AT_WIDTH) {
-                        setShowInputs(false);
-                    } else if (!showInputs && dimension >= SHOW_AT_WIDTH) {
-                        setShowInputs(true);
-                    }
                 }
             }
         };
@@ -119,7 +95,7 @@ export default function RangeSlider(props: RangeSliderProps) {
         return () => {
             resizeObserver.disconnect();
         };
-    }, [showInputs, vertical, step, value]);
+    }, [vertical]);
 
     // Handle prop value changes - equivalent to componentWillReceiveProps
     useEffect(() => {
@@ -168,49 +144,23 @@ export default function RangeSlider(props: RangeSliderProps) {
         });
     }, [min, max, processedMarks, step, sliderWidth]);
 
-    // Calculate dynamic input width based on digits needed and container size
+    // Calculate dynamic input width based on min/max values
     const inputWidth = useMemo(() => {
-        if (!sliderWidth) {
-            return '64px'; // fallback to current width
-        }
-
-        // Count digits needed for min and max values
-        const maxDigits = Math.max(
-            String(Math.floor(Math.abs(minMaxValues.max_mark))).length,
-            String(Math.floor(Math.abs(minMaxValues.min_mark))).length
+        const maxIntegerChars = Math.max(
+            String(Math.floor(minMaxValues.max_mark)).length,
+            String(Math.floor(minMaxValues.min_mark)).length
         );
 
-        // Add 1 for minus sign if min is negative
-        const totalChars = maxDigits + (minMaxValues.min_mark < 0 ? 1 : 0);
-
-        // Calculate width as percentage of container (5% min, 15% max)
-        /* eslint-disable no-magic-numbers */
-        const minWidth = sliderWidth * 0.05;
-        const maxWidth = sliderWidth * 0.15;
-        const charBasedWidth = totalChars * 12; // approx 12px per character
-        /* eslint-enable no-magic-numbers */
-
-        const calculatedWidth = Math.max(
-            minWidth,
-            Math.min(maxWidth, charBasedWidth)
+        const maxDecimalChars = Math.min(
+            String(stepValue).split('.')[1]?.length + 1 ?? 0,
+            3
         );
 
-        // Add padding if box-sizing is border-box
-        let inputPadding = 0;
-        if (inputRef.current) {
-            const computedStyle = window.getComputedStyle(inputRef.current);
-            if (computedStyle.boxSizing === 'border-box') {
-                const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
-                const paddingRight =
-                    parseFloat(computedStyle.paddingRight) || 0;
-                inputPadding = paddingLeft + paddingRight;
-            }
-        }
+        const totalChars = maxIntegerChars + maxDecimalChars;
+        const charWidth = 12;
 
-        const totalWidth = calculatedWidth + inputPadding;
-
-        return `${totalWidth}px`;
-    }, [sliderWidth, minMaxValues.min_mark, minMaxValues.max_mark]);
+        return `${totalChars * charWidth}px`;
+    }, [minMaxValues.min_mark, minMaxValues.max_mark, stepValue]);
 
     const valueIsValid = (val: number): boolean => {
         // Check if value is within min/max bounds
@@ -312,11 +262,17 @@ export default function RangeSlider(props: RangeSliderProps) {
 
     const classNames = ['dash-slider-container', className].filter(Boolean);
 
+    // Determine if inputs should be rendered at all (CSS will handle responsive visibility)
+    const shouldShowInputs =
+        step !== null && // Not disabled by step=None
+        value.length <= 2 && // Only for single or range sliders
+        !vertical; // Only for horizontal sliders
+
     return (
         <LoadingElement>
             {loadingProps => (
                 <div id={id} className={classNames.join(' ')} {...loadingProps}>
-                    {showInputs && value.length === 2 && !vertical && (
+                    {shouldShowInputs && value.length === 2 && (
                         <input
                             type="number"
                             className="dash-input-container dash-range-slider-input dash-range-slider-min-input"
@@ -381,7 +337,7 @@ export default function RangeSlider(props: RangeSliderProps) {
                             disabled={disabled}
                         />
                     )}
-                    {showInputs && !vertical && (
+                    {shouldShowInputs && (
                         <input
                             ref={inputRef}
                             type="number"

--- a/components/dash-core-components/src/types.ts
+++ b/components/dash-core-components/src/types.ts
@@ -52,6 +52,201 @@ export interface BaseDccProps<T>
     persistence_type?: PersistenceTypes;
 }
 
+export enum HTMLInputTypes {
+    // Only allowing the input types with wide browser compatibility
+    'text' = 'text',
+    'number' = 'number',
+    'password' = 'password',
+    'email' = 'email',
+    'range' = 'range',
+    'search' = 'search',
+    'tel' = 'tel',
+    'url' = 'url',
+    'hidden' = 'hidden',
+}
+
+export interface InputProps extends BaseDccProps<InputProps> {
+    /**
+     * The value of the input
+     */
+    value?: string | number;
+    /**
+     * The type of control to render.
+     */
+    type?: HTMLInputTypes;
+    /**
+     * If true, changes to input will be sent back to the Dash server only on enter or when losing focus.
+     * If it's false, it will send the value back on every change.
+     * If a number, it will not send anything back to the Dash server until the user has stopped
+     * typing for that number of seconds.
+     */
+    debounce?: boolean | number;
+    /**
+     * A hint to the user of what can be entered in the control . The placeholder text must not contain carriage returns or line-feeds. Note: Do not use the placeholder attribute instead of a <label> element, their purposes are different. The <label> attribute describes the role of the form element (i.e. it indicates what kind of information is expected), and the placeholder attribute is a hint about the format that the content should take. There are cases in which the placeholder attribute is never displayed to the user, so the form must be understandable without it.
+     */
+    placeholder?: string | number;
+    /**
+     * Number of times the `Enter` key was pressed while the input had focus.
+     */
+    n_submit?: number;
+    /**
+     * Last time that `Enter` was pressed.
+     */
+    n_submit_timestamp?: number;
+    /**
+     * Provides a hint to the browser as to the type of data that might be
+     * entered by the user while editing the element or its contents.
+     */
+    inputMode?: /**
+     * Alphanumeric, non-prose content such as usernames and passwords.
+     */
+    | 'verbatim'
+        /**
+         * Latin-script input in the user's preferred language with typing aids such as text prediction enabled. For human-to-computer communication such as search boxes.
+         */
+        | 'latin'
+        /**
+         * As latin, but for human names.
+         */
+        | 'latin-name'
+        /**
+         * As latin, but with more aggressive typing aids. For human-to-human communication such as instant messaging or email.
+         */
+        | 'latin-prose'
+        /**
+         * As latin-prose, but for the user's secondary languages.
+         */
+        | 'full-width-latin'
+        /**
+         * Kana or romaji input, typically hiragana input, using full-width characters, with support for converting to kanji. Intended for Japanese text input.
+         */
+        | 'kana'
+        /**
+         * Katakana input, using full-width characters, with support for converting to kanji. Intended for Japanese text input.
+         */
+        | 'katakana'
+        /**
+         * Numeric input, including keys for the digits 0 to 9, the user's preferred thousands separator character, and the character for indicating negative numbers. Intended for numeric codes (e.g. credit card numbers). For actual numbers, prefer using type="number"
+         */
+        | 'numeric'
+        /**
+         * Telephone input, including asterisk and pound key. Use type="tel" if possible instead.
+         */
+        | 'tel'
+        /**
+         * Email input. Use type="email" if possible instead.
+         */
+        | 'email'
+        /**
+         * URL input. Use type="url" if possible instead.
+         */
+        | 'url';
+    /**
+     * This attribute indicates whether the value of the control can be automatically completed by the browser.
+     */
+    autoComplete?: string;
+    /**
+     * This attribute indicates that the user cannot modify the value of the control. The value of the attribute is irrelevant. If you need read-write access to the input value, do not add the "readonly" attribute. It is ignored if the value of the type attribute is hidden, range, color, checkbox, radio, file, or a button type (such as button or submit).
+     * readOnly is an HTML boolean attribute - it is enabled by a boolean or
+     * 'readOnly'. Alternative capitalizations `readonly` & `READONLY`
+     * are also acccepted.
+     */
+    readOnly?: boolean | 'readOnly' | 'readonly' | 'READONLY';
+    /**
+     * This attribute specifies that the user must fill in a value before submitting a form. It cannot be used when the type attribute is hidden, image, or a button type (submit, reset, or button). The :optional and :required CSS pseudo-classes will be applied to the field as appropriate.
+     * required is an HTML boolean attribute - it is enabled by a boolean or
+     * 'required'. Alternative capitalizations `REQUIRED`
+     * are also acccepted.
+     */
+    required?: boolean | 'required' | 'REQUIRED';
+    /**
+     * The element should be automatically focused after the page loaded.
+     * autoFocus is an HTML boolean attribute - it is enabled by a boolean or
+     * 'autoFocus'. Alternative capitalizations `autofocus` & `AUTOFOCUS`
+     * are also acccepted.
+     */
+    autoFocus?: boolean | 'autoFocus' | 'autofocus' | 'AUTOFOCUS';
+    /**
+     * If true, the input is disabled and can't be clicked on.
+     * disabled is an HTML boolean attribute - it is enabled by a boolean or
+     * 'disabled'. Alternative capitalizations `DISABLED`
+     */
+    disabled?: boolean | 'disabled' | 'DISABLED';
+    /**
+     * Identifies a list of pre-defined options to suggest to the user.
+     * The value must be the id of a <datalist> element in the same document.
+     * The browser displays only options that are valid values for this
+     * input element.
+     * This attribute is ignored when the type attribute's value is
+     * hidden, checkbox, radio, file, or a button type.
+     */
+    list?: string;
+    /**
+     * This Boolean attribute indicates whether the user can enter more than one value. This attribute applies when the type attribute is set to email or file, otherwise it is ignored.
+     */
+    multiple?: boolean;
+    /**
+     * Setting the value of this attribute to true indicates that the element needs to have its spelling and grammar checked. The value default indicates that the element is to act according to a default behavior, possibly based on the parent element's own spellcheck value. The value false indicates that the element should not be checked.
+     */
+    spellCheck?: boolean | 'true' | 'false';
+    /**
+     * The name of the control, which is submitted with the form data.
+     */
+    name?: string;
+    /**
+     * The minimum (numeric or date-time) value for this item, which must not be greater than its maximum (max attribute) value.
+     */
+    min?: string | number;
+    /**
+     * The maximum (numeric or date-time) value for this item, which must not be less than its minimum (min attribute) value.
+     */
+    max?: string | number;
+    /**
+     * Works with the min and max attributes to limit the increments at which a numeric or date-time value can be set. It can be the string any or a positive floating point number. If this attribute is not set to any, the control accepts only values at multiples of the step value greater than the minimum.
+     */
+    step?: string | number;
+    /**
+     * If the value of the type attribute is text, email, search, password, tel, or url, this attribute specifies the minimum number of characters (in Unicode code points) that the user can enter. For other control types, it is ignored.
+     */
+    minLength?: string | number;
+    /**
+     * If the value of the type attribute is text, email, search, password, tel, or url, this attribute specifies the maximum number of characters (in UTF-16 code units) that the user can enter. For other control types, it is ignored. It can exceed the value of the size attribute. If it is not specified, the user can enter an unlimited number of characters. Specifying a negative number results in the default behavior (i.e. the user can enter an unlimited number of characters). The constraint is evaluated only when the value of the attribute has been changed.
+     */
+    maxLength?: string | number;
+    /**
+     * A regular expression that the control's value is checked against. The pattern must match the entire value, not just some subset. Use the title attribute to describe the pattern to help the user. This attribute applies when the value of the type attribute is text, search, tel, url, email, or password, otherwise it is ignored. The regular expression language is the same as JavaScript RegExp algorithm, with the 'u' parameter that makes it treat the pattern as a sequence of unicode code points. The pattern is not surrounded by forward slashes.
+     */
+    pattern?: string;
+    /**
+     * The offset into the element's text content of the first selected character. If there's no selection, this value indicates the offset to the character following the current text input cursor position (that is, the position the next character typed would occupy).
+     */
+    selectionStart?: string;
+    /**
+     * The offset into the element's text content of the last selected character. If there's no selection, this value indicates the offset to the character following the current text input cursor position (that is, the position the next character typed would occupy).
+     */
+    selectionEnd?: string;
+    /**
+     * The direction in which selection occurred. This is "forward" if the selection was made from left-to-right in an LTR locale or right-to-left in an RTL locale, or "backward" if the selection was made in the opposite direction. On platforms on which it's possible this value isn't known, the value can be "none"; for example, on macOS, the default direction is "none", then as the user begins to modify the selection using the keyboard, this will change to reflect the direction in which the selection is expanding.
+     */
+    selectionDirection?: string;
+    /**
+     * Number of times the input lost focus.
+     */
+    n_blur?: number;
+    /**
+     * Last time the input lost focus.
+     */
+    n_blur_timestamp?: number;
+    /**
+     * The initial size of the control. This value is in pixels unless the value of the type attribute is text or password, in which case it is an integer number of characters. Starting in, this attribute applies only when the type attribute is set to text, search, tel, url, email, or password, otherwise it is ignored. In addition, the size must be greater than zero. If you do not specify a size, a default value of 20 is used.' simply states "the user agent should ensure that at least that many characters are visible", but different characters can have different widths in certain fonts. In some browsers, a certain string with x characters will not be entirely visible even if size is defined to at least x.
+     */
+    size?: string;
+    /**
+     * The input's inline styles
+     */
+    style?: React.CSSProperties;
+}
+
 export type SliderMarks = {
     [key: number]: string | {label: string; style?: React.CSSProperties};
 };

--- a/components/dash-core-components/src/utils/calendar/Calendar.tsx
+++ b/components/dash-core-components/src/utils/calendar/Calendar.tsx
@@ -14,9 +14,9 @@ import {
     ArrowLeftIcon,
     ArrowRightIcon,
 } from '@radix-ui/react-icons';
-import Input, {HTMLInputTypes} from '../../components/Input';
+import Input from '../../components/Input';
 import Dropdown from '../../components/Dropdown';
-import {DayOfWeek, CalendarDirection} from '../../types';
+import {DayOfWeek, CalendarDirection, HTMLInputTypes} from '../../types';
 import {CalendarMonth} from './CalendarMonth';
 import {
     getMonthOptions,

--- a/components/dash-core-components/src/utils/optionRendering.tsx
+++ b/components/dash-core-components/src/utils/optionRendering.tsx
@@ -105,7 +105,7 @@ export const Option: React.FC<OptionProps> = ({
                     disabled={!!option.disabled}
                     onChange={() => onChange(option)}
                     onKeyUp={e => {
-                        if (e.key === 'Enter' && inputType === 'checkbox') {
+                        if (e.key === 'Enter') {
                             onChange(option);
                         }
                     }}

--- a/components/dash-core-components/tests/integration/calendar/test_calendar_props.py
+++ b/components/dash-core-components/tests/integration/calendar/test_calendar_props.py
@@ -13,8 +13,25 @@ def test_cdpr001_date_clearable_true_works(dash_dcc):
         [
             dcc.DatePickerRange(id="dpr", clearable=True),
             dcc.DatePickerSingle(id="dps", clearable=True),
+            html.Div(id="dpr-output"),
+            html.Div(id="dps-output"),
         ]
     )
+
+    @app.callback(
+        Output("dpr-output", "children"),
+        Input("dpr", "start_date"),
+        Input("dpr", "end_date"),
+    )
+    def display_range_dates(start_date, end_date):
+        return f"Range: {start_date} - {end_date}"
+
+    @app.callback(
+        Output("dps-output", "children"),
+        Input("dps", "date"),
+    )
+    def display_single_date(date):
+        return f"Single: {date}"
 
     dash_dcc.start_server(app)
 
@@ -26,20 +43,33 @@ def test_cdpr001_date_clearable_true_works(dash_dcc):
         "1" in start_date and "28" in end_date
     ), "both start date and end date should match the selected day"
 
+    # Verify callback received the dates
+    dash_dcc.wait_for_text_to_equal("#dpr-output", f"Range: {start_date} - {end_date}")
+
     close_btn.click()
     sleep(0.25)
     start_date, end_date = dash_dcc.get_date_range("dpr")
     assert not start_date and not end_date, "both start and end dates should be cleared"
 
+    # Verify callback received the cleared dates (None)
+    dash_dcc.wait_for_text_to_equal("#dpr-output", "Range: None - None")
+
     # DPS
     selected = dash_dcc.select_date_single("dps", day="1")
 
     assert selected, "single date should get a value"
+
+    # Verify callback received the date
+    dash_dcc.wait_for_text_to_equal("#dps-output", f"Single: {selected}")
+
     close_btn = dash_dcc.wait_for_element("#dps-wrapper .dash-datepicker-clear")
     close_btn.click()
     sleep(0.25)
     (single_date,) = dash_dcc.get_date_range("dps")
     assert not single_date, "date should be cleared"
+
+    # Verify callback received the cleared date (None)
+    dash_dcc.wait_for_text_to_equal("#dps-output", "Single: None")
 
     assert dash_dcc.get_logs() == []
 

--- a/components/dash-core-components/tests/integration/calendar/test_calendar_props.py
+++ b/components/dash-core-components/tests/integration/calendar/test_calendar_props.py
@@ -37,6 +37,7 @@ def test_cdpr001_date_clearable_true_works(dash_dcc):
     assert selected, "single date should get a value"
     close_btn = dash_dcc.wait_for_element("#dps-wrapper .dash-datepicker-clear")
     close_btn.click()
+    sleep(0.25)
     (single_date,) = dash_dcc.get_date_range("dps")
     assert not single_date, "date should be cleared"
 

--- a/components/dash-core-components/tests/integration/misc/test_persistence.py
+++ b/components/dash-core-components/tests/integration/misc/test_persistence.py
@@ -118,6 +118,7 @@ def test_msps001_basic_persistence(dash_dcc):
     ]
 
     dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(1024, 768)
     dash_dcc.wait_for_text_to_equal("#settings", json.dumps(initial_settings))
 
     dash_dcc.find_element("#checklist label:last-child input").click()  # 🚀

--- a/components/dash-core-components/tests/integration/sliders/test_sliders.py
+++ b/components/dash-core-components/tests/integration/sliders/test_sliders.py
@@ -60,9 +60,9 @@ def test_slsl002_always_visible_rangeslider(dash_dcc):
     dash_dcc.wait_for_text_to_equal("#out", "You have selected 5-15")
 
     slider = dash_dcc.find_element("#rangeslider")
-    dash_dcc.click_at_coord_fractions(slider, 0.15, 0.25)
+    dash_dcc.click_at_coord_fractions(slider, 0.2, 0.25)
     dash_dcc.wait_for_text_to_equal("#out", "You have selected 3-15")
-    dash_dcc.click_at_coord_fractions(slider, 0.5, 0.25)
+    dash_dcc.click_at_coord_fractions(slider, 0.51, 0.25)
     dash_dcc.wait_for_text_to_equal("#out", "You have selected 3-10")
 
     assert dash_dcc.get_logs() == []

--- a/dash/dash-renderer/src/types/component.ts
+++ b/dash/dash-renderer/src/types/component.ts
@@ -11,7 +11,12 @@ import {
     useDevtoolMenuButtonClassName
 } from '../components/error/menu/DevtoolContext';
 
+// Caution: These docstrings appear in the published documentation!
 export type BaseDashProps = {
+    /**
+     * The ID of this component, used to identify dash components in callbacks.
+     * The ID needs to be unique across all of the components in an app.
+     */
     id?: string;
     componentPath?: DashLayoutPath;
     [key: string]: any;

--- a/tests/integration/callbacks/test_wildcards.py
+++ b/tests/integration/callbacks/test_wildcards.py
@@ -538,18 +538,18 @@ def test_cbwc007_pmc_update_subtree_ordering(dash_duo):
         return str(values)
 
     dash_duo.start_server(app)
-    dash_duo.select_dcc_dropdown(".dash-dropdown:nth-child(3)", index=2)
+    dash_duo.select_dcc_dropdown(".dash-dropdown-wrapper:nth-child(3) button", index=2)
 
     dash_duo.wait_for_text_to_equal("#selected-values", "[None, None, 'option2-2']")
 
     dash_duo.wait_for_element("#refresh-options").click()
 
-    dash_duo.select_dcc_dropdown(".dash-dropdown:nth-child(2)", index=2)
+    dash_duo.select_dcc_dropdown(".dash-dropdown-wrapper:nth-child(2) button", index=2)
     dash_duo.wait_for_text_to_equal(
         "#selected-values", "[None, 'option1-2', 'option2-2']"
     )
 
-    dash_duo.select_dcc_dropdown(".dash-dropdown:nth-child(1)", index=2)
+    dash_duo.select_dcc_dropdown(".dash-dropdown-wrapper:nth-child(1) button", index=2)
     dash_duo.wait_for_text_to_equal(
         "#selected-values", "['option0-2', 'option1-2', 'option2-2']"
     )


### PR DESCRIPTION
Summary of key fixes:

* Incorrect positioning of Popovers in Dropdowns/Datepickers when scrolled down the page in an embedded or DDK app. Fixed by switching from `fixed` to `absolute` positioning
* Use radio items in single-select dropdowns (rather than checkboxes)
* Restore default `autoComplete=false` in `dcc.Input`.
* Change `dcc.Input` width to be "100%" by default, which matches the other components.
* Improve how a Slider's inputs are displayed/hidden in various sizes.
* Fix some accidentally hard-coded colours in `dcc.Tabs`.
* Remove calendar icon from DatePicker

Fixes https://github.com/plotly/ddk-dash-docs/issues/3605, #3531 