### PR TITLE
Bugfix/datepicker feedback

### DIFF
--- a/components/dash-core-components/src/components/css/calendar.css
+++ b/components/dash-core-components/src/components/css/calendar.css
@@ -16,7 +16,6 @@
     font-weight: normal;
     color: var(--Dash-Text-Weak);
     text-align: center;
-    border-radius: 4px;
     cursor: default;
     user-select: none;
     -webkit-user-select: none;
@@ -53,6 +52,28 @@
 .dash-datepicker-calendar td.dash-datepicker-calendar-date-selected {
     background-color: var(--Dash-Fill-Interactive-Strong);
     color: var(--Dash-Fill-Inverse-Strong);
+}
+
+.dash-datepicker-calendar td.dash-datepicker-calendar-date-selected {
+    background-color: var(--Dash-Fill-Interactive-Strong);
+    color: var(--Dash-Fill-Inverse-Strong);
+}
+
+/* start_date selector: a selected date which is preceded by an unselected date */
+.dash-datepicker-calendar
+    td:not(.dash-datepicker-calendar-date-highlighted)
+    + td.dash-datepicker-calendar-date-selected {
+    border-start-start-radius: 4px;
+    border-end-start-radius: 4px;
+}
+
+/* end_date selector: a selected date which is followed by an unselected date */
+.dash-datepicker-calendar
+    td.dash-datepicker-calendar-date-selected:not(
+        :has(+ td.dash-datepicker-calendar-date-highlighted)
+    ) {
+    border-start-end-radius: 4px;
+    border-end-end-radius: 4px;
 }
 
 .dash-datepicker-calendar td.dash-datepicker-calendar-date-disabled {

--- a/components/dash-core-components/src/components/css/calendar.css
+++ b/components/dash-core-components/src/components/css/calendar.css
@@ -36,6 +36,7 @@
 .dash-datepicker-calendar td:focus {
     outline: 2px solid var(--Dash-Fill-Interactive-Strong);
     outline-offset: -2px;
+    border-radius: 4px;
     z-index: 1;
     position: relative;
 }

--- a/components/dash-core-components/src/components/css/datepickers.css
+++ b/components/dash-core-components/src/components/css/datepickers.css
@@ -99,6 +99,12 @@
     transition: transform 0.15s;
 }
 
+.dash-datepicker-range-arrow {
+    color: var(--Dash-Text-Strong);
+    width: 1em;
+    height: 1em;
+}
+
 .dash-datepicker-input-wrapper[aria-expanded='true']
     .dash-datepicker-caret-icon {
     transform: rotate(180deg);

--- a/components/dash-core-components/src/components/css/datepickers.css
+++ b/components/dash-core-components/src/components/css/datepickers.css
@@ -162,15 +162,25 @@
 
 .dash-datepicker-controls .dash-dropdown {
     flex: 0 0 auto;
-    min-width: 122px;
-    width: auto;
     margin: 0;
+}
+
+.dash-datepicker-month-sizer {
+    height: 0;
+    grid-area: 1 / 1;
+    visibility: hidden;
+    pointer-events: none;
+    white-space: nowrap;
+    padding: 0 24px;
+    font-family: inherit;
+    font-size: inherit;
 }
 
 .dash-datepicker-controls .dash-input {
     flex-shrink: 0;
     flex-grow: 0;
-    width: 102px;
+    min-width: 102px;
+    width: calc(5ch + 40px);
 }
 
 .dash-datepicker-controls .dash-input-stepper {

--- a/components/dash-core-components/src/fragments/DatePickerRange.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerRange.tsx
@@ -240,6 +240,19 @@ const DatePickerRange = ({
         [reopen_calendar_on_clear]
     );
 
+    // Focus the selected date when calendar opens
+    useEffect(() => {
+        if (isCalendarOpen) {
+            requestAnimationFrame(() => {
+                // Focus start date if available, otherwise end date
+                const dateToFocus = internalStartDate || internalEndDate;
+                if (dateToFocus) {
+                    calendarRef.current?.focusDate(dateToFocus);
+                }
+            });
+        }
+    }, [isCalendarOpen, internalStartDate, internalEndDate]);
+
     const handleStartInputKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLInputElement>) => {
             if (['ArrowUp', 'ArrowDown'].includes(e.key)) {

--- a/components/dash-core-components/src/fragments/DatePickerSingle.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerSingle.tsx
@@ -122,6 +122,17 @@ const DatePickerSingle = ({
         [reopen_calendar_on_clear]
     );
 
+    // Focus the selected date when calendar opens
+    useEffect(() => {
+        if (isCalendarOpen) {
+            requestAnimationFrame(() => {
+                if (internalDate) {
+                    calendarRef.current?.focusDate(internalDate);
+                }
+            });
+        }
+    }, [isCalendarOpen, internalDate]);
+
     const handleInputKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLInputElement>) => {
             if (['ArrowUp', 'ArrowDown'].includes(e.key)) {

--- a/components/dash-core-components/src/fragments/DatePickerSingle.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerSingle.tsx
@@ -122,28 +122,16 @@ const DatePickerSingle = ({
         [reopen_calendar_on_clear]
     );
 
-    // Focus the selected date when calendar opens
-    useEffect(() => {
-        if (isCalendarOpen) {
-            requestAnimationFrame(() => {
-                if (internalDate) {
-                    calendarRef.current?.focusDate(internalDate);
-                }
-            });
-        }
-    }, [isCalendarOpen, internalDate]);
-
     const handleInputKeyDown = useCallback(
         (e: React.KeyboardEvent<HTMLInputElement>) => {
-            if (['ArrowUp', 'ArrowDown'].includes(e.key)) {
+            if (['ArrowUp', 'ArrowDown', 'Enter'].includes(e.key)) {
                 e.preventDefault();
-                parseUserInput(true);
                 if (!isCalendarOpen) {
-                    // open the calendar after resolving prop changes, so that
-                    // it opens with the correct date showing
-                    setTimeout(() => setIsCalendarOpen(true), 0);
+                    setIsCalendarOpen(true);
                 }
-            } else if (['Enter', 'Tab'].includes(e.key)) {
+                // Wait for calendar to mount before focusing
+                requestAnimationFrame(() => parseUserInput(true));
+            } else if (e.key === 'Tab') {
                 parseUserInput();
             }
         },

--- a/components/dash-core-components/src/utils/calendar/Calendar.tsx
+++ b/components/dash-core-components/src/utils/calendar/Calendar.tsx
@@ -7,7 +7,7 @@ import React, {
     useState,
     forwardRef,
 } from 'react';
-import {addMonths, subMonths} from 'date-fns';
+import {addMonths, subMonths, endOfMonth} from 'date-fns';
 import {
     ArrowUpIcon,
     ArrowDownIcon,
@@ -80,6 +80,12 @@ const CalendarComponent = ({
         initialVisibleDate.getMonth()
     );
 
+    const [firstCalendarMonth, setFirstCalendarMonth] = useState(() => {
+        // Start by displaying calendar months centered around the initial date
+        const halfRange = Math.floor((numberOfMonthsShown - 1) / 2);
+        return subMonths(initialVisibleDate, halfRange);
+    });
+
     const [focusedDate, setFocusedDate] = useState<Date>();
     const [highlightedDates, setHighlightedDates] = useState<[Date, Date]>();
     const calendarContainerRef = useRef(document.createElement('div'));
@@ -101,6 +107,33 @@ const CalendarComponent = ({
         },
     }));
 
+    const isMonthVisible = useCallback(
+        (date: Date) => {
+            const visibleStart = firstCalendarMonth;
+            const visibleEnd = endOfMonth(
+                addMonths(visibleStart, numberOfMonthsShown - 1)
+            );
+            return isDateInRange(date, visibleStart, visibleEnd);
+        },
+        [firstCalendarMonth, numberOfMonthsShown]
+    );
+
+    // Updates the calendar whenever the active month & year change
+    useEffect(() => {
+        const activeDate = new Date(activeYear, activeMonth, 1);
+
+        // Don't change calendar if the active month is already visible
+        if (isMonthVisible(activeDate)) {
+            return;
+        }
+
+        setFirstCalendarMonth(
+            activeDate < firstCalendarMonth
+                ? activeDate // Moved backward: show activeDate as first month
+                : subMonths(activeDate, numberOfMonthsShown - 1) // Moved forward: show activeDate as last month
+        );
+    }, [activeMonth, activeYear, isMonthVisible]);
+
     useEffect(() => {
         // Syncs activeMonth/activeYear to focusedDate when focusedDate changes
         if (!focusedDate) {
@@ -111,21 +144,11 @@ const CalendarComponent = ({
         }
         prevFocusedDateRef.current = focusedDate;
 
-        const halfRange = Math.floor((numberOfMonthsShown - 1) / 2);
-        const activeMonthStart = new Date(activeYear, activeMonth, 1);
-        const visibleStart = subMonths(activeMonthStart, halfRange);
-        const visibleEnd = addMonths(activeMonthStart, halfRange);
-
-        const focusedMonthStart = new Date(
-            focusedDate.getFullYear(),
-            focusedDate.getMonth(),
-            1
-        );
-        if (!isDateInRange(focusedMonthStart, visibleStart, visibleEnd)) {
+        if (!isMonthVisible(focusedDate)) {
             setActiveMonth(focusedDate.getMonth());
             setActiveYear(focusedDate.getFullYear());
         }
-    }, [focusedDate, activeMonth, activeYear, numberOfMonthsShown]);
+    }, [focusedDate, isMonthVisible]);
 
     useEffect(() => {
         if (highlightStart && highlightEnd) {
@@ -225,6 +248,7 @@ const CalendarComponent = ({
             if (isDateInRange(newMonthStart, minDateAllowed, maxDateAllowed)) {
                 setActiveYear(newMonthStart.getFullYear());
                 setActiveMonth(newMonthStart.getMonth());
+                setFirstCalendarMonth(newMonthStart);
             }
         },
         [activeYear, activeMonth, minDateAllowed, maxDateAllowed, direction]
@@ -349,13 +373,7 @@ const CalendarComponent = ({
                 }}
             >
                 {Array.from({length: numberOfMonthsShown}, (_, i) => {
-                    // Center the view: start from (numberOfMonthsShown - 1) / 2 months before activeMonth
-                    const offset =
-                        i - Math.floor((numberOfMonthsShown - 1) / 2);
-                    const monthDate = addMonths(
-                        new Date(activeYear, activeMonth, 1),
-                        offset
-                    );
+                    const monthDate = addMonths(firstCalendarMonth, i);
                     return (
                         <CalendarMonth
                             key={i}

--- a/components/dash-core-components/src/utils/calendar/Calendar.tsx
+++ b/components/dash-core-components/src/utils/calendar/Calendar.tsx
@@ -292,18 +292,30 @@ const CalendarComponent = ({
                 >
                     <PreviousMonthIcon />
                 </button>
-                <Dropdown
-                    options={monthOptions}
-                    value={activeMonth}
-                    clearable={false}
-                    maxHeight={250}
-                    searchable={false}
-                    setProps={({value}) => {
-                        if (Number.isInteger(value)) {
-                            setActiveMonth(value as number);
-                        }
-                    }}
-                />
+                <div style={{display: 'grid'}}>
+                    {/* Render all the month names invisibly so that the longest month name is what determines the width of the month picker, regardless of which language is used */}
+                    {monthOptions.map((opt, i) => (
+                        <div
+                            key={i}
+                            className="dash-datepicker-month-sizer"
+                            aria-hidden="true"
+                        >
+                            {opt.label}
+                        </div>
+                    ))}
+                    <Dropdown
+                        options={monthOptions}
+                        value={activeMonth}
+                        clearable={false}
+                        maxHeight={250}
+                        searchable={false}
+                        setProps={({value}) => {
+                            if (Number.isInteger(value)) {
+                                setActiveMonth(value as number);
+                            }
+                        }}
+                    />
+                </div>
                 <Input
                     type={HTMLInputTypes.number}
                     debounce={0.5}

--- a/components/dash-core-components/tests/integration/calendar/test_a11y_date_picker_range.py
+++ b/components/dash-core-components/tests/integration/calendar/test_a11y_date_picker_range.py
@@ -130,7 +130,6 @@ def test_a11y_range_002_keyboard_update_existing_range(dash_dcc):
     date_picker_input = dash_dcc.find_element(".dash-datepicker-input")
     date_picker_input.click()
     dash_dcc.wait_for_element(".dash-datepicker-calendar-container")
-    send_keys(dash_dcc.driver, Keys.ARROW_DOWN)
 
     # Calendar opens with Jan 10 focused (the current start date)
     # Navigate: Arrow Down (Jan 10 -> 17), then 5x Arrow Left (17 -> 16 -> 15 -> 14 -> 13 -> 12)

--- a/components/dash-core-components/tests/integration/calendar/test_a11y_date_picker_range.py
+++ b/components/dash-core-components/tests/integration/calendar/test_a11y_date_picker_range.py
@@ -47,9 +47,12 @@ def test_a11y_range_001_keyboard_range_selection_with_highlights(dash_dcc):
 
     # Find the first input field and open calendar with keyboard
     date_picker_input = dash_dcc.find_element(".dash-datepicker-input")
-    date_picker_input.click()
+    date_picker_input.send_keys(Keys.ARROW_DOWN)
     dash_dcc.wait_for_element(".dash-datepicker-calendar-container")
-    send_keys(dash_dcc.driver, Keys.ARROW_DOWN)
+    # Wait for focus to be applied
+    import time
+
+    time.sleep(0.1)
 
     # Calendar opens with Jan 1 focused (first day of month since no dates selected)
     # Navigate: Arrow Down (Jan 1 -> 8)
@@ -128,8 +131,12 @@ def test_a11y_range_002_keyboard_update_existing_range(dash_dcc):
 
     # Find the first input field and open calendar with keyboard
     date_picker_input = dash_dcc.find_element(".dash-datepicker-input")
-    date_picker_input.click()
+    date_picker_input.send_keys(Keys.ARROW_DOWN)
     dash_dcc.wait_for_element(".dash-datepicker-calendar-container")
+    # Wait for focus to be applied
+    import time
+
+    time.sleep(0.1)
 
     # Calendar opens with Jan 10 focused (the current start date)
     # Navigate: Arrow Down (Jan 10 -> 17), then 5x Arrow Left (17 -> 16 -> 15 -> 14 -> 13 -> 12)

--- a/components/dash-core-components/tests/integration/calendar/test_a11y_date_picker_single.py
+++ b/components/dash-core-components/tests/integration/calendar/test_a11y_date_picker_single.py
@@ -4,6 +4,7 @@ from dash.dcc import DatePickerSingle
 from dash.html import Div, Label, P
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.action_chains import ActionChains
+from time import sleep
 
 
 def send_keys(driver, key):
@@ -34,8 +35,14 @@ def create_date_picker_app(date_picker_props):
 
 def open_calendar(dash_dcc, date_picker):
     """Open the calendar and wait for it to be visible"""
-    date_picker.click()
+
+    # The input element has the same ID as the date picker component itself
+    input_id = date_picker.get_attribute("id")
+    input_element = dash_dcc.find_element(f"#{input_id}")
+    input_element.send_keys(Keys.ARROW_DOWN)
     dash_dcc.wait_for_element(".dash-datepicker-calendar-container")
+    # Wait for focus to be applied via requestAnimationFrame
+    sleep(0.1)
 
 
 def close_calendar(dash_dcc, driver):

--- a/components/dash-core-components/tests/integration/calendar/test_a11y_date_picker_single.py
+++ b/components/dash-core-components/tests/integration/calendar/test_a11y_date_picker_single.py
@@ -37,9 +37,6 @@ def open_calendar(dash_dcc, date_picker):
     date_picker.click()
     dash_dcc.wait_for_element(".dash-datepicker-calendar-container")
 
-    # Send focus onto the calendar
-    send_keys(dash_dcc.driver, Keys.ARROW_DOWN)
-
 
 def close_calendar(dash_dcc, driver):
     """Close the calendar with Escape and wait for it to disappear"""

--- a/components/dash-core-components/tests/unit/calendar/Calendar.test.tsx
+++ b/components/dash-core-components/tests/unit/calendar/Calendar.test.tsx
@@ -1,16 +1,14 @@
 import React from 'react';
 import {render, waitFor, act} from '@testing-library/react';
-import Calendar from '../../../src/utils/calendar/Calendar';
+import Calendar, {CalendarHandle} from '../../../src/utils/calendar/Calendar';
 import {CalendarDirection} from '../../../src/types';
 
 // Mock LoadingElement to avoid Dash context issues in tests
 jest.mock('../../../src/utils/_LoadingElement', () => {
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const React = require('react');
     return function LoadingElement({
         children,
     }: {
-        children: (props: any) => React.ReactNode;
+        children: (props: unknown) => React.ReactNode;
     }) {
         return children({});
     };
@@ -227,7 +225,7 @@ describe('Calendar', () => {
     ])(
         'focuses $description',
         ({visibleMonth, selectedDate, expectedFocusedDay}) => {
-            const ref = React.createRef<any>();
+            const ref = React.createRef<CalendarHandle>();
             render(
                 <Calendar
                     ref={ref}

--- a/components/dash-core-components/tests/unit/calendar/CalendarMonthNavigation.tsx
+++ b/components/dash-core-components/tests/unit/calendar/CalendarMonthNavigation.tsx
@@ -1,0 +1,178 @@
+import React, {createRef} from 'react';
+import {render, act} from '@testing-library/react';
+import '@testing-library/jest-dom';
+import Calendar, {CalendarHandle} from '../../../src/utils/calendar/Calendar';
+
+describe('Calendar month visibility when calling setVisibleDate', () => {
+    const calendarRef = createRef<CalendarHandle>();
+
+    function getDisplayedMonths() {
+        // Find all month headers in the calendar
+        const monthHeaders = Array.from(
+            document.querySelectorAll('.dash-datepicker-calendar-month-header')
+        );
+        return monthHeaders.map(header => header.textContent);
+    }
+
+    function renderCalendar(date: string, numberOfMonthsShown: number) {
+        return render(
+            <Calendar
+                ref={calendarRef}
+                initialVisibleDate={new Date(date)}
+                numberOfMonthsShown={numberOfMonthsShown}
+                monthFormat="MMMM YYYY"
+                onSelectionChange={() => null}
+            />
+        );
+    }
+
+    describe('Calendar months start centered around initialVisibleDate', () => {
+        test('shows current & next month when numberOfMonthsShown=2', () => {
+            renderCalendar('2024-06-01', 2);
+            expect(getDisplayedMonths()).toEqual(['June 2024', 'July 2024']);
+        });
+
+        test('shows previous, current, and next months when numberOfMonthsShown=3', () => {
+            renderCalendar('2024-06-01', 3);
+            expect(getDisplayedMonths()).toEqual([
+                'May 2024',
+                'June 2024',
+                'July 2024',
+            ]);
+        });
+
+        test('shows previous, current, and next 2 months when numberOfMonthsShown=4', () => {
+            renderCalendar('2024-06-01', 4);
+            expect(getDisplayedMonths()).toEqual([
+                'May 2024',
+                'June 2024',
+                'July 2024',
+                'August 2024',
+            ]);
+        });
+    });
+
+    describe('calendar stays static when navigating to already-displayed dates', () => {
+        test('does not re-order displayed months (numberOfMonthsShown=2)', () => {
+            renderCalendar('2024-06-01', 2);
+            const expectedCalendarMonths = ['June 2024', 'July 2024'];
+
+            // Navigate to second visible month (July)
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2024-07-23'));
+            });
+
+            expect(getDisplayedMonths()).toEqual(expectedCalendarMonths);
+
+            // Navigate to first visible month (June)
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2024-06-15'));
+            });
+
+            expect(getDisplayedMonths()).toEqual(expectedCalendarMonths);
+        });
+
+        test('does not re-order displayed months (numberOfMonthsShown=3)', () => {
+            renderCalendar('2024-06-01', 3);
+            const expectedCalendarMonths = [
+                'May 2024',
+                'June 2024',
+                'July 2024',
+            ];
+
+            // Navigate to first visible month (May)
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2024-05-15'));
+            });
+
+            expect(getDisplayedMonths()).toEqual(expectedCalendarMonths);
+
+            // Navigate to last visible month (July)
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2024-07-23'));
+            });
+
+            expect(getDisplayedMonths()).toEqual(expectedCalendarMonths);
+        });
+
+        test('does not re-order displayed months (numberOfMonthsShown=4)', () => {
+            renderCalendar('2024-06-01', 4);
+            const expectedCalendarMonths = [
+                'May 2024',
+                'June 2024',
+                'July 2024',
+                'August 2024',
+            ];
+
+            // Navigate to middle visible month (June)
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2024-06-15'));
+            });
+
+            expect(getDisplayedMonths()).toEqual(expectedCalendarMonths);
+
+            // Navigate to another middle visible month (July)
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2024-07-23'));
+            });
+
+            expect(getDisplayedMonths()).toEqual(expectedCalendarMonths);
+        });
+    });
+
+    describe('forward navigation to a non-visible month', () => {
+        test('shows target month as last visible month (numberOfMonthsShown=2)', () => {
+            renderCalendar('2024-06-01', 2);
+
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2024-08-15'));
+            });
+
+            expect(getDisplayedMonths()).toEqual(['July 2024', 'August 2024']);
+        });
+
+        test('shows target month as last visible month (numberOfMonthsShown=3)', () => {
+            renderCalendar('2024-06-01', 3);
+
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2024-09-15'));
+            });
+
+            expect(getDisplayedMonths()).toEqual([
+                'July 2024',
+                'August 2024',
+                'September 2024',
+            ]);
+        });
+
+        test('shows target month as last visible month (numberOfMonthsShown=4)', () => {
+            renderCalendar('2024-08-01', 4);
+
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2025-01-17'));
+            });
+
+            expect(getDisplayedMonths()).toEqual([
+                'October 2024',
+                'November 2024',
+                'December 2024',
+                'January 2025',
+            ]);
+        });
+    });
+
+    describe('backward navigation to non-visible month', () => {
+        test('shows target month as first visible month (numberOfMonthsShown=2)', () => {
+            renderCalendar('2024-06-01', 2);
+
+            act(() => {
+                calendarRef.current?.setVisibleDate(new Date('2023-12-10'));
+            });
+
+            expect(getDisplayedMonths()).toEqual([
+                'December 2023',
+                'January 2024',
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
This PR fixes issues found & reported in the new DatePicker:

* Month labels could be cut-off in some languages; so the dropdown width is now dynamic
* Enter key now activates the calendar popup when focused on the dropdown
* Smarter determination of how to handle `numberOfMonthsShown` & _which_ months are shown, based on how the user interacts
    * when opening a calendar for the first time, the current month will be "centered" in the list of months
    * when navigating "forward" in the calendar, the current month will now be displayed last in the list of months
    * when navigating "backward" in the calendar, the current month will be displayed first
    * in all cases, when navigating to a month that is already visible (`numberOfMonthsShown > 1`), do not re-calculate or re-position which months are shown: just keep the current view. 