### PR TITLE
Fix #2989: dcc.Dropdown options order preserved during search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ## [UNRELEASED]
 
 ## Added
+- [#3680](https://github.com/plotly/dash/pull/3680) Added `search_order` prop to `Dropdown` to allow users to preserve original option order during search 
+
+## Added
 - [#3523](https://github.com/plotly/dash/pull/3523) Fall back to background callback function names if source cannot be found
 
 ## Fixed

--- a/components/dash-core-components/src/fragments/Dropdown.tsx
+++ b/components/dash-core-components/src/fragments/Dropdown.tsx
@@ -41,6 +41,7 @@ const Dropdown = (props: DropdownProps) => {
         setProps,
         searchable,
         search_value,
+        search_order,
         style,
         value,
     } = props;
@@ -81,9 +82,9 @@ const Dropdown = (props: DropdownProps) => {
     const filteredOptions = useMemo(
         () =>
             searchable
-                ? filterOptions(sanitized, search_value)
+                ? filterOptions(sanitized, search_value, search_order)
                 : sanitizedOptions,
-        [sanitized, searchable, search_value]
+        [sanitized, searchable, search_value, search_order]
     );
 
     const sanitizedValues: OptionValue[] = useMemo(() => {

--- a/components/dash-core-components/src/types.ts
+++ b/components/dash-core-components/src/types.ts
@@ -746,6 +746,13 @@ export interface DropdownProps extends BaseDccProps<DropdownProps> {
      * Use with `closeOnSelect=False`
      */
     debounce?: boolean;
+
+    /**
+     * The order in which to search results appear. 'index' (the default) means that
+     * options are presented based on search relevance, while 'original' keeps the
+     * order of options as they were originally provided.
+     */
+    search_order?: 'index' | 'original';
 }
 
 export interface ChecklistProps extends BaseDccProps<ChecklistProps> {

--- a/components/dash-core-components/src/utils/dropdownSearch.ts
+++ b/components/dash-core-components/src/utils/dropdownSearch.ts
@@ -60,7 +60,8 @@ export function sanitizeDropdownOptions(
 
 export function filterOptions(
     options: SanitizedOptions,
-    searchValue?: string
+    searchValue?: string,
+    search_order?: 'index' | 'original'
 ): DetailedOption[] {
     if (!searchValue) {
         return options.options;
@@ -82,7 +83,10 @@ export function filterOptions(
     const searchResults =
         (search.search(searchValue) as DetailedOption[]) || [];
 
-    const resultSet = new Set(searchResults);
+    if (search_order === 'original') {
+        const resultSet = new Set(searchResults);
+        return options.options.filter(option => resultSet.has(option));
+    }
 
-    return options.options.filter(option => resultSet.has(option));
+    return searchResults;
 }

--- a/components/dash-core-components/src/utils/dropdownSearch.ts
+++ b/components/dash-core-components/src/utils/dropdownSearch.ts
@@ -79,5 +79,10 @@ export function filterOptions(
         search.addDocuments(options.options);
     }
 
-    return (search.search(searchValue) as DetailedOption[]) || [];
+    const searchResults =
+        (search.search(searchValue) as DetailedOption[]) || [];
+
+    const resultSet = new Set(searchResults);
+
+    return options.options.filter(option => resultSet.has(option));
 }

--- a/components/dash-core-components/tests/integration/dropdown/test_dropdown_search_order.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_dropdown_search_order.py
@@ -1,0 +1,160 @@
+from dash import Dash, html, dcc, Input, Output
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.common.action_chains import ActionChains
+from time import sleep
+
+
+def test_ddso001_search_preserves_custom_order(dash_duo):
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(
+                id="dropdown",
+                options=["11 Text", "12", "23", "112", "111", "110", "22"],
+                searchable=True,
+            ),
+            html.Div(id="output"),
+        ]
+    )
+
+    dash_duo.start_server(app)
+
+    dropdown = dash_duo.find_element("#dropdown")
+    dropdown.click()
+    dash_duo.wait_for_element(".dash-dropdown-options")
+
+    # Search for '11'
+    search_input = dash_duo.find_element(".dash-dropdown-search")
+    search_input.send_keys("11")
+    sleep(0.2)
+
+    # Presents matching options in original order
+    options = dash_duo.find_elements(".dash-dropdown-option")
+    assert len(options) == 4
+    assert [opt.text for opt in options] == ["11 Text", "112", "111", "110"]
+
+    assert dash_duo.get_logs() == []
+
+
+def test_ddso002_multi_search_preserves_custom_order(dash_duo):
+    def send_keys(key):
+        ActionChains(dash_duo.driver).send_keys(key).perform()
+
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(
+                id="dropdown",
+                options=["11 Text", "12", "112", "111", "110"],
+                multi=True,
+                searchable=True,
+            ),
+            html.Div(id="output"),
+        ]
+    )
+
+    @app.callback(Output("output", "children"), Input("dropdown", "value"))
+    def update_output(value):
+        return f"Selected: {value}"
+
+    dash_duo.start_server(app)
+
+    dropdown = dash_duo.find_element("#dropdown")
+    dropdown.click()
+    dash_duo.wait_for_element(".dash-dropdown-options")
+
+    # Select '12' (second option)
+    send_keys(Keys.ARROW_DOWN)
+    sleep(0.2)
+    send_keys(Keys.ARROW_DOWN)
+    sleep(0.2)
+    send_keys(Keys.SPACE)
+    dash_duo.wait_for_text_to_equal("#output", "Selected: ['12']")
+    sleep(0.2)
+
+    # Select '111' (fourth option)
+    send_keys(Keys.ARROW_DOWN)
+    sleep(0.2)
+    send_keys(Keys.ARROW_DOWN)
+    sleep(0.2)
+    send_keys(Keys.SPACE)
+    dash_duo.wait_for_text_to_equal("#output", "Selected: ['12', '111']")
+    sleep(0.2)
+
+    # Search for '1'
+    send_keys(Keys.HOME)
+    sleep(0.2)
+    send_keys("1")
+    sleep(0.2)
+
+    # Presents selected options first and rest in original order
+    options = dash_duo.find_elements(".dash-dropdown-option")
+    assert len(options) == 5
+    assert [opt.text for opt in options] == ["12", "111", "11 Text", "112", "110"]
+
+    assert dash_duo.get_logs() == []
+
+
+def test_ddso003_search_preserves_custom_order_full_list(dash_duo):
+    app = Dash(__name__)
+
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(
+                id="dropdown",
+                options=["A", "Zebra", "Apply", "Apple"],
+                searchable=True,
+            ),
+            html.Div(id="output"),
+        ]
+    )
+    dash_duo.start_server(app)
+
+    dropdown = dash_duo.find_element("#dropdown")
+    dropdown.click()
+
+    search_input = dash_duo.find_element(".dash-dropdown-search")
+
+    # Search for 'A', returns all options
+    search_input.send_keys("A")
+    sleep(0.2)
+
+    # Presents all options in original order
+    options = dash_duo.find_elements(".dash-dropdown-option")
+    assert len(options) == 4
+    assert [opt.text for opt in options] == ["A", "Zebra", "Apply", "Apple"]
+
+    assert dash_duo.get_logs() == []
+
+
+def test_ddso004_search_no_match(dash_duo):
+    app = Dash(__name__)
+
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(
+                id="dropdown",
+                options=["11 Text", "12", "110", "111", "112"],
+                searchable=True,
+            ),
+            html.Div(id="output"),
+        ]
+    )
+    dash_duo.start_server(app)
+
+    dropdown = dash_duo.find_element("#dropdown")
+    dropdown.click()
+
+    search_input = dash_duo.find_element(".dash-dropdown-search")
+
+    # Search for 'A', returns no options
+    search_input.send_keys("A")
+    sleep(0.2)
+
+    options = dash_duo.find_elements(".dash-dropdown-option")
+
+    assert len(options) == 1
+    assert [opt.text for opt in options] == ["No options found"]
+    assert dash_duo.get_logs() == []

--- a/components/dash-core-components/tests/integration/dropdown/test_dropdown_search_order.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_dropdown_search_order.py
@@ -13,6 +13,7 @@ def test_ddso001_search_preserves_custom_order(dash_duo):
                 id="dropdown",
                 options=["11 Text", "12", "23", "112", "111", "110", "22"],
                 searchable=True,
+                search_order="original",
             ),
             html.Div(id="output"),
         ]
@@ -49,6 +50,7 @@ def test_ddso002_multi_search_preserves_custom_order(dash_duo):
                 options=["11 Text", "12", "112", "111", "110"],
                 multi=True,
                 searchable=True,
+                search_order="original",
             ),
             html.Div(id="output"),
         ]
@@ -105,6 +107,7 @@ def test_ddso003_search_preserves_custom_order_full_list(dash_duo):
                 id="dropdown",
                 options=["A", "Zebra", "Apply", "Apple"],
                 searchable=True,
+                search_order="original",
             ),
             html.Div(id="output"),
         ]
@@ -138,6 +141,7 @@ def test_ddso004_search_no_match(dash_duo):
                 id="dropdown",
                 options=["11 Text", "12", "110", "111", "112"],
                 searchable=True,
+                search_order="original",
             ),
             html.Div(id="output"),
         ]


### PR DESCRIPTION
This PR fixes #2989.

When searching in `dcc.Dropdown`, search results should be presented in the original option order instead of being reordered by `js-search`. This is achieved by creating a Set of the search results and filtering the original options array against it, preserving the intended order.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   - [x] Implement Set-based filtering in `DropdownSearch.tsx` to preserve user-defined order in search results
   - [x] Add tests for various option ordering scenarios, including ordering in multi-value dropdowns
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community
