### PR TITLE
fix percy action working directory

### DIFF
--- a/.github/actions/percy-exec/action.yml
+++ b/.github/actions/percy-exec/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'Percy token (pass secrets.PERCY_TOKEN)'
     required: false
     default: ''
+  working-directory:
+    description: 'Working directory for the command'
+    required: false
+    default: '.'
 
 runs:
   using: 'composite'
@@ -16,6 +20,7 @@ runs:
     - name: Run with Percy
       if: inputs.percy-token != ''
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       env:
         PERCY_TOKEN: ${{ inputs.percy-token }}
       run: npx percy exec -- ${{ inputs.command }}
@@ -23,6 +28,7 @@ runs:
     - name: Run without Percy (fork PR)
       if: inputs.percy-token == ''
       shell: bash
+      working-directory: ${{ inputs.working-directory }}
       run: |
         echo "::notice::Skipping Percy (no token available - likely a fork PR)"
         ${{ inputs.command }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -617,8 +617,9 @@ jobs:
         if: matrix.python-version == '3.12'
         uses: ./.github/actions/percy-exec
         with:
-          command: cd components/dash-html-components && pytest --headless --nopercyfinalize --junitxml=test-reports/junit_html.xml
+          command: pytest --headless --nopercyfinalize --junitxml=test-reports/junit_html.xml
           percy-token: ${{ secrets.PERCY_TOKEN }}
+          working-directory: components/dash-html-components
 
       - name: Upload test results
         if: always()


### PR DESCRIPTION
The percy html was failing because of the `cd` before the test command: https://github.com/plotly/dash/actions/runs/24911286028/job/72953632655?pr=3742

Add a working-directory to percy-exec action instead of the `cd`.
