### PR TITLE
Resources attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED]
+
+## Added
+- [#3541](https://github.com/plotly/dash/pull/3541) Add `attributes` dictionary to be be formatted on script/link (_js_dist/_css_dist) tags of the index, allows for `type="module"` or `type="importmap"`. [#3538](https://github.com/plotly/dash/issues/3538)
+
+## Fixed
+- [#3541](https://github.com/plotly/dash/pull/3541) Remove last reference of deprecated `pkg_resources`.
+
 ## [3.3.0] - 2025-11-12
 
 ## Added

--- a/dash/development/component_generator.py
+++ b/dash/development/component_generator.py
@@ -8,7 +8,8 @@ import os
 import argparse
 import shutil
 import functools
-import pkg_resources
+import importlib.resources as importlib_resources
+
 import yaml
 
 from ._r_components_generation import write_class_file
@@ -57,7 +58,16 @@ def generate_components(
 
     is_windows = sys.platform == "win32"
 
-    extract_path = pkg_resources.resource_filename("dash", "extract-meta.js")
+    # Get path to extract-meta.js using importlib.resources
+    try:
+        # Python 3.9+
+        extract_path = str(
+            importlib_resources.files("dash").joinpath("extract-meta.js")
+        )
+    except AttributeError:
+        # Python 3.8 fallback
+        with importlib_resources.path("dash", "extract-meta.js") as p:
+            extract_path = str(p)
 
     reserved_patterns = "|".join(f"^{p}$" for p in reserved_words)
 

--- a/dash/resources.py
+++ b/dash/resources.py
@@ -25,6 +25,7 @@ ResourceType = _tx.TypedDict(
         "external_only": bool,
         "filepath": str,
         "dev_only": bool,
+        "attributes": _t.Dict[str, str],
     },
     total=False,
 )
@@ -80,6 +81,8 @@ class Resources:
                 )
             if "namespace" in s:
                 filtered_resource["namespace"] = s["namespace"]
+            if "attributes" in s:
+                filtered_resource["attributes"] = s["attributes"]
 
             if "external_url" in s and (
                 s.get("external_only") or not self.config.serve_locally

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -13,7 +13,6 @@ pandas>=1.4.0
 pyarrow
 pylint==3.0.3
 pytest-mock
-pytest-sugar==0.9.6
 pyzmq>=26.0.0
 xlrd>=2.0.1
 pytest-rerunfailures

--- a/tests/integration/dash_assets/test_dash_assets.py
+++ b/tests/integration/dash_assets/test_dash_assets.py
@@ -131,6 +131,7 @@ def test_dada003_external_resources_with_attributes(dash_duo):
         {
             "external_url": "https://cdn.example.com/module-script.js",
             "attributes": {"type": "module"},
+            "external_only": True,
         }
     )
 
@@ -138,6 +139,7 @@ def test_dada003_external_resources_with_attributes(dash_duo):
         {
             "external_url": "https://cdn.example.com/async-script.js",
             "attributes": {"async": "true", "data-test": "custom"},
+            "external_only": True,
         }
     )
 
@@ -146,6 +148,7 @@ def test_dada003_external_resources_with_attributes(dash_duo):
         {
             "external_url": "https://cdn.example.com/print-styles.css",
             "attributes": {"media": "print"},
+            "external_only": True,
         }
     )
 

--- a/tests/integration/dash_assets/test_dash_assets.py
+++ b/tests/integration/dash_assets/test_dash_assets.py
@@ -120,3 +120,117 @@ def test_dada002_external_files_init(dash_duo):
 
     # ensure ramda was loaded before the assets so they can use it.
     assert dash_duo.find_element("#ramda-test").text == "Hello World"
+
+
+def test_dada003_external_resources_with_attributes(dash_duo):
+    """Test that attributes field works for external scripts and stylesheets"""
+    app = Dash(__name__)
+
+    # Test scripts with type="module" and other attributes
+    app.scripts.append_script(
+        {
+            "external_url": "https://cdn.example.com/module-script.js",
+            "attributes": {"type": "module"},
+        }
+    )
+
+    app.scripts.append_script(
+        {
+            "external_url": "https://cdn.example.com/async-script.js",
+            "attributes": {"async": "true", "data-test": "custom"},
+        }
+    )
+
+    # Test CSS with custom attributes
+    app.css.append_css(
+        {
+            "external_url": "https://cdn.example.com/print-styles.css",
+            "attributes": {"media": "print"},
+        }
+    )
+
+    app.layout = html.Div("Test Layout", id="content")
+
+    dash_duo.start_server(app)
+
+    # Verify script with type="module" is rendered correctly
+    module_script = dash_duo.find_element(
+        "//script[@src='https://cdn.example.com/module-script.js' and @type='module']",
+        attribute="XPATH",
+    )
+    assert (
+        module_script is not None
+    ), "Module script should be present with type='module'"
+
+    # Verify script with async and custom data attribute
+    async_script = dash_duo.find_element(
+        "//script[@src='https://cdn.example.com/async-script.js' and @async='true' and @data-test='custom']",
+        attribute="XPATH",
+    )
+    assert (
+        async_script is not None
+    ), "Async script should be present with custom attributes"
+
+    # Verify CSS with media attribute
+    print_css = dash_duo.find_element(
+        "//link[@href='https://cdn.example.com/print-styles.css' and @media='print']",
+        attribute="XPATH",
+    )
+    assert print_css is not None, "Print CSS should be present with media='print'"
+
+
+def test_dada004_external_scripts_init_with_attributes(dash_duo):
+    """Test that attributes work when passed via external_scripts in Dash constructor"""
+    js_files = [
+        "https://cdn.example.com/regular-script.js",
+        {"src": "https://cdn.example.com/es-module.js", "type": "module"},
+        {
+            "src": "https://cdn.example.com/integrity-script.js",
+            "integrity": "sha256-test123",
+            "crossorigin": "anonymous",
+        },
+    ]
+
+    css_files = [
+        "https://cdn.example.com/regular-styles.css",
+        {
+            "href": "https://cdn.example.com/dark-theme.css",
+            "media": "(prefers-color-scheme: dark)",
+        },
+    ]
+
+    app = Dash(__name__, external_scripts=js_files, external_stylesheets=css_files)
+    app.layout = html.Div("Test", id="content")
+
+    dash_duo.start_server(app)
+
+    # Verify regular script (string format)
+    dash_duo.find_element(
+        "//script[@src='https://cdn.example.com/regular-script.js']", attribute="XPATH"
+    )
+
+    # Verify ES module script
+    module_script = dash_duo.find_element(
+        "//script[@src='https://cdn.example.com/es-module.js' and @type='module']",
+        attribute="XPATH",
+    )
+    assert module_script is not None
+
+    # Verify script with integrity and crossorigin
+    integrity_script = dash_duo.find_element(
+        "//script[@src='https://cdn.example.com/integrity-script.js' and @integrity='sha256-test123' and @crossorigin='anonymous']",
+        attribute="XPATH",
+    )
+    assert integrity_script is not None
+
+    # Verify regular CSS
+    dash_duo.find_element(
+        "//link[@href='https://cdn.example.com/regular-styles.css']", attribute="XPATH"
+    )
+
+    # Verify CSS with media query
+    dark_css = dash_duo.find_element(
+        "//link[@href='https://cdn.example.com/dark-theme.css' and @media='(prefers-color-scheme: dark)']",
+        attribute="XPATH",
+    )
+    assert dark_css is not None

--- a/tests/unit/test_resources.py
+++ b/tests/unit/test_resources.py
@@ -126,7 +126,7 @@ def test_collect_and_register_resources(mocker):
 
 def test_resources_with_attributes():
     """Test that attributes are passed through in external_url resources"""
-    app = dash.Dash(__name__, serve_locally=False)
+    app = dash.Dash(__name__)
 
     # Test external scripts with attributes
     resources = app._collect_and_register_resources(
@@ -134,6 +134,7 @@ def test_resources_with_attributes():
             {
                 "external_url": "https://example.com/module.js",
                 "attributes": {"type": "module"},
+                "external_only": True,
             },
             {
                 "external_url": "https://example.com/script.js",
@@ -141,6 +142,7 @@ def test_resources_with_attributes():
                     "crossorigin": "anonymous",
                     "integrity": "sha256-abc123",
                 },
+                "external_only": True,
             },
         ]
     )
@@ -157,7 +159,7 @@ def test_resources_with_attributes():
 
 def test_css_resources_with_attributes():
     """Test that attributes are passed through in CSS resources with href"""
-    app = dash.Dash(__name__, serve_locally=False)
+    app = dash.Dash(__name__)
 
     # Test external CSS with attributes
     resources = app._collect_and_register_resources(
@@ -165,10 +167,12 @@ def test_css_resources_with_attributes():
             {
                 "external_url": "https://example.com/styles.css",
                 "attributes": {"media": "print"},
+                "external_only": True,
             },
             {
                 "external_url": "https://example.com/theme.css",
                 "attributes": {"crossorigin": "anonymous"},
+                "external_only": True,
             },
         ],
         url_attr="href",
@@ -182,11 +186,11 @@ def test_css_resources_with_attributes():
 
 def test_resources_without_attributes():
     """Test that resources without attributes still work as strings"""
-    app = dash.Dash(__name__, serve_locally=False)
+    app = dash.Dash(__name__)
 
     resources = app._collect_and_register_resources(
         [
-            {"external_url": "https://example.com/script.js"},
+            {"external_url": "https://example.com/script.js", "external_only": True},
         ]
     )
 
@@ -230,7 +234,7 @@ def test_local_resources_with_attributes(mocker):
 
 def test_multiple_external_urls_with_attributes():
     """Test that multiple external URLs with attributes work correctly"""
-    app = dash.Dash(__name__, serve_locally=False)
+    app = dash.Dash(__name__)
 
     resources = app._collect_and_register_resources(
         [
@@ -240,6 +244,7 @@ def test_multiple_external_urls_with_attributes():
                     "https://example.com/script2.js",
                 ],
                 "attributes": {"type": "module"},
+                "external_only": True,
             }
         ]
     )


### PR DESCRIPTION
- Add `attributes` dictionary to be be formatted on script/link (_js_dist/_css_dist) tags of the index, allows for `type="module"` or `type="importmap"`. Resolve #3538
- Remove pytest-sugar from ci install.
- Remove last reference of deprecated `pkg_resources`