### PR TITLE
Add hidden to clientside callbacks as configurable parameter

### DIFF
--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -854,6 +854,7 @@ def register_clientside_callback(
         None,
         prevent_initial_call,
         no_output=no_output,
+        hidden=True,
     )
 
     # If JS source is explicitly given, create a namespace and function

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -854,7 +854,7 @@ def register_clientside_callback(
         None,
         prevent_initial_call,
         no_output=no_output,
-        hidden=True,
+        hidden=kwargs.get("hidden", False),
     )
 
     # If JS source is explicitly given, create a namespace and function


### PR DESCRIPTION
Added `hidden` to clientside callbacks as configurable parameter.
Now it can be configured from `cilentside_callback` function.

Solves this issue: https://github.com/plotly/dash/issues/3525

## Contributor Checklist

- [ ] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
