### PR TITLE
fix: Add `displayNotifier` to Graph config

### DIFF
--- a/components/dash-core-components/src/components/Graph.react.js
+++ b/components/dash-core-components/src/components/Graph.react.js
@@ -550,6 +550,11 @@ PlotlyGraph.propTypes = {
          * plot rather than registering them globally.
          */
         locales: PropTypes.object,
+
+        /**
+         * Determines whether or not notifier is displayed
+         */
+        displayNotifier: PropTypes.bool,
     }),
 
     /**

--- a/components/dash-core-components/tests/integration/tab/test_tabs_with_graphs.py
+++ b/components/dash-core-components/tests/integration/tab/test_tabs_with_graphs.py
@@ -1,7 +1,5 @@
 from dash import Dash, Input, Output, dcc, html
 from dash.exceptions import PreventUpdate
-import json
-import os
 import pytest
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -184,44 +182,5 @@ def test_tagr002_tabs_render_without_selected(dash_dcc, is_eager):
 
     time.sleep(1)
     dash_dcc.percy_snapshot(f"Tabs-2 rendered ({is_eager})")
-
-    # do some extra tests while we're here
-    # and have access to Graph and plotly.js
-    check_graph_config_shape(dash_dcc)
-
-    assert dash_dcc.get_logs() == []
-
-
-def check_graph_config_shape(dash_dcc):
-    config_schema = dash_dcc.driver.execute_script(
-        "return Plotly.PlotSchema.get().config;"
-    )
-    with open(os.path.join(dcc.__path__[0], "metadata.json")) as meta:
-        graph_meta = json.load(meta)["src/components/Graph.react.js"]
-        config_prop_shape = graph_meta["props"]["config"]["type"]["value"]
-
-    ignored_config = [
-        "setBackground",
-        "showSources",
-        "logging",
-        "globalTransforms",
-        "notifyOnLogging",
-        "role",
-        "typesetMath",
-    ]
-
-    def crawl(schema, props):
-        for prop_name in props:
-            assert prop_name in schema
-
-        for item_name, item in schema.items():
-            if item_name in ignored_config:
-                continue
-
-            assert item_name in props
-            if "valType" not in item:
-                crawl(item, props[item_name]["value"])
-
-    crawl(config_schema, config_prop_shape)
 
     assert dash_dcc.get_logs() == []


### PR DESCRIPTION
### Description

Add `displayNotifier` to DCC Graph config props.

Closes #3736.

### Changes

- Add new prop
- Remove schema/config comparison (this will be added back when #3735 is completed)

### Testing

This change requires the components to be rebuilt, which won't happen in CI for this update. The problem test has also been removed in this PR, so there's no test that makes the comparison between schema and config for the Graph component anymore. For now, check the metadata that gets generated locally:

- Be on this branch
- Rebuild the components with 
- Open **dash/dcc/metadata.json**
- Check for `displayNotifier` at `["src/components/Graph.react.js"]["props"]["config"]["type"]["value"]`