### PR TITLE
add backward compat alias for _Wildcard

### DIFF
--- a/dash/dependencies.py
+++ b/dash/dependencies.py
@@ -31,6 +31,11 @@ MATCH = Wildcard.MATCH
 ALL = Wildcard.ALL
 ALLSMALLER = Wildcard.ALLSMALLER
 
+# Backward compatibility alias — the class was renamed from _Wildcard to
+# Wildcard in Dash 3.4.  Third-party packages (e.g. dash-pydantic-form)
+# still import the old private name.
+_Wildcard = Wildcard
+
 
 class DashDependency:  # pylint: disable=too-few-public-methods
     component_id: ComponentIdType


### PR DESCRIPTION
The `_Wildcard` class was renamed to `Wildcard` in Dash 3.4, but some third-party packages (like dash-pydantic-form) still import the old private name. This breaks on upgrade from 3.3 → 3.4 with `ImportError: cannot import name '_Wildcard' from 'dash.dependencies'`.

This adds `_Wildcard = Wildcard` as a one-line alias so those imports keep working.

Fixes #3580