### PR TITLE
fix: replace 1 bare except clause with except Exception

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -9,7 +9,7 @@ def invincible(func):
     def wrap():
         try:
             return func()
-        except:
+        except Exception:
             pass
 
     return wrap


### PR DESCRIPTION
Replace bare `except:` clauses with `except Exception:` for PEP 8 compliance.