### PR TITLE
run() add new parameter hide_all_callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Added
 - [#3534]((https://github.com/plotly/dash/pull/3534) Adds `playsInline` prop to `html.Video`.  Based on [#2338]((https://github.com/plotly/dash/pull/2338)
 - [#3541](https://github.com/plotly/dash/pull/3541) Add `attributes` dictionary to be be formatted on script/link (_js_dist/_css_dist) tags of the index, allows for `type="module"` or `type="importmap"`. [#3538](https://github.com/plotly/dash/issues/3538)
+- [#3564](https://github.com/plotly/dash/pull/3564) Add new parameter `hide_all_callbacks` to `dash.Dash()`. Closes [#3493](https://github.com/plotly/dash/issues/3493)
 
 ## Fixed
 - [#3541](https://github.com/plotly/dash/pull/3541) Remove last reference of deprecated `pkg_resources`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## Added
 - [#3534]((https://github.com/plotly/dash/pull/3534) Adds `playsInline` prop to `html.Video`.  Based on [#2338]((https://github.com/plotly/dash/pull/2338)
 - [#3541](https://github.com/plotly/dash/pull/3541) Add `attributes` dictionary to be be formatted on script/link (_js_dist/_css_dist) tags of the index, allows for `type="module"` or `type="importmap"`. [#3538](https://github.com/plotly/dash/issues/3538)
-- [#3564](https://github.com/plotly/dash/pull/3564) Add new parameter `hide_all_callbacks` to `dash.Dash()`. Closes [#3493](https://github.com/plotly/dash/issues/3493)
+- [#3564](https://github.com/plotly/dash/pull/3564) Add new parameter `hide_all_callbacks` to `run()`. Closes [#3493](https://github.com/plotly/dash/issues/3493)
 
 ## Fixed
 - [#3541](https://github.com/plotly/dash/pull/3541) Remove last reference of deprecated `pkg_resources`.

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -79,7 +79,7 @@ def callback(
     on_error: Optional[Callable[[Exception], Any]] = None,
     api_endpoint: Optional[str] = None,
     optional: Optional[bool] = False,
-    hidden: Optional[bool] = False,
+    hidden: Optional[bool] = None,
     **_kwargs,
 ) -> Callable[..., Any]:
     """
@@ -181,6 +181,7 @@ def callback(
     config_prevent_initial_callbacks = _kwargs.pop(
         "config_prevent_initial_callbacks", False
     )
+    config_hide_all_callbacks = _kwargs.pop("config_hide_all_callbacks", False)
     callback_map = _kwargs.pop("callback_map", GLOBAL_CALLBACK_MAP)
     callback_list = _kwargs.pop("callback_list", GLOBAL_CALLBACK_LIST)
 
@@ -222,6 +223,7 @@ def callback(
         callback_list,
         callback_map,
         config_prevent_initial_callbacks,
+        config_hide_all_callbacks,
         *_args,
         **_kwargs,
         background=background_spec,
@@ -265,6 +267,7 @@ def insert_callback(
     callback_list,
     callback_map,
     config_prevent_initial_callbacks,
+    config_hide_all_callbacks,
     output,
     outputs_indices,
     inputs,
@@ -277,10 +280,13 @@ def insert_callback(
     dynamic_creator: Optional[bool] = False,
     no_output=False,
     optional=False,
-    hidden=False,
+    hidden=None,
 ):
     if prevent_initial_call is None:
         prevent_initial_call = config_prevent_initial_callbacks
+
+    if hidden is None:
+        hidden = config_hide_all_callbacks
 
     _validate.validate_duplicate_output(
         output, prevent_initial_call, config_prevent_initial_callbacks
@@ -600,6 +606,7 @@ def register_callback(
     callback_list,
     callback_map,
     config_prevent_initial_callbacks,
+    config_hide_all_callbacks,
     *_args,
     **_kwargs,
 ):
@@ -639,6 +646,7 @@ def register_callback(
         callback_list,
         callback_map,
         config_prevent_initial_callbacks,
+        config_hide_all_callbacks,
         insert_output,
         output_indices,
         flat_inputs,
@@ -651,7 +659,7 @@ def register_callback(
         running=running,
         no_output=not has_output,
         optional=_kwargs.get("optional", False),
-        hidden=_kwargs.get("hidden", False),
+        hidden=_kwargs.get("hidden"),
     )
 
     # pylint: disable=too-many-locals
@@ -836,6 +844,7 @@ def register_clientside_callback(
     callback_list,
     callback_map,
     config_prevent_initial_callbacks,
+    config_hide_all_callbacks,
     inline_scripts,
     clientside_function: ClientsideFuncType,
     *args,
@@ -847,6 +856,7 @@ def register_clientside_callback(
         callback_list,
         callback_map,
         config_prevent_initial_callbacks,
+        config_hide_all_callbacks,
         output,
         None,
         inputs,

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -41,7 +41,6 @@ from ._utils import (
 from . import _validate
 from .background_callback.managers import BaseBackgroundCallbackManager
 from ._callback_context import context_value
-from ._get_app import get_app
 from ._no_update import NoUpdate
 
 
@@ -179,13 +178,9 @@ def callback(
 
     background_spec: Any = None
 
-    # Get prevent_initial_callbacks and hide_all_callbacks from get_app().config
-    current_app_config = get_app().config
-
-    config_prevent_initial_callbacks = current_app_config.get(
-        "prevent_initial_callbacks", False
+    config_prevent_initial_callbacks = _kwargs.pop(
+        "config_prevent_initial_callbacks", False
     )
-    config_hide_all_callbacks = current_app_config.get("hide_all_callbacks", False)
     callback_map = _kwargs.pop("callback_map", GLOBAL_CALLBACK_MAP)
     callback_list = _kwargs.pop("callback_list", GLOBAL_CALLBACK_LIST)
 
@@ -227,7 +222,6 @@ def callback(
         callback_list,
         callback_map,
         config_prevent_initial_callbacks,
-        config_hide_all_callbacks,
         *_args,
         **_kwargs,
         background=background_spec,
@@ -259,7 +253,6 @@ def clientside_callback(clientside_function: ClientsideFuncType, *args, **kwargs
         GLOBAL_CALLBACK_LIST,
         GLOBAL_CALLBACK_MAP,
         False,
-        False,
         GLOBAL_INLINE_SCRIPTS,
         clientside_function,
         *args,
@@ -272,7 +265,6 @@ def insert_callback(
     callback_list,
     callback_map,
     config_prevent_initial_callbacks,
-    config_hide_all_callbacks,
     output,
     outputs_indices,
     inputs,
@@ -289,9 +281,6 @@ def insert_callback(
 ):
     if prevent_initial_call is None:
         prevent_initial_call = config_prevent_initial_callbacks
-
-    if hidden is None:
-        hidden = config_hide_all_callbacks
 
     _validate.validate_duplicate_output(
         output, prevent_initial_call, config_prevent_initial_callbacks
@@ -611,7 +600,6 @@ def register_callback(
     callback_list,
     callback_map,
     config_prevent_initial_callbacks,
-    config_hide_all_callbacks,
     *_args,
     **_kwargs,
 ):
@@ -651,7 +639,6 @@ def register_callback(
         callback_list,
         callback_map,
         config_prevent_initial_callbacks,
-        config_hide_all_callbacks,
         insert_output,
         output_indices,
         flat_inputs,
@@ -664,7 +651,7 @@ def register_callback(
         running=running,
         no_output=not has_output,
         optional=_kwargs.get("optional", False),
-        hidden=_kwargs.get("hidden"),
+        hidden=_kwargs.get("hidden", None),
     )
 
     # pylint: disable=too-many-locals
@@ -849,7 +836,6 @@ def register_clientside_callback(
     callback_list,
     callback_map,
     config_prevent_initial_callbacks,
-    config_hide_all_callbacks,
     inline_scripts,
     clientside_function: ClientsideFuncType,
     *args,
@@ -861,7 +847,6 @@ def register_clientside_callback(
         callback_list,
         callback_map,
         config_prevent_initial_callbacks,
-        config_hide_all_callbacks,
         output,
         None,
         inputs,

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -41,6 +41,7 @@ from ._utils import (
 from . import _validate
 from .background_callback.managers import BaseBackgroundCallbackManager
 from ._callback_context import context_value
+from ._get_app import get_app
 from ._no_update import NoUpdate
 
 
@@ -178,10 +179,13 @@ def callback(
 
     background_spec: Any = None
 
-    config_prevent_initial_callbacks = _kwargs.pop(
-        "config_prevent_initial_callbacks", False
+    # Get prevent_initial_callbacks and hide_all_callbacks from get_app().config
+    current_app_config = get_app().config
+
+    config_prevent_initial_callbacks = current_app_config.get(
+        "prevent_initial_callbacks", False
     )
-    config_hide_all_callbacks = _kwargs.pop("config_hide_all_callbacks", False)
+    config_hide_all_callbacks = current_app_config.get("hide_all_callbacks", False)
     callback_map = _kwargs.pop("callback_map", GLOBAL_CALLBACK_MAP)
     callback_list = _kwargs.pop("callback_list", GLOBAL_CALLBACK_LIST)
 

--- a/dash/_callback.py
+++ b/dash/_callback.py
@@ -255,6 +255,7 @@ def clientside_callback(clientside_function: ClientsideFuncType, *args, **kwargs
         GLOBAL_CALLBACK_LIST,
         GLOBAL_CALLBACK_MAP,
         False,
+        False,
         GLOBAL_INLINE_SCRIPTS,
         clientside_function,
         *args,

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -2429,7 +2429,7 @@ class Dash(ObsoleteChecker):
         """
 
         # Update self.config.hide_all_callbacks
-        self.config.update({'hide_all_callbacks': hide_all_callbacks})
+        self.config.update({"hide_all_callbacks": hide_all_callbacks})
 
         if debug is None:
             debug = get_combined_config("debug", None, False)

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -69,7 +69,12 @@ from . import _validate
 from . import _watch
 from . import _get_app
 
-from ._get_app import get_app, with_app_context, with_app_context_async, with_app_context_factory
+from ._get_app import (
+    get_app,
+    with_app_context,
+    with_app_context_async,
+    with_app_context_factory,
+)
 from ._grouping import map_grouping, grouping_len, update_args_group
 from ._obsolete import ObsoleteChecker
 
@@ -366,7 +371,7 @@ class Dash(ObsoleteChecker):
         ``True`` here in which case you must explicitly set it ``False`` for
         those callbacks you wish to have an initial call. This setting has no
         effect on triggering callbacks when their inputs change later on.
-    
+
     :param hide_all_callbacks: Default ``False``: Sets the default value of
         ``hidden`` for all callbacks added to the app. Normally all callbacks
         are visible in the devtools callbacks tab. You can set this for
@@ -1658,13 +1663,10 @@ class Dash(ObsoleteChecker):
         current_app_config = get_app().config
 
         self._callback_list.extend(_callback.GLOBAL_CALLBACK_LIST)
-        # For each callback function, if the hidden parameter uses the default value None, 
+        # For each callback function, if the hidden parameter uses the default value None,
         # replace it with the actual value of the hide_all_callbacks property of the current application instance.
         self._callback_list = [
-            {
-                **_callback,
-                "hidden": current_app_config.get("hide_all_callbacks", False)
-            }
+            {**_callback, "hidden": current_app_config.get("hide_all_callbacks", False)}
             if _callback.get("hidden") is None
             else _callback
             for _callback in self._callback_list

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1466,8 +1466,6 @@ class Dash(ObsoleteChecker):
         """
         return _callback.callback(
             *_args,
-            config_prevent_initial_callbacks=self.config.prevent_initial_callbacks,
-            config_hide_all_callbacks=self.config.hide_all_callbacks,
             callback_list=self._callback_list,
             callback_map=self.callback_map,
             callback_api_paths=self.callback_api_paths,

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -367,6 +367,13 @@ class Dash(ObsoleteChecker):
         those callbacks you wish to have an initial call. This setting has no
         effect on triggering callbacks when their inputs change later on.
 
+    :param hide_all_callbacks: Default ``False``: Sets the default value of
+        ``hidden`` for all callbacks added to the app. Normally all callbacks
+        are visible in the devtools callbacks tab. You can set this for
+        individual callbacks by setting ``hidden`` in their definitions, or set
+        it ``True`` here in which case you must explicitly set it ``False`` for
+        those callbacks you wish to remain visible in the devtools callbacks tab.
+
     :param show_undo_redo: Default ``False``, set to ``True`` to enable undo
         and redo buttons for stepping through the history of the app state.
     :type show_undo_redo: boolean
@@ -457,6 +464,7 @@ class Dash(ObsoleteChecker):
         external_stylesheets: Optional[Sequence[Union[str, Dict[str, Any]]]] = None,
         suppress_callback_exceptions: Optional[bool] = None,
         prevent_initial_callbacks: bool = False,
+        hide_all_callbacks: bool = False,
         show_undo_redo: bool = False,
         extra_hot_reload_paths: Optional[Sequence[str]] = None,
         plugins: Optional[list] = None,
@@ -537,6 +545,7 @@ class Dash(ObsoleteChecker):
                 "suppress_callback_exceptions", suppress_callback_exceptions, False
             ),
             prevent_initial_callbacks=prevent_initial_callbacks,
+            hide_all_callbacks=hide_all_callbacks,
             show_undo_redo=show_undo_redo,
             extra_hot_reload_paths=extra_hot_reload_paths or [],
             title=title,
@@ -671,6 +680,7 @@ class Dash(ObsoleteChecker):
                 self._callback_list,
                 self.callback_map,
                 self.config.prevent_initial_callbacks,
+                self.config.hide_all_callbacks,
                 self._inline_scripts,
                 clientside_function,
                 *args,
@@ -1433,6 +1443,7 @@ class Dash(ObsoleteChecker):
             self._callback_list,
             self.callback_map,
             self.config.prevent_initial_callbacks,
+            self.config.hide_all_callbacks,
             self._inline_scripts,
             clientside_function,
             *args,
@@ -1456,6 +1467,7 @@ class Dash(ObsoleteChecker):
         return _callback.callback(
             *_args,
             config_prevent_initial_callbacks=self.config.prevent_initial_callbacks,
+            config_hide_all_callbacks=self.config.hide_all_callbacks,
             callback_list=self._callback_list,
             callback_map=self.callback_map,
             callback_api_paths=self.callback_api_paths,

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -367,13 +367,6 @@ class Dash(ObsoleteChecker):
         those callbacks you wish to have an initial call. This setting has no
         effect on triggering callbacks when their inputs change later on.
 
-    :param hide_all_callbacks: Default ``False``: Sets the default value of
-        ``hidden`` for all callbacks added to the app. Normally all callbacks
-        are visible in the devtools callbacks tab. You can set this for
-        individual callbacks by setting ``hidden`` in their definitions, or set
-        it ``True`` here in which case you must explicitly set it ``False`` for
-        those callbacks you wish to remain visible in the devtools callbacks tab.
-
     :param show_undo_redo: Default ``False``, set to ``True`` to enable undo
         and redo buttons for stepping through the history of the app state.
     :type show_undo_redo: boolean
@@ -464,7 +457,6 @@ class Dash(ObsoleteChecker):
         external_stylesheets: Optional[Sequence[Union[str, Dict[str, Any]]]] = None,
         suppress_callback_exceptions: Optional[bool] = None,
         prevent_initial_callbacks: bool = False,
-        hide_all_callbacks: bool = False,
         show_undo_redo: bool = False,
         extra_hot_reload_paths: Optional[Sequence[str]] = None,
         plugins: Optional[list] = None,
@@ -545,7 +537,6 @@ class Dash(ObsoleteChecker):
                 "suppress_callback_exceptions", suppress_callback_exceptions, False
             ),
             prevent_initial_callbacks=prevent_initial_callbacks,
-            hide_all_callbacks=hide_all_callbacks,
             show_undo_redo=show_undo_redo,
             extra_hot_reload_paths=extra_hot_reload_paths or [],
             title=title,
@@ -553,6 +544,7 @@ class Dash(ObsoleteChecker):
             include_pages_meta=include_pages_meta,
             description=description,
             health_endpoint=health_endpoint,
+            hide_all_callbacks=False,
         )
         self.config.set_read_only(
             [
@@ -1655,14 +1647,16 @@ class Dash(ObsoleteChecker):
             self.callback_map[k] = _callback.GLOBAL_CALLBACK_MAP.pop(k)
 
         self._callback_list.extend(_callback.GLOBAL_CALLBACK_LIST)
+
         # For each callback function, if the hidden parameter uses the default value None,
-        # replace it with the actual value of the hide_all_callbacks property of the current application instance.
+        # replace it with the actual value of the self.config.hide_all_callbacks.
         self._callback_list = [
             {**_callback, "hidden": self.config.get("hide_all_callbacks", False)}
             if _callback.get("hidden") is None
             else _callback
             for _callback in self._callback_list
         ]
+
         _callback.GLOBAL_CALLBACK_LIST.clear()
 
         _validate.validate_background_callbacks(self.callback_map)
@@ -2310,6 +2304,7 @@ class Dash(ObsoleteChecker):
         port: Optional[Union[str, int]] = None,
         proxy: Optional[str] = None,
         debug: Optional[bool] = None,
+        hide_all_callbacks: bool = False,
         jupyter_mode: Optional[JupyterDisplayMode] = None,
         jupyter_width: str = "100%",
         jupyter_height: int = 650,
@@ -2357,6 +2352,14 @@ class Dash(ObsoleteChecker):
             ``enable_dev_tools`` is called directly, and ``False`` when called
             via ``run``. env: ``DASH_DEBUG``
         :type debug: bool
+
+        :param hide_all_callbacks: Default ``False``: Sets the default value of
+            ``hidden`` for all callbacks added to the app. Normally all callbacks
+            are visible in the devtools callbacks tab. You can set this for
+            individual callbacks by setting ``hidden`` in their definitions, or set
+            it ``True`` here in which case you must explicitly set it ``False`` for
+            those callbacks you wish to remain visible in the devtools callbacks tab.
+        :type hide_all_callbacks: bool
 
         :param dev_tools_ui: Show the dev tools UI. env: ``DASH_UI``
         :type dev_tools_ui: bool
@@ -2424,6 +2427,10 @@ class Dash(ObsoleteChecker):
 
         :return:
         """
+
+        # Update self.config.hide_all_callbacks
+        self.config.update({'hide_all_callbacks': hide_all_callbacks})
+
         if debug is None:
             debug = get_combined_config("debug", None, False)
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -69,12 +69,7 @@ from . import _validate
 from . import _watch
 from . import _get_app
 
-from ._get_app import (
-    get_app,
-    with_app_context,
-    with_app_context_async,
-    with_app_context_factory,
-)
+from ._get_app import with_app_context, with_app_context_async, with_app_context_factory
 from ._grouping import map_grouping, grouping_len, update_args_group
 from ._obsolete import ObsoleteChecker
 
@@ -1659,14 +1654,11 @@ class Dash(ObsoleteChecker):
 
             self.callback_map[k] = _callback.GLOBAL_CALLBACK_MAP.pop(k)
 
-        # Get config of current app instance
-        current_app_config = get_app().config
-
         self._callback_list.extend(_callback.GLOBAL_CALLBACK_LIST)
         # For each callback function, if the hidden parameter uses the default value None,
         # replace it with the actual value of the hide_all_callbacks property of the current application instance.
         self._callback_list = [
-            {**_callback, "hidden": current_app_config.get("hide_all_callbacks", False)}
+            {**_callback, "hidden": self.config.get("hide_all_callbacks", False)}
             if _callback.get("hidden") is None
             else _callback
             for _callback in self._callback_list


### PR DESCRIPTION
For the scenario corresponding to https://github.com/plotly/dash/issues/3493, add a new parameter `hide_all_callbacks` to `Dash()`, which is used to change the default application value of the `hidden` parameter in `app.callback()`, improving the convenience of callback debugging for complex applications. Example:

<img width="1952" height="1226" alt="image" src="https://github.com/user-attachments/assets/645cd66c-3b7e-44cd-9709-205c5ab220bb" />

```python
import dash
from dash import html, Input, Output, State

app = dash.Dash(__name__, hide_all_callbacks=True)

app.layout = html.Div(
    [
        html.Div(
            [
                html.Button("Button 1", id="button1"),
                html.Button("Button 2", id="button2"),
                html.Button("Button 3", id="button3"),
            ]
        ),
        html.Div(0, id="output"),
    ],
    style={"padding": 50},
)


@app.callback(
    Output("output", "children"),
    Input("button1", "n_clicks"),
    State("output", "children"),
    prevent_initial_call=True,
)
def button1_update_output(n_clicks, children):
    return children + 1


@app.callback(
    Output("output", "children", allow_duplicate=True),
    Input("button2", "n_clicks"),
    State("output", "children"),
    prevent_initial_call=True,
)
def button2_update_output(n_clicks, children):
    return children + 1


@app.callback(
    Output("output", "children", allow_duplicate=True),
    Input("button3", "n_clicks"),
    State("output", "children"),
    prevent_initial_call=True,
    hidden=False,
)
def button3_update_output(n_clicks, children):
    return children + 1


if __name__ == "__main__":
    app.run(debug=True)
```