### PR TITLE
Add hidden=True to dash pages callback

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -2515,6 +2515,7 @@ class Dash(ObsoleteChecker):
                     Output(_ID_STORE, "data"),
                     inputs=inputs,
                     prevent_initial_call=True,
+                    hidden=True,
                 )
                 async def update(pathname_, search_, **states):
                     """
@@ -2581,6 +2582,7 @@ class Dash(ObsoleteChecker):
                     Output(_ID_STORE, "data"),
                     inputs=inputs,
                     prevent_initial_call=True,
+                    hidden=True,
                 )
                 def update(pathname_, search_, **states):
                     """


### PR DESCRIPTION
Added `hidden=True` to the dash pages callbacks.
Now this callbacks will not appear in the debug mode callback diagram.

Solves this issue: https://github.com/plotly/dash/issues/3463

## Contributor Checklist

- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
