### PR TITLE
Fix number input spinner when only min is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - [#3916](https://github.com/plotly/dash/pull/3916) Fixed a regression where dragging multiple files into `dcc.Upload` would upload only the first file when `multiple=True`
+- [#3922](https://github.com/plotly/dash/pull/3922) Fix `dcc.Input(type="number")` stepper behavior when only `min` is set.
 
 ## [4.4.1] - 2026-07-21
 

--- a/components/dash-core-components/src/components/Input.tsx
+++ b/components/dash-core-components/src/components/Input.tsx
@@ -128,7 +128,7 @@ function Input({
         setValue(value);
     }, []);
 
-    const onKeyPress: KeyboardEventHandler<HTMLInputElement> = useCallback(
+    const onKeyDown: KeyboardEventHandler<HTMLInputElement> = useCallback(
         (e: KeyboardEvent) => {
             if (e.key === 'Enter') {
                 props.setProps({
@@ -288,7 +288,7 @@ function Input({
                         className="dash-input-element"
                         onBlur={onBlur}
                         onChange={onChange}
-                        onKeyPress={onKeyPress}
+                        onKeyDown={onKeyDown}
                         {...valprops}
                         {...pickedInputs}
                         {...loadingProps}

--- a/components/dash-core-components/src/components/Input.tsx
+++ b/components/dash-core-components/src/components/Input.tsx
@@ -194,7 +194,7 @@ function Input({
                     parseFloat(props.min as string)
                 );
             }
-            if (props.max !== null && props.min !== undefined) {
+            if (props.max !== null && props.max !== undefined) {
                 constrainedValue = Math.min(
                     constrainedValue,
                     parseFloat(props.max as string)

--- a/components/dash-core-components/tests/integration/input/test_number_input.py
+++ b/components/dash-core-components/tests/integration/input/test_number_input.py
@@ -283,4 +283,3 @@ def test_inni011_min_max_bug(dash_dcc, min):
     dash_dcc.wait_for_text_to_equal("#output", "16")
 
     assert dash_dcc.get_logs() == []
-

--- a/components/dash-core-components/tests/integration/input/test_number_input.py
+++ b/components/dash-core-components/tests/integration/input/test_number_input.py
@@ -258,7 +258,7 @@ def test_inni010_valid_numbers(dash_dcc, ninput_app):
     assert dash_dcc.get_logs() == []
 
 
-@pytest.mark.parametrize("min", [None, 1])
+@pytest.mark.parametrize("min", [None, 0, 1])
 def test_inni011_min_max_bug(dash_dcc, min):
     """Test that decrement increment button works correctly with min/max set to None or only min is set."""
 

--- a/components/dash-core-components/tests/integration/input/test_number_input.py
+++ b/components/dash-core-components/tests/integration/input/test_number_input.py
@@ -258,13 +258,14 @@ def test_inni010_valid_numbers(dash_dcc, ninput_app):
     assert dash_dcc.get_logs() == []
 
 
-def test_inni011_min_max_bug(dash_dcc):
-    """Test that decrement increment button works correctly with min/max set to None."""
+@pytest.mark.parametrize("min", [None, 1])
+def test_inni011_min_max_bug(dash_dcc, min):
+    """Test that decrement increment button works correctly with min/max set to None or only min is set."""
 
     app = Dash(__name__)
     app.layout = html.Div(
         [
-            dcc.Input(id="number", value=17, type="number", min=None, max=None),
+            dcc.Input(id="number", value=17, type="number", min=min, max=None),
             html.Div(id="output"),
         ]
     )
@@ -282,3 +283,4 @@ def test_inni011_min_max_bug(dash_dcc):
     dash_dcc.wait_for_text_to_equal("#output", "16")
 
     assert dash_dcc.get_logs() == []
+


### PR DESCRIPTION
Closes #3921 

Fix `dcc.Input(type="number")` stepper  behavior when only `min` is set.

Fixed typo in number input stepper constraint check from  PR #3690 

Also I noticed that `onKeyPress` is deprecated and replaced it with  `onKeyDown`