### PR TITLE
Upgrade pytest-sugar to prevent CI from failing

### DIFF
--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -13,7 +13,7 @@ pandas>=1.4.0
 pyarrow
 pylint==3.0.3
 pytest-mock
-pytest-sugar==0.9.6
+pytest-sugar>=1.1.1
 pyzmq>=26.0.0
 xlrd>=2.0.1
 pytest-rerunfailures


### PR DESCRIPTION
CI is currently failing because a pinned version of `pytest-sugar` uses deprecated `pytest` functions. This broke with the release of `pytest==9.0.0`.

## Contributor Checklist

- [ ] I have broken down my PR scope into the following TODO tasks
   -  [ ] task 1
   -  [ ] task 2
- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
