### PR TITLE
fix: dropdown search crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 - [#3768](https://github.com/plotly/dash/pull/3768) Improved `Dropdown` search performance for large options lists
 - [#3759](https://github.com/plotly/dash/pull/3759) Fix the issue where `Patch` objects cannot be updated via `set_props()` in `websocket` callback. Fix [#3742](https://github.com/plotly/dash/issues/3742)
 - [#3789](https://github.com/plotly/dash/pull/3789) Fixed extra wrapper in `DatePickerRange` and `DatePickerSingle` causing styling and layout issues.
+- [#3799](https://github.com/plotly/dash/pull/3799) Fixed dropdown crash when filtering large datasets with component-based labels by using stable item keys for virtualized rows.
 
 ## [4.2.0rc3] - 2026-05-12
 

--- a/components/dash-core-components/src/utils/optionRendering.tsx
+++ b/components/dash-core-components/src/utils/optionRendering.tsx
@@ -400,6 +400,9 @@ export const OptionsList = forwardRef<OptionsListHandle, OptionsListProps>(
                     className="dash-options-list-virtualized"
                     onItemsRendered={handleItemsRendered}
                     itemData={itemData}
+                    itemKey={(index, data) =>
+                        String(data.options[index]?.value ?? index)
+                    }
                 >
                     {Row}
                 </VariableSizeList>

--- a/components/dash-core-components/tests/integration/dropdown/test_search_value.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_search_value.py
@@ -107,3 +107,41 @@ def test_ddsv002_search_filter_and_scroll(dash_duo):
     last_option.click()
 
     dash_duo.wait_for_text_to_equal("#output", "value=opt_100")
+
+
+def test_ddsv003_dropdown_virtualized_component_label_filtering(dash_duo):
+    app = Dash(__name__)
+
+    options = [
+        {
+            "label": html.Div(["Item ", html.Span(f"#{i}")]),
+            "value": f"item_{i}",
+            "search": f"item_{i}",
+        }
+        for i in range(1, 2000)
+    ]
+
+    app.layout = html.Div(
+        [
+            dcc.Dropdown(
+                id="dd",
+                options=options,
+                value="item_1",
+                searchable=True,
+                clearable=True,
+            )
+        ]
+    )
+
+    dash_duo.start_server(app)
+
+    dropdown = dash_duo.find_element("#dd")
+    dropdown.click()
+
+    search = dash_duo.find_element(".dash-dropdown-search")
+
+    # trigger filtering path that used to crash virtualized list
+    search.send_keys("199")
+    sleep(.5)
+
+    assert dash_duo.get_logs() == []

--- a/components/dash-core-components/tests/integration/dropdown/test_search_value.py
+++ b/components/dash-core-components/tests/integration/dropdown/test_search_value.py
@@ -142,6 +142,6 @@ def test_ddsv003_dropdown_virtualized_component_label_filtering(dash_duo):
 
     # trigger filtering path that used to crash virtualized list
     search.send_keys("199")
-    sleep(.5)
+    sleep(0.5)
 
     assert dash_duo.get_logs() == []


### PR DESCRIPTION
closes #3707

This fixes a virtualization issue introduced in Dash 4.1 for large searchable option lists with component labels.

react-window uses the row index as the default key. After filtering, the same index may point to a different option, causing stale component rows to be reused. With component labels rendered through ExternalWrapper, this could result in errors like:

> Cannot read properties of undefined (reading 'props')

Adding a stable `itemKey` based on the option value makes sure the rows are remounted correctly when the filtered options change.

