### PR TITLE
skip percy on forks

### DIFF
--- a/.github/actions/percy-exec/action.yml
+++ b/.github/actions/percy-exec/action.yml
@@ -1,0 +1,28 @@
+name: 'Percy Exec'
+description: 'Run a command with Percy, or skip Percy for fork PRs (no token access)'
+
+inputs:
+  command:
+    description: 'The command to run (e.g., "pytest --headless tests/")'
+    required: true
+  percy-token:
+    description: 'Percy token (pass secrets.PERCY_TOKEN)'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Run with Percy
+      if: inputs.percy-token != ''
+      shell: bash
+      env:
+        PERCY_TOKEN: ${{ inputs.percy-token }}
+      run: npx percy exec -- ${{ inputs.command }}
+
+    - name: Run without Percy (fork PR)
+      if: inputs.percy-token == ''
+      shell: bash
+      run: |
+        echo "::notice::Skipping Percy (no token available - likely a fork PR)"
+        ${{ inputs.command }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -515,12 +515,15 @@ jobs:
         run: npm run setup-tests.py
 
       - name: Run main integration tests
-        run: |
-          if [ "${{ matrix.python-version }}" == "3.12" ]; then
-            npx percy exec -- pytest --headless --nopercyfinalize --junitxml=test-reports/junit_intg.xml tests/integration --splits 3 --group ${{ matrix.test-group }}
-          else
-            pytest --headless --nopercyfinalize --junitxml=test-reports/junit_intg.xml tests/integration --splits 3 --group ${{ matrix.test-group }}
-          fi
+        if: matrix.python-version != '3.12'
+        run: pytest --headless --nopercyfinalize --junitxml=test-reports/junit_intg.xml tests/integration --splits 3 --group ${{ matrix.test-group }}
+
+      - name: Run main integration tests with Percy
+        if: matrix.python-version == '3.12'
+        uses: ./.github/actions/percy-exec
+        with:
+          command: pytest --headless --nopercyfinalize --junitxml=test-reports/junit_intg.xml tests/integration --splits 3 --group ${{ matrix.test-group }}
+          percy-token: ${{ secrets.PERCY_TOKEN }}
 
       - name: Upload test results
         if: always()
@@ -601,15 +604,21 @@ jobs:
           sudo Xvfb :99 -ac -screen 0 1280x1024x24 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
 
-      - name: Run HTML components tests
+      - name: Install HTML components dependencies
         working-directory: components/dash-html-components
-        run: |
-          npm ci
-          if [ "${{ matrix.python-version }}" == "3.12" ]; then
-            npx percy exec -- pytest --headless --nopercyfinalize --junitxml=test-reports/junit_html.xml
-          else
-            pytest --headless --nopercyfinalize --junitxml=test-reports/junit_html.xml
-          fi
+        run: npm ci
+
+      - name: Run HTML components tests
+        if: matrix.python-version != '3.12'
+        working-directory: components/dash-html-components
+        run: pytest --headless --nopercyfinalize --junitxml=test-reports/junit_html.xml
+
+      - name: Run HTML components tests with Percy
+        if: matrix.python-version == '3.12'
+        uses: ./.github/actions/percy-exec
+        with:
+          command: cd components/dash-html-components && pytest --headless --nopercyfinalize --junitxml=test-reports/junit_html.xml
+          percy-token: ${{ secrets.PERCY_TOKEN }}
 
       - name: Upload test results
         if: always()
@@ -863,11 +872,18 @@ jobs:
           sudo Xvfb :99 -ac -screen 0 1280x1024x24 &
           echo "DISPLAY=:99" >> $GITHUB_ENV
 
-      - name: Run Table visual tests
+      - name: Install Table test dependencies
         working-directory: components/dash-table
-        run: |
-          npm ci
-          npm run test.visual
+        run: npm ci
+
+      - name: Run Table visual tests
+        if: env.PERCY_TOKEN != ''
+        working-directory: components/dash-table
+        run: npm run test.visual
+
+      - name: Skip Table visual tests (fork PR)
+        if: env.PERCY_TOKEN == ''
+        run: echo "::notice::Skipping Percy table visual tests (no token available - likely a fork PR)"
 
       - name: Upload dash artifacts
         if: always()
@@ -883,17 +899,23 @@ jobs:
     needs: [test-main, dcc-test, html-test]
     runs-on: ubuntu-latest
     if: always()
+    env:
+      PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
     steps:
       - name: Finalize Main Percy Build
         if: |
-          needs.test-main.result != 'skipped' ||
-          needs.dcc-test.result != 'skipped' ||
-          needs.html-test.result != 'skipped'
+          env.PERCY_TOKEN != '' && (
+            needs.test-main.result != 'skipped' ||
+            needs.dcc-test.result != 'skipped' ||
+            needs.html-test.result != 'skipped'
+          )
         run: |
           npm install -g @percy/cli
           npx percy build:finalize
-        env:
-          PERCY_TOKEN: ${{ secrets.PERCY_TOKEN }}
+
+      - name: Skip Percy finalize (fork PR)
+        if: env.PERCY_TOKEN == ''
+        run: echo "::notice::Skipping Percy finalize (no token available - likely a fork PR)"
 
   report-table-percy-skipped:
     name: Report Percy Table Skipped


### PR DESCRIPTION
Skip Percy for workflows runs forks PR, the secrets are not available and there is no alternative from Percy. Will require a proper solution for visual testing of forks on the longer term.
