### PR TITLE
Bugfix: dcc redesign rc5 feedback

### DIFF
--- a/components/dash-core-components/src/components/Input.tsx
+++ b/components/dash-core-components/src/components/Input.tsx
@@ -176,6 +176,11 @@ function Input({
         (direction: 'increment' | 'decrement') => {
             const currentValue = parseFloat(input.current.value) || 0;
             const stepAsNum = parseFloat(step as string) || 1;
+
+            // Count decimal places to avoid floating point precision issues
+            const decimalPlaces = (stepAsNum.toString().split('.')[1] || '')
+                .length;
+
             const newValue =
                 direction === 'increment'
                     ? currentValue + stepAsNum
@@ -196,8 +201,13 @@ function Input({
                 );
             }
 
-            input.current.value = constrainedValue.toString();
-            setValue(constrainedValue.toString());
+            // Round to the step's decimal precision
+            const roundedValue = parseFloat(
+                constrainedValue.toFixed(decimalPlaces)
+            );
+
+            input.current.value = roundedValue.toString();
+            setValue(roundedValue.toString());
             onEvent();
         },
         [step, props.min, props.max, onEvent]

--- a/components/dash-core-components/src/components/css/datepickers.css
+++ b/components/dash-core-components/src/components/css/datepickers.css
@@ -143,6 +143,7 @@
     z-index: 500;
     box-shadow: 0px 10px 38px -10px var(--Dash-Shading-Strong),
         0px 10px 20px -15px var(--Dash-Shading-Weak);
+    overscroll-behavior: contain;
 }
 
 .dash-datepicker-calendar-wrapper {

--- a/components/dash-core-components/src/components/css/datepickers.css
+++ b/components/dash-core-components/src/components/css/datepickers.css
@@ -226,8 +226,3 @@
     width: 20px;
     height: 20px;
 }
-
-/* Override Radix's position: fixed to use position: absolute when using custom container */
-div[data-radix-popper-content-wrapper]:has(.dash-datepicker-content) {
-    position: absolute !important;
-}

--- a/components/dash-core-components/src/components/css/datepickers.css
+++ b/components/dash-core-components/src/components/css/datepickers.css
@@ -146,6 +146,74 @@
     overscroll-behavior: contain;
 }
 
+.dash-datepicker
+    [data-radix-popper-content-wrapper]:has(.dash-datepicker-portal) {
+    transform: none !important;
+}
+
+.dash-datepicker-portal {
+    position: fixed;
+    inset: 0;
+    width: 100vw;
+    height: 100vh;
+    max-width: 100vw;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--Dash-Shading-Strong);
+    border: none;
+    box-shadow: none;
+    overflow: visible;
+    padding: 0;
+    pointer-events: none;
+}
+
+.dash-datepicker-portal .dash-datepicker-calendar-wrapper {
+    background: var(--Dash-Fill-Inverse-Strong);
+    border-radius: var(--Dash-Spacing);
+    border: 1px solid var(--Dash-Stroke-Strong);
+    padding: 16px;
+    box-shadow: 0px 10px 38px -10px var(--Dash-Shading-Strong),
+        0px 10px 20px -15px var(--Dash-Shading-Weak);
+    z-index: 1;
+    pointer-events: auto;
+    width: fit-content;
+    max-width: 95vw;
+}
+
+.dash-datepicker-fullscreen {
+    pointer-events: auto;
+    background: var(--Dash-Fill-Inverse-Strong);
+}
+
+.dash-datepicker-close-button {
+    position: fixed;
+    top: calc(var(--Dash-Spacing) * 2);
+    right: calc(var(--Dash-Spacing) * 2);
+    width: 24px;
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--Dash-Fill-Inverse-Strong);
+    border: none;
+    border-radius: var(--Dash-Spacing);
+    color: var(--Dash-Text-Strong);
+    cursor: pointer;
+    z-index: 501;
+    pointer-events: auto;
+}
+
+.dash-datepicker-close-button:hover {
+    background: var(--Dash-Fill-Weak);
+    color: var(--Dash-Fill-Interactive-Strong);
+}
+
+.dash-datepicker-close-button:focus {
+    outline: 2px solid var(--Dash-Fill-Interactive-Strong);
+    outline-offset: 2px;
+}
+
 .dash-datepicker-calendar-wrapper {
     display: flex;
     flex-direction: column;
@@ -156,6 +224,7 @@
     display: flex;
     align-items: flex-start;
     gap: calc(var(--Dash-Spacing) * 4);
+    flex-wrap: wrap;
 }
 
 .dash-datepicker-controls {

--- a/components/dash-core-components/src/components/css/dropdown.css
+++ b/components/dash-core-components/src/components/css/dropdown.css
@@ -84,6 +84,7 @@
     z-index: 500;
     box-shadow: 0px 10px 38px -10px var(--Dash-Shading-Strong),
         0px 10px 20px -15px var(--Dash-Shading-Weak);
+    overscroll-behavior: contain;
 }
 
 .dash-dropdown-value-count,

--- a/components/dash-core-components/src/components/css/dropdown.css
+++ b/components/dash-core-components/src/components/css/dropdown.css
@@ -235,8 +235,3 @@
 .dash-dropdown-wrapper {
     position: relative;
 }
-
-/* Override Radix's position: fixed to use position: absolute when using custom container */
-div[data-radix-popper-content-wrapper]:has(.dash-dropdown-content) {
-    position: absolute !important;
-}

--- a/components/dash-core-components/src/fragments/DatePickerRange.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerRange.tsx
@@ -333,7 +333,7 @@ const DatePickerRange = ({
                             id={start_date_id || accessibleId}
                             inputClassName="dash-datepicker-input dash-datepicker-start-date"
                             value={startInputValue}
-                            onChange={e => setStartInputValue(e.target.value)}
+                            onChange={e => setStartInputValue(e.target?.value)}
                             onKeyDown={handleStartInputKeyDown}
                             onFocus={() => {
                                 if (isCalendarOpen) {
@@ -354,7 +354,7 @@ const DatePickerRange = ({
                             id={end_date_id || accessibleId + '-end-date'}
                             inputClassName="dash-datepicker-input dash-datepicker-end-date"
                             value={endInputValue}
-                            onChange={e => setEndInputValue(e.target.value)}
+                            onChange={e => setEndInputValue(e.target?.value)}
                             onKeyDown={handleEndInputKeyDown}
                             onFocus={() => {
                                 if (isCalendarOpen) {

--- a/components/dash-core-components/src/fragments/DatePickerRange.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerRange.tsx
@@ -384,9 +384,6 @@ const DatePickerRange = ({
                         className="dash-datepicker-content"
                         align="start"
                         sideOffset={5}
-                        collisionBoundary={containerRef.current?.closest(
-                            '#_dash-app-content'
-                        )}
                         onOpenAutoFocus={e => e.preventDefault()}
                         onCloseAutoFocus={e => {
                             e.preventDefault();

--- a/components/dash-core-components/src/fragments/DatePickerRange.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerRange.tsx
@@ -51,6 +51,8 @@ const DatePickerRange = ({
     end_date_id,
     start_date_placeholder_text = 'Start Date',
     end_date_placeholder_text = 'End Date',
+    with_portal = false,
+    with_full_screen_portal = false,
 }: DatePickerRangeProps) => {
     const [internalStartDate, setInternalStartDate] = useState(
         strAsDate(start_date)
@@ -102,6 +104,7 @@ const DatePickerRange = ({
     const startInputRef = useRef<HTMLInputElement | null>(null);
     const endInputRef = useRef<HTMLInputElement | null>(null);
     const calendarRef = useRef<CalendarHandle>(null);
+    const hasPortal = with_portal || with_full_screen_portal;
 
     useEffect(() => {
         setInternalStartDate(strAsDate(start_date));
@@ -381,9 +384,21 @@ const DatePickerRange = ({
 
                 <Popover.Portal container={containerRef.current}>
                     <Popover.Content
-                        className="dash-datepicker-content"
-                        align="start"
-                        sideOffset={5}
+                        className={`dash-datepicker-content${
+                            hasPortal ? ' dash-datepicker-portal' : ''
+                        }${
+                            with_full_screen_portal
+                                ? ' dash-datepicker-fullscreen'
+                                : ''
+                        }`}
+                        align={hasPortal ? 'center' : 'start'}
+                        sideOffset={hasPortal ? 0 : 5}
+                        avoidCollisions={!hasPortal}
+                        onInteractOutside={
+                            with_full_screen_portal
+                                ? e => e.preventDefault()
+                                : undefined
+                        }
                         onOpenAutoFocus={e => e.preventDefault()}
                         onCloseAutoFocus={e => {
                             e.preventDefault();
@@ -404,6 +419,15 @@ const DatePickerRange = ({
                             }
                         }}
                     >
+                        {with_full_screen_portal && (
+                            <button
+                                className="dash-datepicker-close-button"
+                                onClick={() => setIsCalendarOpen(false)}
+                                aria-label="Close calendar"
+                            >
+                                <Cross1Icon />
+                            </button>
+                        )}
                         <Calendar
                             ref={calendarRef}
                             initialVisibleDate={initialCalendarDate}

--- a/components/dash-core-components/src/fragments/DatePickerSingle.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerSingle.tsx
@@ -177,7 +177,7 @@ const DatePickerSingle = ({
                             id={accessibleId}
                             inputClassName="dash-datepicker-input dash-datepicker-end-date"
                             value={inputValue}
-                            onChange={e => setInputValue(e.target.value)}
+                            onChange={e => setInputValue(e.target?.value)}
                             onKeyDown={handleInputKeyDown}
                             placeholder={placeholder}
                             disabled={disabled}

--- a/components/dash-core-components/src/fragments/DatePickerSingle.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerSingle.tsx
@@ -39,6 +39,8 @@ const DatePickerSingle = ({
     day_size = 34,
     number_of_months_shown = 1,
     calendar_orientation,
+    with_portal = false,
+    with_full_screen_portal = false,
 }: DatePickerSingleProps) => {
     const [internalDate, setInternalDate] = useState(strAsDate(date));
     const direction = is_RTL
@@ -61,6 +63,7 @@ const DatePickerSingle = ({
     const containerRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement | null>(null);
     const calendarRef = useRef<CalendarHandle>(null);
+    const hasPortal = with_portal || with_full_screen_portal;
 
     useEffect(() => {
         setInternalDate(strAsDate(date));
@@ -200,9 +203,21 @@ const DatePickerSingle = ({
 
                 <Popover.Portal container={containerRef.current}>
                     <Popover.Content
-                        className="dash-datepicker-content"
-                        align="start"
-                        sideOffset={5}
+                        className={`dash-datepicker-content${
+                            hasPortal ? ' dash-datepicker-portal' : ''
+                        }${
+                            with_full_screen_portal
+                                ? ' dash-datepicker-fullscreen'
+                                : ''
+                        }`}
+                        align={hasPortal ? 'center' : 'start'}
+                        sideOffset={hasPortal ? 0 : 5}
+                        avoidCollisions={!hasPortal}
+                        onInteractOutside={
+                            with_full_screen_portal
+                                ? e => e.preventDefault()
+                                : undefined
+                        }
                         onOpenAutoFocus={e => e.preventDefault()}
                         onCloseAutoFocus={e => {
                             e.preventDefault();
@@ -212,6 +227,15 @@ const DatePickerSingle = ({
                             }
                         }}
                     >
+                        {with_full_screen_portal && (
+                            <button
+                                className="dash-datepicker-close-button"
+                                onClick={() => setIsCalendarOpen(false)}
+                                aria-label="Close calendar"
+                            >
+                                <Cross1Icon />
+                            </button>
+                        )}
                         <Calendar
                             ref={calendarRef}
                             initialVisibleDate={initialMonth}

--- a/components/dash-core-components/src/fragments/DatePickerSingle.tsx
+++ b/components/dash-core-components/src/fragments/DatePickerSingle.tsx
@@ -203,9 +203,6 @@ const DatePickerSingle = ({
                         className="dash-datepicker-content"
                         align="start"
                         sideOffset={5}
-                        collisionBoundary={containerRef.current?.closest(
-                            '#_dash-app-content'
-                        )}
                         onOpenAutoFocus={e => e.preventDefault()}
                         onCloseAutoFocus={e => {
                             e.preventDefault();

--- a/components/dash-core-components/src/fragments/Dropdown.tsx
+++ b/components/dash-core-components/src/fragments/Dropdown.tsx
@@ -394,7 +394,6 @@ const Dropdown = (props: DropdownProps) => {
                         }
                     }}
                     className={`dash-dropdown ${className ?? ''}`}
-                    style={style}
                     aria-labelledby={`${accessibleId}-value-count ${accessibleId}-value`}
                     aria-haspopup="listbox"
                     aria-expanded={isOpen}
@@ -540,7 +539,11 @@ const Dropdown = (props: DropdownProps) => {
     );
 
     return (
-        <div ref={positioningContainerRef} className="dash-dropdown-wrapper">
+        <div
+            ref={positioningContainerRef}
+            className="dash-dropdown-wrapper"
+            style={style}
+        >
             {popover}
         </div>
     );

--- a/components/dash-core-components/src/fragments/Dropdown.tsx
+++ b/components/dash-core-components/src/fragments/Dropdown.tsx
@@ -458,9 +458,6 @@ const Dropdown = (props: DropdownProps) => {
                     className="dash-dropdown-content"
                     align="start"
                     sideOffset={5}
-                    collisionBoundary={positioningContainerRef.current?.closest(
-                        '#_dash-app-content'
-                    )}
                     onOpenAutoFocus={e => e.preventDefault()}
                     onKeyDown={handleKeyDown}
                     style={{

--- a/components/dash-core-components/tests/integration/calendar/test_portal.py
+++ b/components/dash-core-components/tests/integration/calendar/test_portal.py
@@ -1,0 +1,426 @@
+from datetime import date
+from dash import Dash, html, dcc
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from time import sleep
+import pytest
+
+
+def click_everything_in_datepicker(datepicker_id, dash_dcc):
+    """Click on every clickable element in a datepicker calendar.
+
+    Args:
+        datepicker_id: CSS selector for the datepicker element (e.g., "#dpr")
+        dash_dcc: The dash_dcc fixture
+    """
+    # Click on the datepicker to open calendar
+    datepicker = dash_dcc.find_element(datepicker_id)
+    datepicker.click()
+
+    # Wait for calendar to open
+    popover = dash_dcc.find_element(".dash-datepicker-content")
+
+    interactive_elements = []
+    interactive_elements.extend(popover.find_elements(By.CSS_SELECTOR, "td"))
+    interactive_elements.extend(popover.find_elements(By.CSS_SELECTOR, "input"))
+
+    buttons = reversed(
+        popover.find_elements(By.CSS_SELECTOR, "button")
+    )  # reversed so that "close" button will be clicked after all other buttons
+    interactive_elements.extend(buttons)  # Add close buttons last
+
+    for el in interactive_elements:
+        try:
+            el.click()
+            sleep(0.05)
+        except Exception as e:
+            print(e)
+            assert not e, f"Unable to click on {el.tag_name})"
+
+
+def test_dppt000_datepicker_single_default(dash_dcc):
+    """Test DatePickerSingle with default (no portal) configuration.
+
+    Verifies that the calendar opens without portal and all elements are clickable.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("DatePickerSingle Default"),
+            dcc.DatePickerSingle(
+                id="dps-default",
+                date=date(2024, 1, 15),
+                stay_open_on_select=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+
+    dash_dcc.wait_for_element("#dps-default")
+
+    click_everything_in_datepicker("#dps-default", dash_dcc)
+
+    dps_input = dash_dcc.find_element("#dps-default")
+    dps_input.send_keys(Keys.ESCAPE)
+    dash_dcc.wait_for_no_elements(".dash-datepicker-calendar-container", timeout=2)
+
+    assert dash_dcc.get_logs() == []
+
+
+def test_dppt001_datepicker_single_with_portal(dash_dcc):
+    """Test DatePickerSingle with with_portal=True.
+
+    Verifies that the calendar opens in a portal (document.body) and all
+    elements are clickable.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("DatePickerSingle with Portal"),
+            dcc.DatePickerSingle(
+                id="dps-portal",
+                date=date(2024, 1, 15),
+                stay_open_on_select=True,
+                with_portal=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+
+    # Wait for the page to load
+    dash_dcc.wait_for_element("#dps-portal")
+
+    # Test DatePickerSingle with portal - click everything to verify all elements are accessible
+    click_everything_in_datepicker("#dps-portal", dash_dcc)
+
+    # Close the calendar by pressing escape
+    dps_input = dash_dcc.find_element("#dps-portal")
+    dps_input.send_keys(Keys.ESCAPE)
+    dash_dcc.wait_for_no_elements(".dash-datepicker-calendar-container", timeout=2)
+
+    assert dash_dcc.get_logs() == []
+
+
+def test_dppt006_fullscreen_portal_close_button_keyboard(dash_dcc):
+    """Test fullscreen portal dismiss behavior and keyboard accessibility.
+
+    Verifies clicking background doesn't close the portal and close button
+    is keyboard-accessible.
+    """
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.DatePickerSingle(
+                id="dps-fullscreen",
+                date=date(2024, 1, 15),
+                with_full_screen_portal=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+    dash_dcc.wait_for_element("#dps-fullscreen")
+
+    dps = dash_dcc.find_element("#dps-fullscreen")
+    dps.click()
+
+    popover = dash_dcc.find_element(".dash-datepicker-content")
+    assert popover.is_displayed()
+
+    action = ActionChains(dash_dcc.driver)
+    action.move_to_element_with_offset(popover, 10, 10).click().perform()
+    sleep(0.2)
+
+    popover = dash_dcc.find_element(".dash-datepicker-content")
+    assert (
+        popover.is_displayed()
+    ), "Fullscreen portal should not close when clicking background"
+
+    dash_dcc.find_element(".dash-datepicker-close-button")
+
+    action.send_keys(Keys.TAB).perform()
+    sleep(0.1)
+    action.send_keys(Keys.ENTER).perform()
+    sleep(0.2)
+
+    dash_dcc.wait_for_no_elements(".dash-datepicker-content", timeout=2)
+    assert dash_dcc.get_logs() == []
+
+
+def test_dppt007_portal_close_by_clicking_outside(dash_dcc):
+    """Test regular portal closes when clicking outside the calendar."""
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.DatePickerSingle(
+                id="dps-portal",
+                date=date(2024, 1, 15),
+                with_portal=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+    dash_dcc.wait_for_element("#dps-portal")
+
+    dps = dash_dcc.find_element("#dps-portal")
+    dps.click()
+
+    popover = dash_dcc.find_element(".dash-datepicker-content")
+    assert popover.is_displayed()
+
+    popover.click()
+    sleep(0.2)
+
+    dash_dcc.wait_for_no_elements(".dash-datepicker-content", timeout=2)
+    assert dash_dcc.get_logs() == []
+
+
+def test_dppt001a_datepicker_range_default(dash_dcc):
+    """Test DatePickerRange with default (no portal) configuration.
+
+    Verifies that the calendar opens without portal and all elements are clickable.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("DatePickerRange Default"),
+            dcc.DatePickerRange(
+                id="dpr-default",
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 1, 15),
+                stay_open_on_select=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+
+    dash_dcc.wait_for_element("#dpr-default")
+
+    click_everything_in_datepicker("#dpr-default", dash_dcc)
+
+    dpr_input = dash_dcc.find_element("#dpr-default")
+    dpr_input.send_keys(Keys.ESCAPE)
+    dash_dcc.wait_for_no_elements(".dash-datepicker-calendar-container", timeout=2)
+
+    assert dash_dcc.get_logs() == []
+
+
+def test_dppt002_datepicker_range_with_portal(dash_dcc):
+    """Test DatePickerRange with with_portal=True.
+
+    Verifies that the calendar opens in a portal (document.body) and all
+    elements are clickable.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("DatePickerRange with Portal"),
+            dcc.DatePickerRange(
+                id="dpr-portal",
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 1, 15),
+                stay_open_on_select=True,
+                with_portal=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+
+    # Wait for the page to load
+    dash_dcc.wait_for_element("#dpr-portal")
+
+    # Test DatePickerRange with portal - click everything to verify all elements are accessible
+    click_everything_in_datepicker("#dpr-portal", dash_dcc)
+
+    # Close the calendar by pressing escape
+    dpr_input = dash_dcc.find_element("#dpr-portal")
+    dpr_input.send_keys(Keys.ESCAPE)
+    dash_dcc.wait_for_no_elements(".dash-datepicker-calendar-container", timeout=2)
+
+    assert dash_dcc.get_logs() == []
+
+
+def test_dppt003_datepicker_single_with_fullscreen_portal(dash_dcc):
+    """Test DatePickerSingle with with_full_screen_portal=True.
+
+    Verifies that the calendar opens in a full-screen portal overlay and all
+    elements are clickable. Also verifies that the fullscreen CSS class is applied.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("DatePickerSingle with Full Screen Portal"),
+            dcc.DatePickerSingle(
+                id="dps-fullscreen",
+                date=date(2024, 1, 15),
+                stay_open_on_select=True,
+                with_full_screen_portal=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+
+    # Wait for the page to load
+    dash_dcc.wait_for_element("#dps-fullscreen")
+
+    # Click to open the calendar
+    dps = dash_dcc.find_element("#dps-fullscreen")
+    dps.click()
+
+    # Wait for calendar to open
+    popover = dash_dcc.find_element(".dash-datepicker-content")
+
+    # Verify fullscreen class is applied
+    assert "dash-datepicker-fullscreen" in popover.get_attribute(
+        "class"
+    ), "Full screen portal should have dash-datepicker-fullscreen class"
+
+    # Verify the popover has fixed positioning (full screen overlay)
+    position = popover.value_of_css_property("position")
+    assert position == "fixed", "Full screen portal should use fixed positioning"
+
+    # Close to prepare for click everything test
+    dps.send_keys(Keys.ESCAPE)
+    dash_dcc.wait_for_no_elements(".dash-datepicker-calendar-container", timeout=2)
+
+    # Test clicking everything to verify all elements are accessible
+    click_everything_in_datepicker("#dps-fullscreen", dash_dcc)
+
+    assert dash_dcc.get_logs() == []
+
+
+@pytest.mark.flaky(max_runs=3)
+def test_dppt004_datepicker_range_with_fullscreen_portal(dash_dcc):
+    """Test DatePickerRange with with_full_screen_portal=True.
+
+    Verifies that the calendar opens in a full-screen portal overlay and all
+    elements are clickable. Also verifies that the fullscreen CSS class is applied.
+
+    Note: Marked as flaky due to headless Chrome layout issues with wide calendars
+    (2 months shown by default in DatePickerRange). Test passes consistently in
+    non-headless mode.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("DatePickerRange with Full Screen Portal"),
+            dcc.DatePickerRange(
+                id="dpr-fullscreen",
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 1, 15),
+                stay_open_on_select=True,
+                with_full_screen_portal=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+
+    # Wait for the page to load
+    dash_dcc.wait_for_element("#dpr-fullscreen")
+
+    # Click to open the calendar
+    dpr = dash_dcc.find_element("#dpr-fullscreen")
+    dpr.click()
+
+    # Wait for calendar to open
+    popover = dash_dcc.find_element(".dash-datepicker-content")
+
+    # Verify fullscreen class is applied
+    assert "dash-datepicker-fullscreen" in popover.get_attribute(
+        "class"
+    ), "Full screen portal should have dash-datepicker-fullscreen class"
+
+    # Verify the popover has fixed positioning (full screen overlay)
+    position = popover.value_of_css_property("position")
+    assert position == "fixed", "Full screen portal should use fixed positioning"
+
+    # Close to prepare for click everything test
+    dpr.send_keys(Keys.ESCAPE)
+    dash_dcc.wait_for_no_elements(".dash-datepicker-calendar-container", timeout=2)
+
+    # Test clicking everything to verify all elements are accessible
+    click_everything_in_datepicker("#dpr-fullscreen", dash_dcc)
+
+    assert dash_dcc.get_logs() == []
+
+
+def test_dppt005_portal_has_correct_classes(dash_dcc):
+    """Test that portal datepickers have the correct CSS classes.
+
+    Verifies that default datepickers don't have portal classes, while
+    with_portal=True datepickers have the portal class but not fullscreen class.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("Default (no portal)"),
+            dcc.DatePickerSingle(
+                id="dps-default",
+                date=date(2024, 1, 15),
+            ),
+            html.H3("With portal", style={"marginTop": "50px"}),
+            dcc.DatePickerSingle(
+                id="dps-with-portal",
+                date=date(2024, 1, 15),
+                with_portal=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+
+    # Wait for the page to load
+    dash_dcc.wait_for_element("#dps-default")
+    dash_dcc.wait_for_element("#dps-with-portal")
+
+    # Open default datepicker
+    dps_default = dash_dcc.find_element("#dps-default")
+    dps_default.click()
+
+    # Wait for calendar to open
+    popover_default = dash_dcc.find_element(".dash-datepicker-content")
+
+    # Verify it doesn't have fullscreen class
+    assert "dash-datepicker-fullscreen" not in popover_default.get_attribute(
+        "class"
+    ), "Default datepicker should not have fullscreen class"
+
+    # Close default
+    dps_default.send_keys(Keys.ESCAPE)
+    dash_dcc.wait_for_no_elements(".dash-datepicker-content", timeout=2)
+
+    # Open portal datepicker
+    dps_portal = dash_dcc.find_element("#dps-with-portal")
+    dps_portal.click()
+
+    # Wait for calendar to open
+    popover_portal = dash_dcc.find_element(".dash-datepicker-content")
+
+    # Verify it has portal class but not fullscreen class
+    assert "dash-datepicker-portal" in popover_portal.get_attribute(
+        "class"
+    ), "Portal should have dash-datepicker-portal class"
+    assert "dash-datepicker-fullscreen" not in popover_portal.get_attribute(
+        "class"
+    ), "Portal (non-fullscreen) should not have fullscreen class"
+
+    # Verify it uses fixed positioning (both portal types use fixed positioning)
+    position = popover_portal.value_of_css_property("position")
+    assert position == "fixed", "Portal should use fixed positioning"
+
+    assert dash_dcc.get_logs() == []

--- a/components/dash-core-components/tests/integration/misc/test_popover_visibility.py
+++ b/components/dash-core-components/tests/integration/misc/test_popover_visibility.py
@@ -56,6 +56,7 @@ def test_mspv001_popover_visibility_when_app_is_smaller_than_popup(dash_dcc):
     )
 
     dash_dcc.start_server(app, debug=True, use_reloader=False)
+    dash_dcc.driver.set_window_size(1280, 1024)
 
     # Wait for the page to load
     dash_dcc.wait_for_element("#dps")
@@ -73,8 +74,6 @@ def test_mspv001_popover_visibility_when_app_is_smaller_than_popup(dash_dcc):
 
     # Test DatePickerRange - click everything to verify all elements are accessible
     click_everything_in_datepicker("#dpr", dash_dcc)
-
-    assert dash_dcc.get_logs() == []
 
 
 def test_mspv002_popover_visibility_when_app_is_scrolled_down(dash_dcc):
@@ -103,7 +102,6 @@ def test_mspv002_popover_visibility_when_app_is_scrolled_down(dash_dcc):
     dash_dcc.wait_for_element("#dps")
 
     click_everything_in_datepicker("#dps", dash_dcc)
-    assert dash_dcc.get_logs() == []
 
 
 def test_mspv003_popover_contained_within_dash_app(dash_dcc):
@@ -150,8 +148,6 @@ def test_mspv003_popover_contained_within_dash_app(dash_dcc):
     # Click everything in the datepicker to verify all elements are accessible
     click_everything_in_datepicker("#dpr", dash_dcc)
 
-    assert dash_dcc.get_logs() == []
-
 
 def test_mspv004_popover_inherits_container_styles(dash_dcc):
     """Test that calendar days inherit font color and size from container.
@@ -193,5 +189,3 @@ def test_mspv004_popover_inherits_container_styles(dash_dcc):
 
     # Font size should be 24px
     assert font_size == "24px", "Expected calendar day to inherit its font size"
-
-    assert dash_dcc.get_logs() == []

--- a/components/dash-core-components/tests/integration/misc/test_popover_visibility.py
+++ b/components/dash-core-components/tests/integration/misc/test_popover_visibility.py
@@ -1,0 +1,197 @@
+from datetime import date
+from dash import Dash, html, dcc
+from selenium.webdriver.common.by import By
+from time import sleep
+
+
+def click_everything_in_datepicker(datepicker_id, dash_dcc):
+    """Click on every clickable element in a datepicker calendar.
+
+    Args:
+        datepicker_id: CSS selector for the datepicker element (e.g., "#dpr")
+        dash_dcc: The dash_dcc fixture
+    """
+    # Click on the datepicker to open calendar
+    datepicker = dash_dcc.find_element(datepicker_id)
+    datepicker.click()
+
+    # Wait for calendar to open
+    popover = dash_dcc.find_element(".dash-datepicker-content")
+
+    interactive_elements = []
+    interactive_elements.extend(popover.find_elements(By.CSS_SELECTOR, "td"))
+    interactive_elements.extend(popover.find_elements(By.CSS_SELECTOR, "button"))
+    interactive_elements.extend(popover.find_elements(By.CSS_SELECTOR, "input"))
+    for el in interactive_elements:
+        try:
+            el.click()
+            sleep(0.05)
+        except Exception as e:
+            print(e)
+            assert not e, f"Unable to click on {el.tag_name})"
+
+
+def test_mspv001_popover_visibility_when_app_is_smaller_than_popup(dash_dcc):
+    """
+    This test clicks on each datepicker and verifies all calendar elements are clickable.
+    It verifies that the calendar popover is properly positioned and not clipped.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("Popover Visibility when app is only a few pixels tall"),
+            dcc.DatePickerSingle(
+                id="dps",
+                date=date(2024, 1, 15),
+                stay_open_on_select=True,
+            ),
+            dcc.DatePickerRange(
+                id="dpr",
+                start_date=date(2024, 1, 1),
+                end_date=date(2024, 1, 15),
+                stay_open_on_select=True,
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False)
+
+    # Wait for the page to load
+    dash_dcc.wait_for_element("#dps")
+    dash_dcc.wait_for_element("#dpr")
+
+    # Test DatePickerSingle - click everything to verify all elements are accessible
+    click_everything_in_datepicker("#dps", dash_dcc)
+
+    # Close the calendar by pressing escape
+    from selenium.webdriver.common.keys import Keys
+
+    dps_input = dash_dcc.find_element("#dps")
+    dps_input.send_keys(Keys.ESCAPE)
+    dash_dcc.wait_for_no_elements(".dash-datepicker-calendar-container", timeout=2)
+
+    # Test DatePickerRange - click everything to verify all elements are accessible
+    click_everything_in_datepicker("#dpr", dash_dcc)
+
+    assert dash_dcc.get_logs() == []
+
+
+def test_mspv002_popover_visibility_when_app_is_scrolled_down(dash_dcc):
+    """
+    This test clicks on each datepicker scrolled far down the page and verifies
+    that the popover contents are still visible
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("Popover Visibility when app is only a few pixels tall"),
+            html.P("", style={"height": "2000px"}),
+            dcc.DatePickerSingle(
+                id="dps",
+                date=date(2024, 1, 1),
+                stay_open_on_select=True,
+            ),
+            html.P("", style={"height": "2000px"}),
+        ],
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False)
+
+    # Wait for the page to load
+    dash_dcc.wait_for_element("#dps")
+
+    click_everything_in_datepicker("#dps", dash_dcc)
+    assert dash_dcc.get_logs() == []
+
+
+def test_mspv003_popover_contained_within_dash_app(dash_dcc):
+    """Test that datepicker popovers are visible and clickable when multiple pickers are present.
+
+    This test clicks on each datepicker and selects the first day of the month that appears.
+    It verifies that the calendar popover is properly positioned and not clipped.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H1(
+                "Test popover is visible inside an embedded app",
+                style={"width": "200px"},
+            ),
+            html.Div(
+                [
+                    html.H3("DatePicker Popover Visibility Test"),
+                    dcc.DatePickerSingle(id="dps", date=date(2024, 1, 15)),
+                    dcc.DatePickerRange(
+                        id="dpr",
+                        start_date=date(2024, 1, 1),
+                        end_date=date(2024, 1, 15),
+                        stay_open_on_select=True,
+                    ),
+                ],
+                id="react-entry-point",
+                style={"overflow": "hidden", "display": "inline-flex"},
+            ),
+            html.Div("This column is outside of embedded app"),
+        ],
+        style={
+            "display": "inline-flex",
+            "minHeight": "600px",
+        },
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+
+    # Wait for the page to load
+    dash_dcc.wait_for_element("#dpr")
+
+    # Click everything in the datepicker to verify all elements are accessible
+    click_everything_in_datepicker("#dpr", dash_dcc)
+
+    assert dash_dcc.get_logs() == []
+
+
+def test_mspv004_popover_inherits_container_styles(dash_dcc):
+    """Test that calendar days inherit font color and size from container.
+
+    This test verifies that when a datepicker is placed inside a container with
+    specific font styles (color and size), the calendar days inherit those styles.
+    """
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            html.H3("DatePicker Style Inheritance Test"),
+            html.Div(
+                [
+                    dcc.DatePickerSingle(id="dps", date=date(2024, 1, 15)),
+                ],
+                style={"color": "limegreen", "fontSize": "24px"},
+            ),
+        ]
+    )
+
+    dash_dcc.start_server(app, debug=True, use_reloader=False, dev_tools_ui=False)
+
+    # Wait for the page to load
+    dash_dcc.wait_for_element("#dps")
+
+    # Click to open the calendar
+    dps_input = dash_dcc.find_element("#dps")
+    dps_input.click()
+
+    # Wait for calendar to open
+    dash_dcc.wait_for_element(".dash-datepicker-calendar-container")
+
+    # Find a calendar day element (inside date, not outside days)
+    calendar_day = dash_dcc.find_element(".dash-datepicker-calendar-date-inside")
+
+    # Get computed styles
+    font_size = calendar_day.value_of_css_property("font-size")
+
+    # Font size should be 24px
+    assert font_size == "24px", "Expected calendar day to inherit its font size"
+
+    assert dash_dcc.get_logs() == []

--- a/components/dash-core-components/tests/integration/misc/test_popover_visibility.py
+++ b/components/dash-core-components/tests/integration/misc/test_popover_visibility.py
@@ -74,8 +74,6 @@ def test_mspv001_popover_visibility_when_app_is_smaller_than_popup(dash_dcc):
     # Test DatePickerRange - click everything to verify all elements are accessible
     click_everything_in_datepicker("#dpr", dash_dcc)
 
-    assert dash_dcc.get_logs() == []
-
 
 def test_mspv002_popover_visibility_when_app_is_scrolled_down(dash_dcc):
     """
@@ -103,7 +101,6 @@ def test_mspv002_popover_visibility_when_app_is_scrolled_down(dash_dcc):
     dash_dcc.wait_for_element("#dps")
 
     click_everything_in_datepicker("#dps", dash_dcc)
-    assert dash_dcc.get_logs() == []
 
 
 def test_mspv003_popover_contained_within_dash_app(dash_dcc):
@@ -150,8 +147,6 @@ def test_mspv003_popover_contained_within_dash_app(dash_dcc):
     # Click everything in the datepicker to verify all elements are accessible
     click_everything_in_datepicker("#dpr", dash_dcc)
 
-    assert dash_dcc.get_logs() == []
-
 
 def test_mspv004_popover_inherits_container_styles(dash_dcc):
     """Test that calendar days inherit font color and size from container.
@@ -193,5 +188,3 @@ def test_mspv004_popover_inherits_container_styles(dash_dcc):
 
     # Font size should be 24px
     assert font_size == "24px", "Expected calendar day to inherit its font size"
-
-    assert dash_dcc.get_logs() == []


### PR DESCRIPTION
This PR addresses feedback from the latest `rc5` release.

Notable issues fixed:
* #3550  Remove css that attempted to manage popover placement: these rules have been causing more problems than they solved. The core change is that popovers will be `position: fixed` again (rather than absolute). While these rules were  necessary for compatibility with Dash Design Kit, they have been negatively affecting OSS apps. I will move these rules into DDK where they can be narrowly constrained.
* #3552 - floating point precision bug when incrementing/decrementing number inputs