### PR TITLE
Fix misaligned slider marks with empty labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Fixed
 - [#3690](https://github.com/plotly/dash/pull/3690) Fixes Input when min or max is set to None
+- [#3723](https://github.com/plotly/dash/pull/3723) Fix misaligned `dcc.Slider` marks when some labels are empty strings
 
 ## [4.1.0] - 2026-03-23
 

--- a/components/dash-core-components/src/components/css/sliders.css
+++ b/components/dash-core-components/src/components/css/sliders.css
@@ -92,6 +92,7 @@
 .dash-slider-mark {
     position: absolute;
     font-size: 12px;
+    height: 12px;
     line-height: 12px;
     color: var(--Dash-Text-Strong);
     white-space: nowrap;

--- a/components/dash-core-components/tests/integration/sliders/test_sliders.py
+++ b/components/dash-core-components/tests/integration/sliders/test_sliders.py
@@ -734,3 +734,30 @@ def test_slsl019_allow_direct_input_false(dash_dcc):
     dash_dcc.wait_for_text_to_equal("#rangeslider-output", "RangeSlider: 10-75")
 
     assert dash_dcc.get_logs() == []
+
+
+def test_slsl020_empty_mark_labels_keep_tick_alignment(dash_dcc):
+    app = Dash(__name__)
+    marks = {val: (str(val) if val % 10 == 0 else "") for val in range(0, 151, 5)}
+
+    app.layout = dcc.Slider(
+        id="slider-empty-mark-labels",
+        min=0,
+        max=150,
+        step=None,
+        value=0,
+        marks=marks,
+    )
+
+    dash_dcc.start_server(app)
+    dash_dcc.wait_for_element("#slider-empty-mark-labels")
+
+    rendered_marks = dash_dcc.find_elements(
+        "#slider-empty-mark-labels .dash-slider-mark"
+    )
+    labeled_mark = next(mark for mark in rendered_marks if mark.text)
+    empty_mark = next(mark for mark in rendered_marks if not mark.text)
+
+    assert labeled_mark.size["height"] == 12
+    assert empty_mark.size["height"] == labeled_mark.size["height"]
+    assert dash_dcc.get_logs() == []


### PR DESCRIPTION
## Summary

- add an explicit `height: 12px` to `.dash-slider-mark` so empty labels keep the same mark box height as labeled marks
- add an integration regression test covering the empty-string marks case from `#3715`
- add the corresponding unreleased changelog entry

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   - [x] add the slider mark height fix
   - [x] add a regression test for empty mark labels
   - [x] add the changelog entry
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    - [ ] this GitHub [#PR number]() updates the dash docs
    - [ ] here is the show and tell thread in Plotly Dash community

Fixes #3715
