### PR TITLE
Bugfix: MCP server returns error when chrome not available for kaleido

### DIFF
--- a/dash/mcp/primitives/tools/results/result_plotly_figure.py
+++ b/dash/mcp/primitives/tools/results/result_plotly_figure.py
@@ -23,8 +23,6 @@ IMAGE_HEIGHT = 450
 def _render_image(figure: Any) -> ImageContent | None:
     """
     Render the figure as a base64 PNG ImageContent.
-
-    Returns None if kaleido is not installed.
     """
     try:
         img_bytes = figure.to_image(
@@ -32,8 +30,8 @@ def _render_image(figure: Any) -> ImageContent | None:
             width=IMAGE_WIDTH,
             height=IMAGE_HEIGHT,
         )
-    except (ValueError, ImportError):
-        logger.debug("MCP: kaleido not available, skipping image render")
+    except Exception:  # pylint: disable=broad-exception-caught
+        logger.debug("MCP: unable to render figure image, skipping", exc_info=True)
         return None
 
     b64 = base64.b64encode(img_bytes).decode("ascii")

--- a/tests/unit/mcp/tools/test_mcp_formatted_output_results.py
+++ b/tests/unit/mcp/tools/test_mcp_formatted_output_results.py
@@ -222,6 +222,18 @@ def test_mcpr013_returns_empty_when_kaleido_unavailable():
     assert result == []
 
 
+def test_mcpr017_returns_empty_when_chrome_unavailable():
+    # https://github.com/plotly/dash/issues/3914
+    fig_dict = go.Figure(data=[go.Bar(x=["A", "B"], y=[1, 2])]).to_plotly_json()
+    with patch.object(
+        go.Figure,
+        "to_image",
+        side_effect=RuntimeError("Kaleido requires Google Chrome to be installed."),
+    ):
+        result = PlotlyFigureResult.format(GRAPH_FIGURE_OUTPUT, fig_dict)
+    assert result == []
+
+
 def test_mcpr014_ignores_non_graph_components():
     output = {
         **GRAPH_FIGURE_OUTPUT,


### PR DESCRIPTION
Fixes https://github.com/plotly/dash/issues/3914