### PR TITLE
fix: correct typo 'seperate_4digits' to 'separate_4digits' in tests

### DIFF
--- a/components/dash-table/tests/selenium/test_formatting.py
+++ b/components/dash-table/tests/selenium/test_formatting.py
@@ -26,7 +26,7 @@ def get_app(props=dict()):
             c.update(
                 dict(
                     format=dict(
-                        locale=dict(seperate_4digits=False),
+                        locale=dict(separate_4digits=False),
                         prefix=1000,
                         specifier=".3f",
                     )
@@ -36,7 +36,7 @@ def get_app(props=dict()):
             c.update(
                 dict(
                     format=dict(
-                        locale=dict(symbol=["eq. $", ""], seperate_4digits=False),
+                        locale=dict(symbol=["eq. $", ""], separate_4digits=False),
                         nully=0,
                         specifier="$,.2f",
                     ),


### PR DESCRIPTION
Corrects the parameter name in `test_formatting.py` to match the actual API parameter `separate_4digits` used throughout the codebase.