### PR TITLE
Fix html build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,18 +158,18 @@ jobs:
             pip install --no-cache-dir --upgrade -e .[ci,dev] --progress-bar off
       - run:
           command: |
-            nvm install lts/iron && nvm use lts/iron
+            nvm install 24 && nvm use 24
       - run:
           name: npm prereqs
           command: |
-            nvm use lts/iron
+            nvm use 24
             npm ci
             cd dash/dash-renderer && npm i && cd ../../
             cd components/dash-html-components && npm i && npm run extract && cd ../../
       - run:
           name: ️️🏗️ build dash
           command: |
-            nvm use lts/iron
+            nvm use 24
             . venv/Scripts/activate
             npm run private::build.jupyterlab && npm run private::build.renderer
             cd components/dash-html-components && npm run build:windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,21 +158,21 @@ jobs:
             pip install --no-cache-dir --upgrade -e .[ci,dev] --progress-bar off
       - run:
           command: |
-            nvm install 18 && nvm use 18
+            nvm install lts/iron && nvm use lts/iron
       - run:
           name: npm prereqs
           command: |
-            nvm use 18
+            nvm use lts/iron
             npm ci
             cd dash/dash-renderer && npm i && cd ../../
             cd components/dash-html-components && npm i && npm run extract && cd ../../
       - run:
           name: ️️🏗️ build dash
           command: |
-            nvm use 18
+            nvm use lts/iron
             . venv/Scripts/activate
             npm run private::build.jupyterlab && npm run private::build.renderer
-            cd components/dash-html-components && npm run build
+            cd components/dash-html-components && npm run build:windows
           no_output_timeout: 30m
 
   test-312: &test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -172,7 +172,7 @@ jobs:
             nvm use 24
             . venv/Scripts/activate
             npm run private::build.jupyterlab && npm run private::build.renderer
-            cd components/dash-html-components && npm run build:windows
+            cd components/dash-html-components && npm run build
           no_output_timeout: 30m
 
   test-312: &test

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
-* @T4rk1n @ndrezn @gvwilson @emilykl
+* @T4rk1n @ndrezn @emilykl @camdecoster

--- a/components/dash-html-components/package.json
+++ b/components/dash-html-components/package.json
@@ -19,11 +19,11 @@
     "lint": "eslint src scripts",
     "build:js": "webpack --mode production",
     "build:backends": "dash-generate-components ./src/components dash_html_components -p package-info.json && cp dash_html_components_base/** dash_html_components && dash-generate-components ./src/components dash_html_components -p package-info.json --r-prefix 'html' --r-suggests 'dash,dashCoreComponents' --jl-prefix 'html' && black dash_html_components",
-    "build:py": "dash-generate-components ./src/components dash_html_components -p package-info.json && cp dash_html_components_base/** dash_html_components && dash-generate-components ./src/components dash_html_components -p package-info.json  && black dash_html_components",
+    "build:py": "dash-generate-components ./src/components dash_html_components -p package-info.json && cp dash_html_components_base/** dash_html_components && dash-generate-components ./src/components dash_html_components -p package-info.json && black dash_html_components",
     "build": "npm run build:js && npm run build:backends",
     "postbuild": "es-check es5 dash_html_components/*.js",
     "build:watch": "watch 'npm run build' src",
-    "build:windows": "run-p build:js build:py",
+    "build:windows": "npm run build:js && build:py",
     "test:py": "pytest --nopercyfinalize --headless tests/test_dash_html_components.py tests/test_integration.py",
     "test": "run-s -c test:py lint"
   },

--- a/components/dash-html-components/package.json
+++ b/components/dash-html-components/package.json
@@ -19,11 +19,9 @@
     "lint": "eslint src scripts",
     "build:js": "webpack --mode production",
     "build:backends": "dash-generate-components ./src/components dash_html_components -p package-info.json && cp dash_html_components_base/** dash_html_components && dash-generate-components ./src/components dash_html_components -p package-info.json --r-prefix 'html' --r-suggests 'dash,dashCoreComponents' --jl-prefix 'html' && black dash_html_components",
-    "build:py": "dash-generate-components ./src/components dash_html_components -p package-info.json && cp dash_html_components_base/** dash_html_components && dash-generate-components ./src/components dash_html_components -p package-info.json && black dash_html_components",
     "build": "npm run build:js && npm run build:backends",
     "postbuild": "es-check es5 dash_html_components/*.js",
     "build:watch": "watch 'npm run build' src",
-    "build:windows": "npm run build:js && build:py",
     "test:py": "pytest --nopercyfinalize --headless tests/test_dash_html_components.py tests/test_integration.py",
     "test": "run-s -c test:py lint"
   },

--- a/components/dash-html-components/package.json
+++ b/components/dash-html-components/package.json
@@ -19,9 +19,11 @@
     "lint": "eslint src scripts",
     "build:js": "webpack --mode production",
     "build:backends": "dash-generate-components ./src/components dash_html_components -p package-info.json && cp dash_html_components_base/** dash_html_components && dash-generate-components ./src/components dash_html_components -p package-info.json --r-prefix 'html' --r-suggests 'dash,dashCoreComponents' --jl-prefix 'html' && black dash_html_components",
+    "build:py": "dash-generate-components ./src/components dash_html_components -p package-info.json && cp dash_html_components_base/** dash_html_components && dash-generate-components ./src/components dash_html_components -p package-info.json  && black dash_html_components",
     "build": "npm run build:js && npm run build:backends",
     "postbuild": "es-check es5 dash_html_components/*.js",
     "build:watch": "watch 'npm run build' src",
+    "build:windows": "run-p build:js build:py",
     "test:py": "pytest --nopercyfinalize --headless tests/test_dash_html_components.py tests/test_integration.py",
     "test": "run-s -c test:py lint"
   },

--- a/components/dash-html-components/scripts/extract-elements.js
+++ b/components/dash-html-components/scripts/extract-elements.js
@@ -22,7 +22,11 @@ function extractElements($) {
         // experimental, don't add yet
         'portal',
         'fencedframe',
-        'selectedcontent'
+        'selectedcontent',
+        // Geolocation has a weird formatting catch
+        `geolocation 
+Experimental
+`
     ];
     // `<section>` is for some reason missing from the reference tables.
     const addElements = [


### PR DESCRIPTION
The element extractor script was catching `geolocation \nExperimental` then failing the generated component because of the whitespace. This exclude the element from the script.