### PR TITLE
Fix multiple file drag-and-drop in dcc.Upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Removed
 - [#3646](https://github.com/plotly/dash/pull/3646) Remove React 16 support (`16.14.0` is no longer an accepted value for `REACT_VERSION` / `_set_react_version`).
 
+### Fixed
+- [#3916](https://github.com/plotly/dash/pull/3916) Fixed a regression where dragging multiple files into `dcc.Upload` would upload only the first file when `multiple=True`
+
 ## [4.4.1] - 2026-07-21
 
 ## Fixed

--- a/components/dash-core-components/src/fragments/Upload.react.js
+++ b/components/dash-core-components/src/fragments/Upload.react.js
@@ -111,24 +111,33 @@ export default class Upload extends Component {
         // Handle drag-and-drop with folder support when multiple=true
         if (event.dataTransfer && event.dataTransfer.items) {
             const items = Array.from(event.dataTransfer.items);
+
+            // Get all entries synchronously before the first await
+            const entries = [];
             const files = [];
 
             for (const item of items) {
-                if (item.kind === 'file') {
-                    const entry = item.webkitGetAsEntry
-                        ? item.webkitGetAsEntry()
-                        : null;
-                    if (entry) {
-                        const entryFiles = await this.traverseFileTree(entry);
-                        files.push(...entryFiles);
-                    } else {
-                        // Fallback for browsers without webkitGetAsEntry
-                        const file = item.getAsFile();
-                        if (file) {
-                            files.push(file);
-                        }
+                if (item.kind !== 'file') {
+                    continue;
+                }
+
+                const entry = item.webkitGetAsEntry
+                    ? item.webkitGetAsEntry()
+                    : null;
+                if (entry) {
+                    entries.push(entry);
+                } else {
+                    // Fallback for browsers without webkitGetAsEntry
+                    const file = item.getAsFile();
+                    if (file) {
+                        files.push(file);
                     }
                 }
+            }
+            // Process all entries after collecting them
+            for (const entry of entries) {
+                const entryFiles = await this.traverseFileTree(entry);
+                files.push(...entryFiles);
             }
             return files;
         }


### PR DESCRIPTION
closes #3671 

Fixes a regression introduced in #3464

Fix drag-and-drop of multiple files in `dcc.Upload`. Collect all `DataTransferItem` entries before the first async operation to avoid losing items during drag event processing.

I'm not sure how to do a test for this, but when I run it locally, this fixes the multiple file drag/drop