### PR TITLE
fix to loadingOptions.rawPath type

### DIFF
--- a/dash/dash-renderer/src/wrapper/DashContext.tsx
+++ b/dash/dash-renderer/src/wrapper/DashContext.tsx
@@ -18,7 +18,7 @@ type LoadingOptions = {
      * Useful if you want the loading of a child component
      * as the path is available in `child.props.componentPath`.
      */
-    rawPath?: boolean;
+    rawPath?: (string | number)[];
     /**
      * Function used to filter the properties of the loading component.
      * Filter argument is an Entry of `{path, property, id}`.


### PR DESCRIPTION
loadingOptions.rawPath was incorrectly set to boolean. Following show docs example (https://dash.plotly.com/dash-3-for-component-developers) so it aligns with example.