### PR TITLE
Fix claude code connectivity timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ## Fixed
 - [#3805](https://github.com/plotly/dash/pull/3805) Fix FastAPI POST routes deadlock caused by middleware consuming request body. Fixes [#3801](https://github.com/plotly/dash/issues/3801).
+- [#3813](https://github.com/plotly/dash/pull/3813) Fix websockets using incorrect path when deployed behind a proxy
+- [#3830](https://github.com/plotly/dash/pull/3830) MCP: Respond to the Streamable HTTP `GET` (SSE) request with an empty event stream instead of `405 Method Not Allowed`
 
 ## [4.3.0rc0] - 2026-05-21
 

--- a/dash/mcp/_server.py
+++ b/dash/mcp/_server.py
@@ -167,8 +167,25 @@ def enable_mcp_server(app: Dash, mcp_path: str) -> None:
 
         return _json_response(response_data)
 
-    def _handle_not_allowed():
-        """Return 405 for GET and DELETE (MCP SSE not supported)."""
+    def _handle_get():
+        """
+        Accept GET requests for SSE streams with an empty, immediately-completed
+        stream. This used to be a 405 "Method Not Allowed", but that caused the
+        dev server to close the connection, introducing intermittent Claude
+        connectivity timeouts.
+        """
+        resp = app.backend.make_response(
+            ": mcp stream open\n\n",
+            content_type="text/event-stream",
+            status=200,
+        )
+        resp.headers["Cache-Control"] = "no-cache, no-transform"
+        if _session_id is not None:
+            resp.headers["Mcp-Session-Id"] = _session_id
+        return resp
+
+    def _handle_delete():
+        """Return 405 for DELETE; the spec allows refusing session teardown."""
         return app.backend.make_response(
             json.dumps({"error": "Method not allowed"}),
             content_type="application/json",
@@ -192,13 +209,13 @@ def enable_mcp_server(app: Dash, mcp_path: str) -> None:
     )
     app.backend.add_url_rule(
         mcp_url,
-        view_func=_handle_not_allowed,
+        view_func=_handle_get,
         endpoint=f"{mcp_url}:GET",
         methods=["GET"],
     )
     app.backend.add_url_rule(
         mcp_url,
-        view_func=_handle_not_allowed,
+        view_func=_handle_delete,
         endpoint=f"{mcp_url}:DELETE",
         methods=["DELETE"],
     )


### PR DESCRIPTION
Recent versions of Claude Code have intermittent issues connecting to a Dash MCP server when run on localhost.
This PR adds a workaround that allows Claude to connect reliably.

Issue:
The MCP server previously responded to GET requests with a `405 Not Allowed`. While the spec does allow this, the dev server automatically closes connections with this response. Depending on the timing, Claude would attempt to reuse the already-closed connection which caused connectivity failures.

Solution:
The 405 response code is replaced with a 200 and an empty, completed stream which Claude accepts and correctly moves on.
