### PR TITLE
MCP Server Part 10: OAuth discovery

### DIFF
--- a/dash/_configs.py
+++ b/dash/_configs.py
@@ -36,6 +36,7 @@ def load_dash_env_vars():
                 "DASH_MCP_ENABLED",
                 "DASH_MCP_PATH",
                 "DASH_MCP_EXPOSE_DOCSTRINGS",
+                "DASH_MCP_AUTHORIZATION_SERVER",
                 "HOST",
                 "PORT",
             )

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -489,6 +489,7 @@ class Dash(ObsoleteChecker):
         enable_mcp: Optional[bool] = None,
         mcp_path: Optional[str] = None,
         mcp_expose_docstrings: Optional[bool] = None,
+        mcp_authorization_server: Optional[str] = None,
         **obsolete,
     ):
 
@@ -608,6 +609,9 @@ class Dash(ObsoleteChecker):
         _mcp_path = get_combined_config("mcp_path", mcp_path, "_mcp")
         self._mcp_path = (
             _mcp_path.lstrip("/") if isinstance(_mcp_path, str) else _mcp_path
+        )
+        self._mcp_authorization_server = get_combined_config(
+            "mcp_authorization_server", mcp_authorization_server
         )
 
         # list of dependencies - this one is used by the back end for dispatching
@@ -829,7 +833,11 @@ class Dash(ObsoleteChecker):
             )
 
             try:
-                enable_mcp_server(self, self._mcp_path)
+                enable_mcp_server(
+                    self,
+                    self._mcp_path,
+                    mcp_authorization_server=self._mcp_authorization_server,
+                )
             except Exception as e:  # pylint: disable=broad-exception-caught
                 self._enable_mcp = False
                 self.logger.warning(

--- a/dash/mcp/_server.py
+++ b/dash/mcp/_server.py
@@ -74,6 +74,15 @@ def _setup_mcp_oauth(app: Dash, mcp_path: str, mcp_authorization_server: str) ->
     server. Auth enforcement is the responsibility of the hosting platform
     (e.g. Plotly Cloud gateway, Dash Embedded, or a reverse proxy).
     """
+    if app.config.requests_pathname_prefix != "/":
+        raise ValueError(
+            "`mcp_authorization_server` cannot be used in conjunction with "
+            "`requests_pathname_prefix`. "
+            "Authorization must be implemented at the platform level "
+            "(see https://www.rfc-editor.org/rfc/rfc9728#section-3). "
+            "Remove the mcp_authorization_server parameter."
+        )
+
     well_known_path = urljoin("/.well-known/oauth-protected-resource/", mcp_path)
 
     def _serve_resource_metadata():

--- a/dash/mcp/_server.py
+++ b/dash/mcp/_server.py
@@ -11,7 +11,9 @@ import inspect
 import json
 import logging
 import os
+from functools import reduce
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urljoin
 
 from mcp.types import (
     LATEST_PROTOCOL_VERSION,
@@ -47,7 +49,61 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def enable_mcp_server(app: Dash, mcp_path: str) -> None:
+def _url_from_path(app: Dash, *parts: str) -> str:
+    """Build an absolute URL by joining path parts onto the current request origin.
+
+    Behind a reverse proxy, TLS terminates at the proxy so
+    the scheme may report HTTP even when the client connected
+    over HTTPS.  Use HTTPS unless running on localhost.
+    """
+    from urllib.parse import urlparse  # pylint: disable=import-outside-toplevel
+
+    adapter = app.backend.request_adapter()
+    parsed = urlparse(adapter.url)
+    host = parsed.netloc
+    is_localhost = host.startswith("localhost") or host.startswith("127.0.0.1")
+    scheme = "http" if is_localhost else "https"
+    path = reduce(urljoin, parts, "/")
+    return f"{scheme}://{host}{path}"
+
+
+def _setup_mcp_oauth(app: Dash, mcp_path: str, mcp_authorization_server: str) -> None:
+    """Register RFC 9728 Protected Resource Metadata endpoint for MCP.
+
+    Serves discovery metadata so MCP clients can find the authorization
+    server. Auth enforcement is the responsibility of the hosting platform
+    (e.g. Plotly Cloud gateway, Dash Embedded, or a reverse proxy).
+    """
+    well_known_path = urljoin("/.well-known/oauth-protected-resource/", mcp_path)
+
+    def _serve_resource_metadata():
+        return app.backend.make_response(
+            json.dumps(
+                {
+                    "resource": _url_from_path(
+                        app, app.config.requests_pathname_prefix, mcp_path
+                    ),
+                    "authorization_servers": [mcp_authorization_server],
+                    "bearer_methods_supported": ["header"],
+                }
+            ),
+            content_type="application/json",
+        )
+
+    # pylint: disable-next=protected-access
+    app._add_url(well_known_path.lstrip("/"), _serve_resource_metadata)
+
+    logger.info(
+        "MCP OAuth discovery enabled, authorization server: %s",
+        mcp_authorization_server,
+    )
+
+
+def enable_mcp_server(
+    app: Dash,
+    mcp_path: str,
+    mcp_authorization_server: str | None = None,
+) -> None:
     """Add MCP routes to a Dash app."""
 
     app.mcp_decorated_functions = dict(MCP_DECORATED_FUNCTIONS)
@@ -206,6 +262,9 @@ def enable_mcp_server(app: Dash, mcp_path: str) -> None:
         methods=["DELETE"],
     )
     app.routes.append(mcp_url)
+
+    if mcp_authorization_server:
+        _setup_mcp_oauth(app, mcp_path, mcp_authorization_server)
 
     logger.info(
         "MCP routes registered at %s%s",


### PR DESCRIPTION
## Summary

Support OAuth so MCP clients can discover how to authenticate against an authorization server when connecting to the Dash MCP endpoint. Implements the discovery half of the [MCP Authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization).

- New `mcp_authorization_server` constructor arg (and `DASH_MCP_AUTHORIZATION_SERVER` env var). When set, registers an [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) Protected Resource Metadata endpoint at `/.well-known/oauth-protected-resource/<mcp-path>` advertising the authorization server.
- **Dash serves discovery metadata only — it does not enforce auth.** Token validation, 401 responses, and `WWW-Authenticate` headers are the responsibility of the hosting platform (middleware, reverse proxy, etc.).
