### PR TITLE
Fix input when min or max is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to `dash` will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [UNRELEASED]
+
+## Fixed
+- [#3690](https://github.com/plotly/dash/pull/3690)  Fixes Input when min or max is set to None
+
 ## [4.1.0] - 2026-03-23
 
 ## Added

--- a/components/dash-core-components/src/components/Input.tsx
+++ b/components/dash-core-components/src/components/Input.tsx
@@ -188,13 +188,13 @@ function Input({
 
             // Apply min/max constraints
             let constrainedValue = newValue;
-            if (props.min !== undefined) {
+            if (props.min !== null && props.min !== undefined) {
                 constrainedValue = Math.max(
                     constrainedValue,
                     parseFloat(props.min as string)
                 );
             }
-            if (props.max !== undefined) {
+            if (props.max !== null && props.min !== undefined) {
                 constrainedValue = Math.min(
                     constrainedValue,
                     parseFloat(props.max as string)

--- a/components/dash-core-components/tests/integration/input/test_number_input.py
+++ b/components/dash-core-components/tests/integration/input/test_number_input.py
@@ -253,3 +253,29 @@ def test_inni010_valid_numbers(dash_dcc, ninput_app):
         dash_dcc.clear_input(elem)
 
     assert dash_dcc.get_logs() == []
+
+
+def test_inni011_min_max_bug(dash_dcc):
+    """Test that decrement increment button works correctly with min/max set to None."""
+
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.Input(id="number", value=17, type="number", min=None, max=None),
+            html.Div(id="output"),
+        ]
+    )
+
+    @app.callback(Output("output", "children"), [Input("number", "value")])
+    def update_output(val):
+        return val
+
+    dash_dcc.start_server(app)
+
+    decrement_btn = dash_dcc.find_element(".dash-stepper-decrement")
+
+    # Initial value is 17, should be able to decrement to 16
+    decrement_btn.click()
+    dash_dcc.wait_for_text_to_equal("#output", "16")
+
+    assert dash_dcc.get_logs() == []


### PR DESCRIPTION
Closes #3689 

Fixes a bug in `Input` when `min` or `max` is set to `None`