### PR TITLE
Bugfix: websockets use incorrect pathname when deployed behind proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - [#3805](https://github.com/plotly/dash/pull/3805) Fix FastAPI POST routes deadlock caused by middleware consuming request body. Fixes [#3801](https://github.com/plotly/dash/issues/3801).
+- [#3813](https://github.com/plotly/dash/pull/3813) Fix websockets using incorrect path when deployed behind a proxy
 
 ## [4.2.0] - 2026-06-01 - *The Freedom Update*
 

--- a/dash/backends/_fastapi.py
+++ b/dash/backends/_fastapi.py
@@ -682,7 +682,7 @@ class FastAPIDashServer(BaseDashServer[FastAPI]):
             dash_app: The Dash application instance
         """
         # pylint: disable=too-many-statements,too-many-locals
-        ws_path = dash_app.config.requests_pathname_prefix + "_dash-ws-callback"
+        ws_path = dash_app.config.routes_pathname_prefix + "_dash-ws-callback"
 
         # Get allowed origins from dash app config
         allowed_origins = getattr(

--- a/dash/backends/_quart.py
+++ b/dash/backends/_quart.py
@@ -516,7 +516,7 @@ class QuartDashServer(BaseDashServer[Quart]):
             dash_app: The Dash application instance
         """
         # pylint: disable=too-many-statements,too-many-locals
-        ws_path = dash_app.config.requests_pathname_prefix + "_dash-ws-callback"
+        ws_path = dash_app.config.routes_pathname_prefix + "_dash-ws-callback"
         # pylint: disable=protected-access
         allowed_origins = getattr(dash_app, "_websocket_allowed_origins", [])
 


### PR DESCRIPTION
This PR fixes websocket callbacks being unable to connect when deployed behind a reverse proxy.