### PR TITLE
Remove space in css variable (which broke the CSS variable link)

### DIFF
--- a/components/dash-core-components/src/components/css/input.css
+++ b/components/dash-core-components/src/components/css/input.css
@@ -101,7 +101,7 @@
     cursor: pointer;
     font-size: 16px;
     font-weight: bold;
-    color: var(--Dash -Text-Primary);
+    color: var(--Dash-Text-Primary);
 }
 
 .dash-input-stepper:hover,


### PR DESCRIPTION
Remove space in css variable (which broke the CSS variable link)