### PR TITLE
feat: make CSRF cookie and header names configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Added
 - [#3680](https://github.com/plotly/dash/pull/3680) Added `search_order` prop to `Dropdown` to allow users to preserve original option order during search 
+- Added `csrf_token_name` and `csrf_header_name` config options to allow configuring the CSRF cookie and header names. Fixes [#729](https://github.com/plotly/dash/issues/729)
 
 ## Added
 - [#3523](https://github.com/plotly/dash/pull/3523) Fall back to background callback function names if source cannot be found

--- a/dash/dash-renderer/src/actions/api.js
+++ b/dash/dash-renderer/src/actions/api.js
@@ -7,22 +7,22 @@ import {JWT_EXPIRED_MESSAGE, STATUS} from '../constants/constants';
 /* eslint-disable-next-line no-console */
 const logWarningOnce = once(console.warn);
 
-function GET(path, fetchConfig) {
+function GET(path, fetchConfig, _body, config) {
     return fetch(
         path,
         mergeDeepRight(fetchConfig, {
             method: 'GET',
-            headers: getCSRFHeader()
+            headers: getCSRFHeader(config)
         })
     );
 }
 
-function POST(path, fetchConfig, body = {}) {
+function POST(path, fetchConfig, body = {}, config) {
     return fetch(
         path,
         mergeDeepRight(fetchConfig, {
             method: 'POST',
-            headers: getCSRFHeader(),
+            headers: getCSRFHeader(config),
             body: body ? JSON.stringify(body) : null
         })
     );
@@ -55,7 +55,12 @@ export default function apiThunk(endpoint, method, store, id, body) {
             let res;
             for (let retry = 0; retry <= MAX_AUTH_RETRIES; retry++) {
                 try {
-                    res = await request[method](url, config.fetch, body);
+                    res = await request[method](
+                        url,
+                        config.fetch,
+                        body,
+                        config
+                    );
                 } catch (e) {
                     // fetch rejection - this means the request didn't return,
                     // we don't get here from 400/500 errors, only network

--- a/dash/dash-renderer/src/actions/callbacks.ts
+++ b/dash/dash-renderer/src/actions/callbacks.ts
@@ -483,7 +483,7 @@ function handleServerside(
     }
 
     const fetchCallback = () => {
-        const headers = getCSRFHeader() as any;
+        const headers = getCSRFHeader(config) as any;
         let url = `${urlBase(config)}_dash-update-component`;
         let newBody = body;
 

--- a/dash/dash-renderer/src/actions/index.js
+++ b/dash/dash-renderer/src/actions/index.js
@@ -61,11 +61,16 @@ export function hydrateInitialOutputs() {
 /* eslint-disable-next-line no-console */
 const logWarningOnce = once(console.warn);
 
-export function getCSRFHeader() {
+export function getCSRFHeader(config) {
     try {
-        return {
-            'X-CSRFToken': cookie.parse(document.cookie)._csrf_token
-        };
+        const tokenName = (config && config.csrf_token_name) || '_csrf_token';
+        const headerName = (config && config.csrf_header_name) || 'X-CSRFToken';
+        const cookies = cookie.parse(document.cookie);
+        const token = cookies[tokenName];
+        if (!token) {
+            return {};
+        }
+        return {[headerName]: token};
     } catch (e) {
         logWarningOnce(e);
         return {};

--- a/dash/dash-renderer/src/config.ts
+++ b/dash/dash-renderer/src/config.ts
@@ -22,6 +22,8 @@ export type DashConfig = {
     serve_locally?: boolean;
     plotlyjs_url?: string;
     validate_callbacks: boolean;
+    csrf_token_name?: string;
+    csrf_header_name?: string;
 };
 
 export default function getConfigFromDOM(): DashConfig {

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -1139,11 +1139,9 @@ class Dash(ObsoleteChecker):
 
         return "\n".join(
             [
-                (
-                    format_tag("link", link, opened=True)
-                    if isinstance(link, dict)
-                    else f'<link rel="stylesheet" href="{link}">'
-                )
+                format_tag("link", link, opened=True)
+                if isinstance(link, dict)
+                else f'<link rel="stylesheet" href="{link}">'
                 for link in (external_links + links)
             ]
         )
@@ -1197,11 +1195,9 @@ class Dash(ObsoleteChecker):
 
         return "\n".join(
             [
-                (
-                    format_tag("script", src)
-                    if isinstance(src, dict)
-                    else f'<script src="{src}"></script>'
-                )
+                format_tag("script", src)
+                if isinstance(src, dict)
+                else f'<script src="{src}"></script>'
                 for src in srcs
             ]
             + [f"<script>{src}</script>" for src in self._inline_scripts]
@@ -1678,11 +1674,9 @@ class Dash(ObsoleteChecker):
         # For each callback function, if the hidden parameter uses the default value None,
         # replace it with the actual value of the self.config.hide_all_callbacks.
         self._callback_list = [
-            (
-                {**_callback, "hidden": self.config.get("hide_all_callbacks", False)}
-                if _callback.get("hidden") is None
-                else _callback
-            )
+            {**_callback, "hidden": self.config.get("hide_all_callbacks", False)}
+            if _callback.get("hidden") is None
+            else _callback
             for _callback in self._callback_list
         ]
 
@@ -2192,7 +2186,9 @@ class Dash(ObsoleteChecker):
                     pkg_dir = (
                         package.submodule_search_locations[0]
                         if package.submodule_search_locations
-                        else os.path.dirname(package.origin) if package.origin else None
+                        else os.path.dirname(package.origin)
+                        if package.origin
+                        else None
                     )
                     if pkg_dir and "dash/dash" in pkg_dir:
                         component_packages_dist[i : i + 1] = [
@@ -2521,12 +2517,14 @@ class Dash(ObsoleteChecker):
 
                 def verify_url_part(served_part, url_part, part_name):
                     if served_part != url_part:
-                        raise ProxyError(f"""
+                        raise ProxyError(
+                            f"""
                             {part_name}: {url_part} is incompatible with the proxy:
                                 {proxy}
                             To see your app at {proxied_url.geturl()},
                             you must use {part_name}: {served_part}
-                            """)
+                            """
+                        )
 
                 verify_url_part(served_url.scheme, protocol, "protocol")
                 verify_url_part(served_url.hostname, host, "host")
@@ -2638,16 +2636,16 @@ class Dash(ObsoleteChecker):
                 if not self.config.suppress_callback_exceptions:
                     self.validation_layout = html.Div(
                         [
-                            (
-                                asyncio.run(execute_async_function(page["layout"]))
-                                if callable(page["layout"])
-                                else page["layout"]
-                            )
+                            asyncio.run(execute_async_function(page["layout"]))
+                            if callable(page["layout"])
+                            else page["layout"]
                             for page in _pages.PAGE_REGISTRY.values()
                         ]
                         + [
                             # pylint: disable=not-callable
-                            self.layout() if callable(self.layout) else self.layout
+                            self.layout()
+                            if callable(self.layout)
+                            else self.layout
                         ]
                     )
                     if _ID_CONTENT not in self.validation_layout:
@@ -2704,15 +2702,15 @@ class Dash(ObsoleteChecker):
                     if not isinstance(layout, list):
                         layout = [
                             # pylint: disable=not-callable
-                            self.layout() if callable(self.layout) else self.layout
+                            self.layout()
+                            if callable(self.layout)
+                            else self.layout
                         ]
                         self.validation_layout = html.Div(
                             [
-                                (
-                                    page["layout"]()
-                                    if callable(page["layout"])
-                                    else page["layout"]
-                                )
+                                page["layout"]()
+                                if callable(page["layout"])
+                                else page["layout"]
                                 for page in _pages.PAGE_REGISTRY.values()
                             ]
                             + layout

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -421,6 +421,15 @@ class Dash(ObsoleteChecker):
     :param health_endpoint: Path for the health check endpoint. Set to None to
         disable the health endpoint. Default is None.
     :type health_endpoint: string or None
+
+    :param csrf_token_name: Name of the cookie to read the CSRF token from.
+        Default ``'_csrf_token'``. Set this to match the CSRF cookie name
+        used by your server framework (e.g. ``'csrftoken'`` for Django).
+    :type csrf_token_name: string
+
+    :param csrf_header_name: Name of the HTTP header to send the CSRF token in.
+        Default ``'X-CSRFToken'``.
+    :type csrf_header_name: string
     """
 
     _plotlyjs_url: str
@@ -472,6 +481,8 @@ class Dash(ObsoleteChecker):
         on_error: Optional[Callable[[Exception], Any]] = None,
         use_async: Optional[bool] = None,
         health_endpoint: Optional[str] = None,
+        csrf_token_name: str = "_csrf_token",
+        csrf_header_name: str = "X-CSRFToken",
         **obsolete,
     ):
 
@@ -491,6 +502,11 @@ class Dash(ObsoleteChecker):
                 ) from exc
 
         _validate.check_obsolete(obsolete)
+
+        if not csrf_token_name or not csrf_token_name.strip():
+            raise ValueError("csrf_token_name must be a non-empty string")
+        if not csrf_header_name or not csrf_header_name.strip():
+            raise ValueError("csrf_header_name must be a non-empty string")
 
         caller_name: str = name if name is not None else get_caller_name()
 
@@ -545,6 +561,8 @@ class Dash(ObsoleteChecker):
             description=description,
             health_endpoint=health_endpoint,
             hide_all_callbacks=False,
+            csrf_token_name=csrf_token_name,
+            csrf_header_name=csrf_header_name,
         )
         self.config.set_read_only(
             [
@@ -555,6 +573,8 @@ class Dash(ObsoleteChecker):
                 "serve_locally",
                 "compress",
                 "pages_folder",
+                "csrf_token_name",
+                "csrf_header_name",
             ],
             "Read-only: can only be set in the Dash constructor",
         )
@@ -938,6 +958,8 @@ class Dash(ObsoleteChecker):
             "ddk_version": ddk_version,
             "plotly_version": plotly_version,
             "validate_callbacks": self._dev_tools.validate_callbacks,
+            "csrf_token_name": self.config.csrf_token_name,
+            "csrf_header_name": self.config.csrf_header_name,
         }
         if self._plotly_cloud is None:
             if os.getenv("DASH_ENTERPRISE_ENV") == "WORKSPACE":
@@ -1117,9 +1139,11 @@ class Dash(ObsoleteChecker):
 
         return "\n".join(
             [
-                format_tag("link", link, opened=True)
-                if isinstance(link, dict)
-                else f'<link rel="stylesheet" href="{link}">'
+                (
+                    format_tag("link", link, opened=True)
+                    if isinstance(link, dict)
+                    else f'<link rel="stylesheet" href="{link}">'
+                )
                 for link in (external_links + links)
             ]
         )
@@ -1173,9 +1197,11 @@ class Dash(ObsoleteChecker):
 
         return "\n".join(
             [
-                format_tag("script", src)
-                if isinstance(src, dict)
-                else f'<script src="{src}"></script>'
+                (
+                    format_tag("script", src)
+                    if isinstance(src, dict)
+                    else f'<script src="{src}"></script>'
+                )
                 for src in srcs
             ]
             + [f"<script>{src}</script>" for src in self._inline_scripts]
@@ -1652,9 +1678,11 @@ class Dash(ObsoleteChecker):
         # For each callback function, if the hidden parameter uses the default value None,
         # replace it with the actual value of the self.config.hide_all_callbacks.
         self._callback_list = [
-            {**_callback, "hidden": self.config.get("hide_all_callbacks", False)}
-            if _callback.get("hidden") is None
-            else _callback
+            (
+                {**_callback, "hidden": self.config.get("hide_all_callbacks", False)}
+                if _callback.get("hidden") is None
+                else _callback
+            )
             for _callback in self._callback_list
         ]
 
@@ -2164,9 +2192,7 @@ class Dash(ObsoleteChecker):
                     pkg_dir = (
                         package.submodule_search_locations[0]
                         if package.submodule_search_locations
-                        else os.path.dirname(package.origin)
-                        if package.origin
-                        else None
+                        else os.path.dirname(package.origin) if package.origin else None
                     )
                     if pkg_dir and "dash/dash" in pkg_dir:
                         component_packages_dist[i : i + 1] = [
@@ -2495,14 +2521,12 @@ class Dash(ObsoleteChecker):
 
                 def verify_url_part(served_part, url_part, part_name):
                     if served_part != url_part:
-                        raise ProxyError(
-                            f"""
+                        raise ProxyError(f"""
                             {part_name}: {url_part} is incompatible with the proxy:
                                 {proxy}
                             To see your app at {proxied_url.geturl()},
                             you must use {part_name}: {served_part}
-                            """
-                        )
+                            """)
 
                 verify_url_part(served_url.scheme, protocol, "protocol")
                 verify_url_part(served_url.hostname, host, "host")
@@ -2614,16 +2638,16 @@ class Dash(ObsoleteChecker):
                 if not self.config.suppress_callback_exceptions:
                     self.validation_layout = html.Div(
                         [
-                            asyncio.run(execute_async_function(page["layout"]))
-                            if callable(page["layout"])
-                            else page["layout"]
+                            (
+                                asyncio.run(execute_async_function(page["layout"]))
+                                if callable(page["layout"])
+                                else page["layout"]
+                            )
                             for page in _pages.PAGE_REGISTRY.values()
                         ]
                         + [
                             # pylint: disable=not-callable
-                            self.layout()
-                            if callable(self.layout)
-                            else self.layout
+                            self.layout() if callable(self.layout) else self.layout
                         ]
                     )
                     if _ID_CONTENT not in self.validation_layout:
@@ -2680,15 +2704,15 @@ class Dash(ObsoleteChecker):
                     if not isinstance(layout, list):
                         layout = [
                             # pylint: disable=not-callable
-                            self.layout()
-                            if callable(self.layout)
-                            else self.layout
+                            self.layout() if callable(self.layout) else self.layout
                         ]
                         self.validation_layout = html.Div(
                             [
-                                page["layout"]()
-                                if callable(page["layout"])
-                                else page["layout"]
+                                (
+                                    page["layout"]()
+                                    if callable(page["layout"])
+                                    else page["layout"]
+                                )
                                 for page in _pages.PAGE_REGISTRY.values()
                             ]
                             + layout

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -480,3 +480,47 @@ def test_debug_mode_enable_dev_tools(empty_environ, debug_env, debug, expected):
 def test_missing_flask_compress_raises():
     with pytest.raises(ImportError):
         Dash(compress=True)
+
+
+def test_csrf_config_defaults():
+    app = Dash()
+    assert app.config.csrf_token_name == "_csrf_token"
+    assert app.config.csrf_header_name == "X-CSRFToken"
+
+    config = app._config()
+    assert config["csrf_token_name"] == "_csrf_token"
+    assert config["csrf_header_name"] == "X-CSRFToken"
+
+
+def test_csrf_config_custom():
+    app = Dash(csrf_token_name="csrftoken", csrf_header_name="X-CSRF-Token")
+    assert app.config.csrf_token_name == "csrftoken"
+    assert app.config.csrf_header_name == "X-CSRF-Token"
+
+    config = app._config()
+    assert config["csrf_token_name"] == "csrftoken"
+    assert config["csrf_header_name"] == "X-CSRF-Token"
+
+
+def test_csrf_config_in_index():
+    app = Dash(csrf_token_name="csrftoken")
+    config_html = app._generate_config_html()
+    assert '"csrf_token_name":"csrftoken"' in config_html
+    assert '"csrf_header_name":"X-CSRFToken"' in config_html
+
+
+@pytest.mark.parametrize(
+    "token_name, header_name",
+    [("", "X-CSRFToken"), ("csrftoken", ""), ("  ", "X-CSRFToken")],
+)
+def test_csrf_config_validation(token_name, header_name):
+    with pytest.raises(ValueError):
+        Dash(csrf_token_name=token_name, csrf_header_name=header_name)
+
+
+def test_csrf_config_read_only():
+    app = Dash()
+    with pytest.raises(AttributeError):
+        app.config.csrf_token_name = "something_else"
+    with pytest.raises(AttributeError):
+        app.config.csrf_header_name = "something_else"


### PR DESCRIPTION
## Summary

- Add `csrf_token_name` and `csrf_header_name` config options to the `Dash` constructor
- Allows users to match the CSRF cookie/header names used by their server framework (e.g. Django uses `csrftoken` instead of `_csrf_token`)
- Values flow through Dash's standard config pipeline: Python `app.config` -> HTML `_dash-config` JSON -> frontend Redux store
- `getCSRFHeader()` now reads cookie/header names from config with backward-compatible defaults
- When the configured CSRF cookie is absent, no header is sent (previously sent `undefined` value)

### Usage

```python
# Django users
app = Dash(__name__, csrf_token_name="csrftoken")

# Custom CSRF setup
app = Dash(__name__, csrf_token_name="my_csrf", csrf_header_name="X-My-CSRF")

# Default behavior unchanged
app = Dash(__name__)  # uses '_csrf_token' / 'X-CSRFToken'
```

### Motivation

Dash's frontend hardcodes the CSRF cookie name as `_csrf_token`, which conflicts with Django's default `csrftoken`. Users embedding Dash in Django apps with CSRF middleware enabled cannot use Dash without project-wide Django config changes. See #729 for full history.

This follows the architecture [recommended by @chriddyp in #729](https://github.com/plotly/dash/issues/729): config variables should flow through Dash's standard config pipeline, not through hooks.

### Prior art

PR #990 attempted this via the hooks system but was closed without review. This PR instead uses the config pipeline as maintainers requested.

### Files changed

| File | Change |
|------|--------|
| `dash/dash.py` | Added params, config, validation, read-only, docstrings |
| `dash-renderer/src/actions/index.js` | `getCSRFHeader(config)` with dynamic cookie/header names |
| `dash-renderer/src/actions/api.js` | Pass config through GET/POST |
| `dash-renderer/src/actions/callbacks.ts` | Pass config to `getCSRFHeader` |
| `dash-renderer/src/config.ts` | Added optional fields to `DashConfig` type |
| `tests/unit/test_configs.py` | 7 unit tests (defaults, custom, HTML output, validation, read-only) |
| `CHANGELOG.md` | Added entry under UNRELEASED |

## Test plan

- [x] Unit tests for default config values
- [x] Unit tests for custom config values
- [x] Unit tests verifying config appears in generated HTML
- [x] Unit tests for input validation (empty/whitespace rejected)
- [x] Unit tests for read-only enforcement
- [x] Validated with Django 6.0 + `CsrfViewMiddleware` active
- [x] Renderer builds successfully
- [x] ESLint + Prettier pass on all JS/TS changes
- [x] Black + flake8 pass on all Python changes
- [x] CI integration tests

Fixes #729