### PR TITLE
Chore: `percy/dash-table-test` blocks merges when table tests are skipped

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -895,6 +895,30 @@ jobs:
         env:
           PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
 
+  report-table-percy-skipped:
+    name: Report Percy Table Skipped
+    needs: table-visual-test
+    runs-on: ubuntu-latest
+    if: |
+      always() &&
+      github.event_name == 'pull_request' &&
+      needs.table-visual-test.result == 'skipped'
+    permissions:
+      statuses: write
+    steps:
+      - name: Post success status for percy/dash-table-test
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.payload.pull_request.head.sha,
+              state: 'success',
+              context: 'percy/dash-table-test',
+              description: 'Skipped — no dash-table changes',
+            });
+
   test-report:
     name: Consolidated Test Report
     needs: [lint-unit, test-main, dcc-test, html-test, table-server, background-callbacks, test-typing]


### PR DESCRIPTION
The percy table tests are required to merge a PR, but the job never runs if the table tests are skipped. This is a small bugfix to unblock PRs that don't trigger the table tests.