### PR TITLE
fix RangeSlider allow_cross

### DIFF
--- a/components/dash-core-components/src/fragments/RangeSlider.tsx
+++ b/components/dash-core-components/src/fragments/RangeSlider.tsx
@@ -15,6 +15,72 @@ import {RangeSliderProps} from '../types';
 
 const MAX_MARKS = 500;
 
+type SliderInteractionKind = 'keyboard' | 'pointer';
+
+interface SliderInteraction {
+    kind: SliderInteractionKind;
+    thumbIndex: number | null;
+    startValue: number[];
+}
+
+type InputSide = 'max' | 'min';
+
+interface InputEdit {
+    side: InputSide;
+    text: string;
+    startValue: number[];
+    fixedValue?: number;
+    lastValidCandidate: number;
+}
+
+interface ThumbValueChange {
+    candidate: number;
+    previousIndex: number;
+}
+
+const numbersEqual = (left: number, right: number): boolean =>
+    Object.is(left, right);
+
+const valuesEqual = (left: number[], right: number[]): boolean =>
+    left.length === right.length &&
+    left.every((item, index) => numbersEqual(item, right[index]));
+
+const canonicalizeValues = (values: number[]): number[] =>
+    [...values].sort((left, right) => left - right);
+
+const findThumbValueChange = (
+    previousValue: number[],
+    attemptedValue: number[]
+): ThumbValueChange | undefined => {
+    const unmatchedPrevious = previousValue.map((value, index) => ({
+        index,
+        value,
+    }));
+    let candidate: number | undefined;
+
+    for (const attemptedCandidate of attemptedValue) {
+        const matchIndex = unmatchedPrevious.findIndex(previous =>
+            numbersEqual(previous.value, attemptedCandidate)
+        );
+
+        if (matchIndex === -1) {
+            if (candidate !== undefined) {
+                return undefined;
+            }
+            candidate = attemptedCandidate;
+        } else {
+            unmatchedPrevious.splice(matchIndex, 1);
+        }
+    }
+
+    return candidate !== undefined && unmatchedPrevious.length === 1
+        ? {
+              candidate,
+              previousIndex: unmatchedPrevious[0].index,
+          }
+        : undefined;
+};
+
 /**
  * A double slider with two handles.
  * Used for specifying a range of numerical values.
@@ -36,7 +102,7 @@ export default function RangeSlider(props: RangeSliderProps) {
         disabled,
         dots,
         included,
-        allowCross,
+        allowCross = true,
         pushable,
         count,
         reverse,
@@ -44,22 +110,40 @@ export default function RangeSlider(props: RangeSliderProps) {
     } = props;
 
     // For range slider, we expect an array of values
-    const [value, setValue] = useState<number[]>(propValue || []);
+    const [value, setValue] = useState<number[]>(
+        propValue ? [...propValue] : []
+    );
+    const [inputEdit, setInputEdit] = useState<InputEdit | null>(null);
 
     // Track slider dimension (width for horizontal, height for vertical) for marks rendering
     const [sliderWidth, setSliderWidth] = useState<number | null>(null);
 
     const sliderRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>(null);
+    const valueRef = useRef<number[]>(value);
+    const inputEditRef = useRef<InputEdit | null>(null);
+    const interactionRef = useRef<SliderInteraction | null>(null);
+    const thumbRefs = useRef<Array<HTMLSpanElement | null>>([]);
+    const pendingValueEchoRef = useRef<number[] | null>(null);
+
+    const setSliderProps = (newProps: Partial<RangeSliderProps>) => {
+        if (Array.isArray(newProps.value)) {
+            pendingValueEchoRef.current = [...newProps.value];
+        }
+        setProps(newProps);
+    };
 
     // Handle initial mount - equivalent to componentWillMount
     useEffect(() => {
         if (propValue && propValue.length > 0) {
-            setProps({drag_value: propValue});
-            setValue(propValue);
+            const initialValue = [...propValue];
+            setSliderProps({drag_value: initialValue});
+            valueRef.current = initialValue;
+            setValue(initialValue);
         } else {
             // Default to range from min to max if no value provided
             const defaultValue = [min ?? (propValue ? propValue[0] : 0)];
+            valueRef.current = defaultValue;
             setValue(defaultValue);
         }
     }, []);
@@ -100,9 +184,46 @@ export default function RangeSlider(props: RangeSliderProps) {
 
     // Handle prop value changes - equivalent to componentWillReceiveProps
     useEffect(() => {
-        if (propValue && JSON.stringify(propValue) !== JSON.stringify(value)) {
-            setProps({drag_value: propValue});
-            setValue(propValue);
+        if (propValue) {
+            const incomingValue = [...propValue];
+            const pendingValueEcho = pendingValueEchoRef.current;
+            const isLocalValueEcho =
+                pendingValueEcho !== null &&
+                valuesEqual(incomingValue, pendingValueEcho);
+            pendingValueEchoRef.current = null;
+
+            if (!isLocalValueEcho) {
+                if (inputEditRef.current) {
+                    inputEditRef.current = null;
+                    setInputEdit(null);
+                }
+
+                const currentInteraction = interactionRef.current;
+                if (currentInteraction) {
+                    if (
+                        currentInteraction.kind === 'keyboard' &&
+                        currentInteraction.startValue.length !==
+                            incomingValue.length
+                    ) {
+                        interactionRef.current = null;
+                    } else {
+                        currentInteraction.startValue = [...incomingValue];
+                        if (
+                            currentInteraction.thumbIndex !== null &&
+                            currentInteraction.thumbIndex >=
+                                incomingValue.length
+                        ) {
+                            currentInteraction.thumbIndex = null;
+                        }
+                    }
+                }
+            }
+
+            if (!valuesEqual(incomingValue, valueRef.current)) {
+                setSliderProps({drag_value: incomingValue});
+                valueRef.current = incomingValue;
+                setValue(incomingValue);
+            }
         }
     }, [propValue]);
 
@@ -163,6 +284,10 @@ export default function RangeSlider(props: RangeSliderProps) {
     }, [minMaxValues.min_mark, minMaxValues.max_mark, stepValue]);
 
     const valueIsValid = (val: number): boolean => {
+        if (!Number.isFinite(val)) {
+            return false;
+        }
+
         // Check if value is within min/max bounds
         if (val < minMaxValues.min_mark || val > minMaxValues.max_mark) {
             return false;
@@ -233,31 +358,355 @@ export default function RangeSlider(props: RangeSliderProps) {
         return constrained;
     };
 
-    const handleValueChange = (newValue: number[]) => {
-        let adjustedValue = newValue;
+    const isKeyboardControlKey = (key: string): boolean =>
+        [
+            'ArrowDown',
+            'ArrowLeft',
+            'ArrowRight',
+            'ArrowUp',
+            'End',
+            'Home',
+            'PageDown',
+            'PageUp',
+        ].includes(key);
 
-        // Snap to nearest marks if step is null and marks exist
+    const updateInputEdit = (edit: InputEdit | null) => {
+        inputEditRef.current = edit;
+        setInputEdit(edit);
+    };
+
+    const updateCurrentValue = (newValue: number[]): boolean => {
+        const canonicalValue = canonicalizeValues(newValue);
+
+        if (valuesEqual(canonicalValue, valueRef.current)) {
+            return false;
+        }
+
+        valueRef.current = canonicalValue;
+        setValue(canonicalValue);
+        return true;
+    };
+
+    const publishValueChange = (newValue: number[]) => {
+        const canonicalValue = canonicalizeValues(newValue);
+
+        if (!updateCurrentValue(canonicalValue)) {
+            return;
+        }
+
+        if (updatemode === 'drag') {
+            setSliderProps({
+                value: canonicalValue,
+                drag_value: canonicalValue,
+            });
+        } else {
+            setSliderProps({drag_value: canonicalValue});
+        }
+    };
+
+    const commitSliderInteraction = (interaction: SliderInteraction) => {
+        if (
+            updatemode === 'mouseup' &&
+            !valuesEqual(valueRef.current, interaction.startValue)
+        ) {
+            setSliderProps({value: [...valueRef.current]});
+        }
+    };
+
+    const startSliderInteraction = (
+        kind: SliderInteractionKind,
+        thumbIndex: number | null
+    ) => {
+        const currentInteraction = interactionRef.current;
+
+        if (currentInteraction) {
+            if (currentInteraction.thumbIndex === null && thumbIndex !== null) {
+                currentInteraction.thumbIndex = thumbIndex;
+            }
+
+            if (currentInteraction.kind === kind) {
+                return;
+            }
+
+            // Keep a captured pointer gesture authoritative until release.
+            // If a pointer starts during a keyboard gesture, commit the
+            // keyboard value before starting the new pointer transaction.
+            if (currentInteraction.kind === 'pointer') {
+                return;
+            }
+
+            interactionRef.current = null;
+            commitSliderInteraction(currentInteraction);
+        }
+
+        interactionRef.current = {
+            kind,
+            thumbIndex,
+            startValue: [...valueRef.current],
+        };
+    };
+
+    const finishSliderInteraction = (kind: SliderInteractionKind) => {
+        const currentInteraction = interactionRef.current;
+
+        if (!currentInteraction || currentInteraction.kind !== kind) {
+            return;
+        }
+
+        interactionRef.current = null;
+        commitSliderInteraction(currentInteraction);
+    };
+
+    const findClosestThumbFromPointer = (
+        event: React.PointerEvent<HTMLElement>
+    ): number | null => {
+        const currentValue = valueRef.current;
+        if (currentValue.length === 0) {
+            return null;
+        }
+
+        const bounds = event.currentTarget.getBoundingClientRect();
+        const dimension = vertical ? bounds.height : bounds.width;
+        if (dimension <= 0) {
+            return null;
+        }
+
+        const pointerOffset = vertical
+            ? event.clientY - bounds.top
+            : event.clientX - bounds.left;
+        const pointerRatio = pointerOffset / dimension;
+        const valuesIncreaseFromStart = vertical ? !!reverse : !reverse;
+        const valueRatio = valuesIncreaseFromStart
+            ? pointerRatio
+            : 1 - pointerRatio;
+        const pointerValue =
+            minMaxValues.min_mark +
+            valueRatio * (minMaxValues.max_mark - minMaxValues.min_mark);
+
+        let closestIndex = 0;
+        let closestDistance = Math.abs(currentValue[0] - pointerValue);
+        for (let index = 1; index < currentValue.length; index++) {
+            const distance = Math.abs(currentValue[index] - pointerValue);
+            if (distance < closestDistance) {
+                closestIndex = index;
+                closestDistance = distance;
+            }
+        }
+
+        return closestIndex;
+    };
+
+    const buildValueForThumbCandidate = (
+        activeThumbIndex: number,
+        candidate: number
+    ): number[] => {
+        const previousValue = valueRef.current;
+
+        if (allowCross) {
+            const taggedValues = previousValue.map((item, index) => ({
+                originalIndex: index,
+                value: index === activeThumbIndex ? candidate : item,
+            }));
+            taggedValues.sort(
+                (left, right) =>
+                    left.value - right.value ||
+                    left.originalIndex - right.originalIndex
+            );
+
+            const currentInteraction = interactionRef.current;
+            if (currentInteraction) {
+                currentInteraction.thumbIndex = taggedValues.findIndex(
+                    item => item.originalIndex === activeThumbIndex
+                );
+            }
+
+            return taggedValues.map(item => item.value);
+        }
+
+        const nextValue = [...previousValue];
+        const lowerBound =
+            activeThumbIndex > 0
+                ? previousValue[activeThumbIndex - 1]
+                : minMaxValues.min_mark;
+        const upperBound =
+            activeThumbIndex < previousValue.length - 1
+                ? previousValue[activeThumbIndex + 1]
+                : minMaxValues.max_mark;
+        nextValue[activeThumbIndex] = Math.max(
+            lowerBound,
+            Math.min(upperBound, candidate)
+        );
+        return nextValue;
+    };
+
+    const deriveValueFromAttempt = (attemptedValue: number[]): number[] => {
+        const previousValue = valueRef.current;
+        const currentInteraction = interactionRef.current;
+
+        if (!currentInteraction) {
+            return canonicalizeValues(attemptedValue);
+        }
+
+        const valueChange = findThumbValueChange(previousValue, attemptedValue);
+        if (!valueChange) {
+            return previousValue;
+        }
+
+        const activeThumbIndex =
+            currentInteraction.thumbIndex ?? valueChange.previousIndex;
+        currentInteraction.thumbIndex = activeThumbIndex;
+        if (
+            activeThumbIndex >= attemptedValue.length ||
+            activeThumbIndex >= previousValue.length
+        ) {
+            return canonicalizeValues(attemptedValue);
+        }
+
+        let {candidate} = valueChange;
         if (
             step === null &&
             processedMarks &&
             typeof processedMarks === 'object'
         ) {
-            const marks = processedMarks;
-            adjustedValue = newValue.map(val => snapToNearestMark(val, marks));
+            candidate = snapToNearestMark(candidate, processedMarks);
         }
 
-        setValue(adjustedValue);
-        if (updatemode === 'drag') {
-            setProps({value: adjustedValue, drag_value: adjustedValue});
-        } else {
-            setProps({drag_value: adjustedValue});
+        return buildValueForThumbCandidate(activeThumbIndex, candidate);
+    };
+
+    const handleValueChange = (attemptedValue: number[]) => {
+        const adjustedValue = deriveValueFromAttempt(attemptedValue);
+        publishValueChange(adjustedValue);
+
+        const currentInteraction = interactionRef.current;
+        if (currentInteraction && currentInteraction.thumbIndex !== null) {
+            const activeThumb =
+                thumbRefs.current[currentInteraction.thumbIndex];
+
+            if (activeThumb && document.activeElement !== activeThumb) {
+                activeThumb.focus();
+            }
         }
     };
 
-    const handleValueCommit = (newValue: number[]) => {
-        if (updatemode === 'mouseup') {
-            setProps({value: newValue});
+    const createInputEdit = (side: InputSide, text?: string): InputEdit => {
+        const currentValue = valueRef.current;
+        const activeIndex = side === 'min' ? 0 : currentValue.length - 1;
+        const activeValue =
+            currentValue[activeIndex] ??
+            (side === 'min' ? minMaxValues.min_mark : minMaxValues.max_mark);
+
+        return {
+            side,
+            text: text ?? String(activeValue),
+            startValue: [...currentValue],
+            fixedValue:
+                currentValue.length === 2
+                    ? currentValue[side === 'min' ? 1 : 0]
+                    : undefined,
+            lastValidCandidate: activeValue,
+        };
+    };
+
+    const beginInputEdit = (side: InputSide) => {
+        if (inputEditRef.current?.side !== side) {
+            updateInputEdit(createInputEdit(side));
         }
+    };
+
+    const buildDirectInputValue = (
+        edit: InputEdit,
+        candidate: number
+    ): number[] => {
+        if (edit.fixedValue === undefined) {
+            return [candidate];
+        }
+
+        if (allowCross) {
+            return canonicalizeValues([candidate, edit.fixedValue]);
+        }
+
+        return edit.side === 'min'
+            ? [Math.min(candidate, edit.fixedValue), edit.fixedValue]
+            : [edit.fixedValue, Math.max(candidate, edit.fixedValue)];
+    };
+
+    const handleInputChange = (side: InputSide, text: string) => {
+        const currentEdit =
+            inputEditRef.current?.side === side
+                ? inputEditRef.current
+                : createInputEdit(side, text);
+        const candidate = parseFloat(text);
+        const nextEdit = {
+            ...currentEdit,
+            text,
+            lastValidCandidate: valueIsValid(candidate)
+                ? candidate
+                : currentEdit.lastValidCandidate,
+        };
+        updateInputEdit(nextEdit);
+
+        if (valueIsValid(candidate)) {
+            publishValueChange(buildDirectInputValue(nextEdit, candidate));
+        }
+    };
+
+    const finishInputEdit = (side: InputSide) => {
+        const currentEdit = inputEditRef.current;
+
+        if (!currentEdit || currentEdit.side !== side) {
+            return;
+        }
+
+        const parsedCandidate = parseFloat(currentEdit.text);
+        const candidate = constrainToValidValue(
+            Number.isFinite(parsedCandidate)
+                ? parsedCandidate
+                : currentEdit.lastValidCandidate
+        );
+        const finalValue = buildDirectInputValue(currentEdit, candidate);
+        const currentValueChanged = updateCurrentValue(finalValue);
+
+        if (updatemode === 'drag') {
+            if (currentValueChanged) {
+                setSliderProps({
+                    value: finalValue,
+                    drag_value: finalValue,
+                });
+            }
+        } else {
+            const propsToPublish: Partial<RangeSliderProps> = {};
+
+            if (!valuesEqual(finalValue, currentEdit.startValue)) {
+                propsToPublish.value = finalValue;
+            }
+            if (currentValueChanged) {
+                propsToPublish.drag_value = finalValue;
+            }
+            if (
+                propsToPublish.value !== undefined ||
+                propsToPublish.drag_value !== undefined
+            ) {
+                setSliderProps(propsToPublish);
+            }
+        }
+
+        updateInputEdit(null);
+    };
+
+    const inputDisplayValue = (side: InputSide): string | number => {
+        if (inputEdit) {
+            if (inputEdit.side === side) {
+                return inputEdit.text;
+            }
+
+            if (inputEdit.fixedValue !== undefined) {
+                return inputEdit.fixedValue;
+            }
+        }
+
+        const valueIndex = side === 'min' ? 0 : value.length - 1;
+        return isNaN(value[valueIndex]) ? '' : value[valueIndex];
     };
 
     const classNames = ['dash-slider-container', className].filter(Boolean);
@@ -278,62 +727,15 @@ export default function RangeSlider(props: RangeSliderProps) {
                             type="number"
                             className="dash-input-container dash-range-slider-input dash-range-slider-min-input"
                             style={{width: inputWidth}}
-                            value={isNaN(value[0]) ? '' : value[0]}
-                            onChange={e => {
-                                const inputValue = e.target.value;
-
-                                // Parse the input value
-                                const newMin = parseFloat(inputValue);
-                                const newValue = [newMin, value[1]];
-                                setValue(newValue);
-                                // Only update props if value is valid
-                                if (valueIsValid(newMin)) {
-                                    if (updatemode === 'drag') {
-                                        setProps({
-                                            value: newValue,
-                                            drag_value: newValue,
-                                        });
-                                    } else {
-                                        setProps({
-                                            drag_value: newValue,
-                                        });
-                                    }
-                                }
-                            }}
-                            onBlur={e => {
-                                const inputValue = e.target.value;
-                                let newMin: number;
-
-                                // If empty, default to current value or min_mark
-                                if (inputValue === '') {
-                                    newMin = isNaN(value[0])
-                                        ? minMaxValues.min_mark
-                                        : value[0];
-                                } else {
-                                    newMin = parseFloat(inputValue);
-                                    newMin = isNaN(newMin)
-                                        ? minMaxValues.min_mark
-                                        : newMin;
-                                }
-
-                                // Constrain to not exceed the max value
-                                newMin = Math.min(
-                                    value[1] ?? minMaxValues.max_mark,
-                                    newMin
-                                );
-
-                                // Snap to valid value (respecting step and marks)
-                                const constrainedMin =
-                                    constrainToValidValue(newMin);
-                                const newValue = [constrainedMin, value[1]];
-                                setValue(newValue);
-                                if (updatemode === 'mouseup') {
-                                    setProps({value: newValue});
-                                }
-                            }}
+                            value={inputDisplayValue('min')}
+                            onFocus={() => beginInputEdit('min')}
+                            onChange={e =>
+                                handleInputChange('min', e.currentTarget.value)
+                            }
+                            onBlur={() => finishInputEdit('min')}
                             pattern="^\\d*\\.?\\d*$"
                             min={minMaxValues.min_mark}
-                            max={isNaN(value[1]) ? max : value[1]}
+                            max={allowCross || isNaN(value[1]) ? max : value[1]}
                             step={step || undefined}
                             disabled={disabled}
                         />
@@ -344,67 +746,15 @@ export default function RangeSlider(props: RangeSliderProps) {
                             type="number"
                             className="dash-input-container dash-range-slider-input  dash-range-slider-max-input"
                             style={{width: inputWidth}}
-                            value={
-                                isNaN(value[value.length - 1])
-                                    ? ''
-                                    : value[value.length - 1]
+                            value={inputDisplayValue('max')}
+                            onFocus={() => beginInputEdit('max')}
+                            onChange={e =>
+                                handleInputChange('max', e.currentTarget.value)
                             }
-                            onChange={e => {
-                                const inputValue = e.target.value;
-
-                                // Parse the input value
-                                const newMax = parseFloat(inputValue);
-                                const newValue = [...value];
-                                newValue[newValue.length - 1] = newMax;
-                                setValue(newValue);
-                                // Only update props if value is valid
-                                if (valueIsValid(newMax)) {
-                                    if (updatemode === 'drag') {
-                                        setProps({
-                                            value: newValue,
-                                            drag_value: newValue,
-                                        });
-                                    } else {
-                                        setProps({
-                                            drag_value: newValue,
-                                        });
-                                    }
-                                }
-                            }}
-                            onBlur={e => {
-                                const inputValue = e.target.value;
-                                let newMax: number;
-
-                                // If empty, default to current value or max_mark
-                                if (inputValue === '') {
-                                    newMax = isNaN(value[value.length - 1])
-                                        ? minMaxValues.max_mark
-                                        : value[value.length - 1];
-                                } else {
-                                    newMax = parseFloat(inputValue);
-                                    newMax = isNaN(newMax)
-                                        ? minMaxValues.max_mark
-                                        : newMax;
-                                }
-                                // Constrain to not be less than the min value
-                                newMax = Math.max(
-                                    value[0] ?? minMaxValues.min_mark,
-                                    newMax
-                                );
-
-                                // Snap to valid value (respecting step and marks)
-                                const constrainedMax =
-                                    constrainToValidValue(newMax);
-                                const newValue = [...value];
-                                newValue[newValue.length - 1] = constrainedMax;
-                                setValue(newValue);
-                                if (updatemode === 'mouseup') {
-                                    setProps({value: newValue});
-                                }
-                            }}
+                            onBlur={() => finishInputEdit('max')}
                             pattern="^\\d*\\.?\\d*$"
                             min={
-                                value.length === 1
+                                allowCross || value.length === 1
                                     ? minMaxValues.min_mark
                                     : value[0]
                             }
@@ -433,7 +783,26 @@ export default function RangeSlider(props: RangeSliderProps) {
                             }}
                             value={value}
                             onValueChange={handleValueChange}
-                            onValueCommit={handleValueCommit}
+                            onPointerDown={event =>
+                                startSliderInteraction(
+                                    'pointer',
+                                    findClosestThumbFromPointer(event)
+                                )
+                            }
+                            onPointerUp={() =>
+                                finishSliderInteraction('pointer')
+                            }
+                            onPointerCancel={() =>
+                                finishSliderInteraction('pointer')
+                            }
+                            onLostPointerCapture={() =>
+                                finishSliderInteraction('pointer')
+                            }
+                            onKeyUp={e => {
+                                if (isKeyboardControlKey(e.key)) {
+                                    finishSliderInteraction('keyboard');
+                                }
+                            }}
                             min={minMaxValues.min_mark}
                             max={minMaxValues.max_mark}
                             step={stepValue}
@@ -480,6 +849,59 @@ export default function RangeSlider(props: RangeSliderProps) {
                                     <RadixSlider.Thumb
                                         key={'thumb' + index}
                                         className={thumbClassName}
+                                        ref={thumb => {
+                                            thumbRefs.current[index] = thumb;
+                                        }}
+                                        onPointerDown={() => {
+                                            startSliderInteraction(
+                                                'pointer',
+                                                index
+                                            );
+                                        }}
+                                        onKeyDown={e => {
+                                            if (
+                                                !disabled &&
+                                                isKeyboardControlKey(e.key)
+                                            ) {
+                                                startSliderInteraction(
+                                                    'keyboard',
+                                                    index
+                                                );
+                                                if (
+                                                    e.key === 'Home' ||
+                                                    e.key === 'End'
+                                                ) {
+                                                    e.preventDefault();
+                                                    publishValueChange(
+                                                        buildValueForThumbCandidate(
+                                                            index,
+                                                            e.key === 'Home'
+                                                                ? constrainToValidValue(
+                                                                      minMaxValues.min_mark
+                                                                  )
+                                                                : constrainToValidValue(
+                                                                      minMaxValues.max_mark
+                                                                  )
+                                                        )
+                                                    );
+                                                    const destinationIndex =
+                                                        interactionRef.current
+                                                            ?.thumbIndex;
+                                                    if (
+                                                        destinationIndex !==
+                                                            null &&
+                                                        destinationIndex !==
+                                                            undefined &&
+                                                        destinationIndex !==
+                                                            index
+                                                    ) {
+                                                        thumbRefs.current[
+                                                            destinationIndex
+                                                        ]?.focus();
+                                                    }
+                                                }
+                                            }
+                                        }}
                                     >
                                         {tooltip && (
                                             <Tooltip

--- a/components/dash-core-components/tests/integration/sliders/test_rangeslider_allow_cross.py
+++ b/components/dash-core-components/tests/integration/sliders/test_rangeslider_allow_cross.py
@@ -1,0 +1,940 @@
+from dash import Dash, Input, Output, dcc, html
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
+
+
+def assert_no_browser_errors(dash_dcc):
+    logs = dash_dcc.get_logs()
+    assert logs in ([], None)
+
+
+def test_rangeslider_click_updates_callback(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        style={"width": "400px"},
+        children=[
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+            ),
+            html.Div(id="out"),
+        ],
+    )
+
+    @app.callback(Output("out", "children"), Input("range-slider", "value"))
+    def update_output(value):
+        return f"{value[0]}-{value[1]}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.wait_for_text_to_equal("#out", "5-15")
+
+    slider = dash_dcc.find_element("#range-slider")
+    dash_dcc.click_at_coord_fractions(slider, 0.2, 0.25)
+    dash_dcc.wait_for_text_to_equal("#out", "2-15")
+
+    dash_dcc.click_at_coord_fractions(slider, 0.51, 0.25)
+    dash_dcc.wait_for_text_to_equal("#out", "2-10")
+
+    assert len(dash_dcc.find_elements("#range-slider .dash-slider-thumb-1")) == 1
+    assert len(dash_dcc.find_elements("#range-slider .dash-slider-thumb-2")) == 1
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_direct_inputs_update_callbacks(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+            ),
+            html.Div(id="value"),
+            html.Div(id="drag-value"),
+        ]
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    max_input = dash_dcc.find_element("#range-slider .dash-range-slider-max-input")
+    assert min_input.get_attribute("value") == "5"
+    assert max_input.get_attribute("value") == "15"
+
+    dash_dcc.clear_input(min_input)
+    min_input.send_keys("4", Keys.TAB)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [4, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [4, 15]")
+
+    dash_dcc.clear_input(max_input)
+    max_input.send_keys("18", Keys.TAB)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [4, 18]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [4, 18]")
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_min_direct_input_above_max_clamps_to_max_handle(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+                allowCross=False,
+                updatemode="drag",
+            ),
+            html.Div(id="value"),
+            html.Div(id="drag-value"),
+        ]
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    dash_dcc.clear_input(min_input)
+    min_input.send_keys("18")
+
+    dash_dcc.wait_for_text_to_equal("#value", "value is [15, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [15, 15]")
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    max_input = dash_dcc.find_element("#range-slider .dash-range-slider-max-input")
+    assert min_input.get_attribute("value") == "18"
+    assert max_input.get_attribute("value") == "15"
+
+    min_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-1")
+    max_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-2")
+    min_thumb_center = dash_dcc.driver.execute_script(
+        "const rect = arguments[0].getBoundingClientRect();"
+        "return rect.left + rect.width / 2;",
+        min_thumb,
+    )
+    max_thumb_center = dash_dcc.driver.execute_script(
+        "const rect = arguments[0].getBoundingClientRect();"
+        "return rect.left + rect.width / 2;",
+        max_thumb,
+    )
+    assert abs(min_thumb_center - max_thumb_center) <= 1
+
+    min_input.send_keys(Keys.TAB)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [15, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [15, 15]")
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    max_input = dash_dcc.find_element("#range-slider .dash-range-slider-max-input")
+    assert min_input.get_attribute("value") == "15"
+    assert max_input.get_attribute("value") == "15"
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_allow_cross_true_min_direct_input_above_max_allows_crossing(
+    dash_dcc,
+):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+                allowCross=True,
+                updatemode="mouseup",
+            ),
+            html.Div(id="value"),
+            html.Div(id="drag-value"),
+        ]
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    dash_dcc.clear_input(min_input)
+    min_input.send_keys("18")
+
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [15, 18]")
+    assert dash_dcc.find_element("#value").text == "value is [5, 15]"
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    max_input = dash_dcc.find_element("#range-slider .dash-range-slider-max-input")
+    assert min_input.get_attribute("value") == "18"
+    assert max_input.get_attribute("value") == "15"
+    min_input.send_keys(Keys.TAB)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [15, 18]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [15, 18]")
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    max_input = dash_dcc.find_element("#range-slider .dash-range-slider-max-input")
+    assert min_input.get_attribute("value") == "15"
+    assert max_input.get_attribute("value") == "18"
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_allow_cross_false_prevents_handle_crossing(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        style={"width": "400px"},
+        children=[
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+                allowCross=False,
+                updatemode="mouseup",
+            ),
+            html.Div(id="value"),
+            html.Div(id="drag-value"),
+            html.Div(id="state"),
+        ],
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    @app.callback(
+        Output("state", "children"),
+        Input("range-slider", "value"),
+        Input("range-slider", "drag_value"),
+    )
+    def update_state(value, drag_value):
+        return f"value is {value}; drag_value is {drag_value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#state", "value is [5, 15]; drag_value is [5, 15]")
+
+    slider_root = dash_dcc.find_element("#range-slider .dash-slider-root")
+    min_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-1")
+    dash_dcc.click_and_hold_at_coord_fractions(min_thumb, 0.5, 0.5)
+    dash_dcc.move_to_coord_fractions(slider_root, 0.6, 0.5)
+    dash_dcc.wait_for_text_to_equal(
+        "#state", "value is [5, 15]; drag_value is [12, 15]"
+    )
+    active_thumb = dash_dcc.driver.switch_to.active_element
+    assert "dash-slider-thumb-1" in active_thumb.get_attribute("class")
+    ActionChains(dash_dcc.driver).key_down(Keys.ARROW_RIGHT).key_up(
+        Keys.ARROW_RIGHT
+    ).move_to_element_with_offset(
+        slider_root,
+        slider_root.size["width"] * 0.9,
+        slider_root.size["height"] * 0.5,
+    ).release().perform()
+    dash_dcc.wait_for_text_to_equal(
+        "#state", "value is [15, 15]; drag_value is [15, 15]"
+    )
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_allow_cross_false_keyboard_clamps_active_min_thumb(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        style={"width": "400px"},
+        children=[
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+                allowCross=False,
+                updatemode="drag",
+            ),
+            html.Div(id="value"),
+            html.Div(id="drag-value"),
+        ],
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    min_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-1")
+    min_thumb.click()
+    for _ in range(15):
+        min_thumb.send_keys(Keys.ARROW_RIGHT)
+
+    dash_dcc.wait_for_text_to_equal("#value", "value is [15, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [15, 15]")
+    min_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-1")
+    max_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-2")
+    assert min_thumb.get_attribute("aria-valuenow") == "15"
+    assert max_thumb.get_attribute("aria-valuenow") == "15"
+
+    min_thumb_center = dash_dcc.driver.execute_script(
+        "const rect = arguments[0].getBoundingClientRect();"
+        "return rect.left + rect.width / 2;",
+        min_thumb,
+    )
+    max_thumb_center = dash_dcc.driver.execute_script(
+        "const rect = arguments[0].getBoundingClientRect();"
+        "return rect.left + rect.width / 2;",
+        max_thumb,
+    )
+    assert abs(min_thumb_center - max_thumb_center) <= 1
+
+    min_thumb.send_keys(Keys.TAB)
+    active_thumb = dash_dcc.driver.switch_to.active_element
+    assert "dash-slider-thumb-2" in active_thumb.get_attribute("class")
+    active_thumb.send_keys(Keys.ARROW_RIGHT)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [15, 16]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [15, 16]")
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_home_end_update_the_focused_thumb(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        style={"width": "400px"},
+        children=[
+            dcc.RangeSlider(
+                id="no-cross-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[0, 15],
+                allowCross=False,
+            ),
+            html.Div(id="no-cross-value"),
+            html.Div(id="no-cross-drag-value"),
+            dcc.RangeSlider(
+                id="cross-slider",
+                min=0,
+                max=10,
+                step=3,
+                value=[3, 6],
+                allowCross=True,
+                updatemode="drag",
+            ),
+            html.Div(id="cross-value"),
+            html.Div(id="cross-drag-value"),
+        ],
+    )
+
+    @app.callback(
+        Output("no-cross-value", "children"), Input("no-cross-slider", "value")
+    )
+    def update_no_cross_value(value):
+        return f"value is {value}"
+
+    @app.callback(
+        Output("no-cross-drag-value", "children"),
+        Input("no-cross-slider", "drag_value"),
+    )
+    def update_no_cross_drag_value(value):
+        return f"drag_value is {value}"
+
+    @app.callback(Output("cross-value", "children"), Input("cross-slider", "value"))
+    def update_cross_value(value):
+        return f"value is {value}"
+
+    @app.callback(
+        Output("cross-drag-value", "children"), Input("cross-slider", "drag_value")
+    )
+    def update_cross_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#no-cross-value", "value is [0, 15]")
+    dash_dcc.wait_for_text_to_equal("#no-cross-drag-value", "drag_value is [0, 15]")
+    dash_dcc.wait_for_text_to_equal("#cross-value", "value is [3, 6]")
+    dash_dcc.wait_for_text_to_equal("#cross-drag-value", "drag_value is [3, 6]")
+
+    no_cross_max = dash_dcc.find_element("#no-cross-slider .dash-slider-thumb-2")
+    no_cross_max.click()
+    no_cross_max.send_keys(Keys.HOME)
+    dash_dcc.wait_for_text_to_equal("#no-cross-value", "value is [0, 0]")
+    dash_dcc.wait_for_text_to_equal("#no-cross-drag-value", "drag_value is [0, 0]")
+
+    cross_max = dash_dcc.find_element("#cross-slider .dash-slider-thumb-2")
+    cross_max.click()
+    cross_max.send_keys(Keys.HOME)
+    dash_dcc.wait_for_text_to_equal("#cross-value", "value is [0, 3]")
+    dash_dcc.wait_for_text_to_equal("#cross-drag-value", "drag_value is [0, 3]")
+    active_thumb = dash_dcc.driver.switch_to.active_element
+    assert "dash-slider-thumb-1" in active_thumb.get_attribute("class")
+    active_thumb.send_keys(Keys.ARROW_RIGHT)
+    dash_dcc.wait_for_text_to_equal("#cross-value", "value is [3, 3]")
+    dash_dcc.wait_for_text_to_equal("#cross-drag-value", "drag_value is [3, 3]")
+    active_thumb.send_keys(Keys.END)
+    dash_dcc.wait_for_text_to_equal("#cross-value", "value is [3, 9]")
+    dash_dcc.wait_for_text_to_equal("#cross-drag-value", "drag_value is [3, 9]")
+    active_thumb = dash_dcc.driver.switch_to.active_element
+    assert "dash-slider-thumb-2" in active_thumb.get_attribute("class")
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_disabled_home_end_do_not_update_retained_focus(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            html.Button("Toggle disabled", id="toggle-disabled"),
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+                updatemode="drag",
+            ),
+            html.Div(id="disabled-state"),
+            html.Div(id="value-event"),
+            html.Div(id="drag-value"),
+        ]
+    )
+    value_events = []
+
+    @app.callback(
+        Output("range-slider", "disabled"),
+        Output("disabled-state", "children"),
+        Input("toggle-disabled", "n_clicks"),
+    )
+    def toggle_disabled(n_clicks):
+        disabled = bool((n_clicks or 0) % 2)
+        return disabled, f"disabled is {disabled}"
+
+    @app.callback(Output("value-event", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        value_events.append(value)
+        return f"event {len(value_events)}: {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#disabled-state", "disabled is False")
+    dash_dcc.wait_for_text_to_equal("#value-event", "event 1: [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    max_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-2")
+    max_thumb.click()
+    assert dash_dcc.driver.switch_to.active_element == max_thumb
+
+    dash_dcc.driver.execute_script(
+        "window.dash_clientside.set_props('toggle-disabled', {n_clicks: 1});"
+    )
+    dash_dcc.wait_for_text_to_equal("#disabled-state", "disabled is True")
+    dash_dcc.find_element("#range-slider .dash-slider-root[data-disabled]")
+    max_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-2")
+    dash_dcc.driver.execute_script(
+        """
+        const thumb = arguments[0];
+        for (const key of ['Home', 'End']) {
+            const options = {key, code: key, bubbles: true, cancelable: true};
+            thumb.dispatchEvent(new KeyboardEvent('keydown', options));
+            thumb.dispatchEvent(new KeyboardEvent('keyup', options));
+        }
+        """,
+        max_thumb,
+    )
+
+    dash_dcc.driver.execute_script(
+        "window.dash_clientside.set_props('toggle-disabled', {n_clicks: 2});"
+    )
+    dash_dcc.wait_for_text_to_equal("#disabled-state", "disabled is False")
+    max_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-2")
+    max_thumb.click()
+    max_thumb.send_keys(Keys.ARROW_RIGHT)
+    dash_dcc.wait_for_text_to_equal("#value-event", "event 2: [5, 16]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 16]")
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_allow_cross_tracks_thumb_through_duplicate_values(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        style={"width": "400px"},
+        children=[
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=30,
+                step=1,
+                value=[0, 10, 20],
+                allowCross=True,
+                updatemode="drag",
+            ),
+            html.Div(id="value"),
+            dcc.RangeSlider(
+                id="descending-slider",
+                min=0,
+                max=30,
+                step=1,
+                value=[0, 10, 20],
+                allowCross=True,
+                updatemode="drag",
+            ),
+            html.Div(id="descending-value"),
+        ],
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(
+        Output("descending-value", "children"),
+        Input("descending-slider", "value"),
+    )
+    def update_descending_value(value):
+        return f"value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [0, 10, 20]")
+    dash_dcc.wait_for_text_to_equal("#descending-value", "value is [0, 10, 20]")
+
+    slider_root = dash_dcc.find_element("#range-slider .dash-slider-root")
+    first_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-1")
+    dash_dcc.click_and_hold_at_coord_fractions(first_thumb, 0.5, 0.5)
+    dash_dcc.move_to_coord_fractions(slider_root, 2 / 3, 0.5)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [10, 20, 20]")
+    dash_dcc.move_to_coord_fractions(slider_root, 0.7, 0.5)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [10, 20, 21]")
+    dash_dcc.release()
+
+    descending_root = dash_dcc.find_element("#descending-slider .dash-slider-root")
+    third_thumb = dash_dcc.find_element("#descending-slider .dash-slider-thumb-3")
+    dash_dcc.click_and_hold_at_coord_fractions(third_thumb, 0.5, 0.5)
+    dash_dcc.move_to_coord_fractions(descending_root, 1 / 3, 0.5)
+    dash_dcc.wait_for_text_to_equal("#descending-value", "value is [0, 10, 10]")
+    active_thumb = dash_dcc.driver.switch_to.active_element
+    assert "dash-slider-thumb-3" in active_thumb.get_attribute("class")
+    dash_dcc.move_to_coord_fractions(descending_root, 0.3, 0.5)
+    dash_dcc.wait_for_text_to_equal("#descending-value", "value is [0, 9, 10]")
+    active_thumb = dash_dcc.driver.switch_to.active_element
+    assert "dash-slider-thumb-2" in active_thumb.get_attribute("class")
+    dash_dcc.release()
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_track_noop_start_keeps_the_closest_thumb(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        style={"width": "400px"},
+        children=[
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=2,
+                step=0.5,
+                value=[0, 1, 2],
+                allowCross=False,
+                updatemode="drag",
+            ),
+            html.Div(id="value"),
+            dcc.RangeSlider(
+                id="duplicate-slider",
+                min=0,
+                max=2,
+                step=0.25,
+                value=[0, 1, 1, 2],
+                allowCross=False,
+                updatemode="drag",
+            ),
+            html.Div(id="duplicate-value"),
+            dcc.RangeSlider(
+                id="duplicate-right-slider",
+                min=0,
+                max=2,
+                step=0.25,
+                value=[0, 1, 1, 2],
+                allowCross=False,
+                updatemode="drag",
+            ),
+            html.Div(id="duplicate-right-value"),
+        ],
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(
+        Output("duplicate-value", "children"), Input("duplicate-slider", "value")
+    )
+    def update_duplicate_value(value):
+        return f"value is {value}"
+
+    @app.callback(
+        Output("duplicate-right-value", "children"),
+        Input("duplicate-right-slider", "value"),
+    )
+    def update_duplicate_right_value(value):
+        return f"value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [0, 1, 2]")
+    dash_dcc.wait_for_text_to_equal("#duplicate-value", "value is [0, 1, 1, 2]")
+    dash_dcc.wait_for_text_to_equal("#duplicate-right-value", "value is [0, 1, 1, 2]")
+
+    slider_root = dash_dcc.find_element("#range-slider .dash-slider-root")
+    dash_dcc.click_and_hold_at_coord_fractions(slider_root, 0.1, 0.5)
+    dash_dcc.move_to_coord_fractions(slider_root, 0.75, 0.5)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [1, 1, 2]")
+    dash_dcc.release()
+
+    duplicate_root = dash_dcc.find_element("#duplicate-slider .dash-slider-root")
+    dash_dcc.click_and_hold_at_coord_fractions(duplicate_root, 0.46, 0.5)
+    dash_dcc.move_to_coord_fractions(duplicate_root, 0.375, 0.5)
+    dash_dcc.wait_for_text_to_equal("#duplicate-value", "value is [0, 0.75, 1, 2]")
+    dash_dcc.release()
+
+    duplicate_right_root = dash_dcc.find_element(
+        "#duplicate-right-slider .dash-slider-root"
+    )
+    dash_dcc.click_and_hold_at_coord_fractions(duplicate_right_root, 0.54, 0.5)
+    dash_dcc.move_to_coord_fractions(duplicate_right_root, 0.625, 0.5)
+    dash_dcc.release()
+    assert (
+        dash_dcc.find_element("#duplicate-right-value").text == "value is [0, 1, 1, 2]"
+    )
+    duplicate_right_thumbs = dash_dcc.find_elements(
+        "#duplicate-right-slider .dash-slider-thumb"
+    )
+    assert [
+        thumb.get_attribute("aria-valuenow") for thumb in duplicate_right_thumbs
+    ] == [
+        "0",
+        "1",
+        "1",
+        "2",
+    ]
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_allow_cross_true_allows_handle_crossing(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        style={"width": "400px"},
+        children=[
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+                allowCross=True,
+                updatemode="drag",
+            ),
+            html.Div(id="value"),
+            html.Div(id="drag-value"),
+        ],
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    slider_root = dash_dcc.find_element("#range-slider .dash-slider-root")
+    min_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-1")
+    dash_dcc.click_and_hold_at_coord_fractions(min_thumb, 0.5, 0.5)
+    dash_dcc.move_to_coord_fractions(slider_root, 0.9, 0.5)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [15, 18]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [15, 18]")
+    dash_dcc.release()
+    dash_dcc.wait_for_text_to_equal("#value", "value is [15, 18]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [15, 18]")
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_allow_cross_defaults_to_true(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        style={"width": "400px"},
+        children=[
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+                updatemode="drag",
+            ),
+            html.Div(id="value"),
+            html.Div(id="drag-value"),
+        ],
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    slider_root = dash_dcc.find_element("#range-slider .dash-slider-root")
+    min_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-1")
+    dash_dcc.click_and_hold_at_coord_fractions(min_thumb, 0.5, 0.5)
+    dash_dcc.move_to_coord_fractions(slider_root, 0.9, 0.5)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [15, 18]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [15, 18]")
+    dash_dcc.release()
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_external_value_clears_direct_input_draft(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            html.Button("Set value", id="set-value"),
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+            ),
+            html.Div(id="value"),
+            html.Div(id="drag-value"),
+            html.Div(id="set-result"),
+        ]
+    )
+
+    @app.callback(
+        Output("range-slider", "value"),
+        Output("set-result", "children"),
+        Input("set-value", "n_clicks"),
+        prevent_initial_call=True,
+    )
+    def set_value(n_clicks):
+        value = [5, 15] if n_clicks == 1 else [2, 12]
+        return value, f"set {n_clicks}"
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    dash_dcc.clear_input(min_input)
+    min_input.send_keys("999")
+    assert min_input.get_attribute("value") == "999"
+    assert dash_dcc.driver.switch_to.active_element == min_input
+
+    dash_dcc.driver.execute_script(
+        "window.dash_clientside.set_props('set-value', {n_clicks: 1});"
+    )
+    dash_dcc.wait_for_text_to_equal("#set-result", "set 1")
+
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    max_input = dash_dcc.find_element("#range-slider .dash-range-slider-max-input")
+    assert min_input.get_attribute("value") == "5"
+    assert max_input.get_attribute("value") == "15"
+    assert dash_dcc.driver.switch_to.active_element == min_input
+
+    dash_dcc.clear_input(min_input)
+    min_input.send_keys("9")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [9, 15]")
+    assert dash_dcc.find_element("#value").text == "value is [5, 15]"
+    assert dash_dcc.driver.switch_to.active_element == min_input
+
+    dash_dcc.driver.execute_script(
+        "window.dash_clientside.set_props('set-value', {n_clicks: 2});"
+    )
+    dash_dcc.wait_for_text_to_equal("#set-result", "set 2")
+    dash_dcc.wait_for_text_to_equal("#value", "value is [2, 12]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [2, 12]")
+
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    max_input = dash_dcc.find_element("#range-slider .dash-range-slider-max-input")
+    assert min_input.get_attribute("value") == "2"
+    assert max_input.get_attribute("value") == "12"
+    assert dash_dcc.driver.switch_to.active_element == min_input
+    min_input.send_keys(Keys.TAB)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [2, 12]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [2, 12]")
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_external_handle_shrink_resets_keyboard_transaction(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[0, 10, 20],
+                updatemode="mouseup",
+            ),
+            html.Div(id="value-event"),
+            html.Div(id="drag-value"),
+        ]
+    )
+    value_events = []
+
+    @app.callback(Output("value-event", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        value_events.append(value)
+        return f"event {len(value_events)}: {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value-event", "event 1: [0, 10, 20]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [0, 10, 20]")
+
+    third_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-3")
+    third_thumb.click()
+    ActionChains(dash_dcc.driver).key_down(Keys.ARROW_LEFT).perform()
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [0, 10, 19]")
+    assert dash_dcc.find_element("#value-event").text == "event 1: [0, 10, 20]"
+
+    dash_dcc.driver.execute_script(
+        "window.dash_clientside.set_props('range-slider', {value: [0, 10]});"
+    )
+    dash_dcc.wait_for_text_to_equal("#value-event", "event 2: [0, 10]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [0, 10]")
+    assert len(dash_dcc.find_elements("#range-slider .dash-slider-thumb")) == 2
+
+    ActionChains(dash_dcc.driver).key_up(Keys.ARROW_LEFT).perform()
+    first_thumb = dash_dcc.find_element("#range-slider .dash-slider-thumb-1")
+    first_thumb.send_keys(Keys.ARROW_RIGHT)
+    dash_dcc.wait_for_text_to_equal("#value-event", "event 3: [1, 10]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [1, 10]")
+
+    assert_no_browser_errors(dash_dcc)
+
+
+def test_rangeslider_mouseup_input_blur_resynchronizes_drag_value(dash_dcc):
+    app = Dash(__name__)
+    app.layout = html.Div(
+        [
+            dcc.RangeSlider(
+                id="range-slider",
+                min=0,
+                max=20,
+                step=1,
+                value=[5, 15],
+                allowCross=False,
+                updatemode="mouseup",
+            ),
+            html.Div(id="value"),
+            html.Div(id="drag-value"),
+        ]
+    )
+
+    @app.callback(Output("value", "children"), Input("range-slider", "value"))
+    def update_value(value):
+        return f"value is {value}"
+
+    @app.callback(Output("drag-value", "children"), Input("range-slider", "drag_value"))
+    def update_drag_value(value):
+        return f"drag_value is {value}"
+
+    dash_dcc.start_server(app)
+    dash_dcc.driver.set_window_size(800, 600)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    min_input = dash_dcc.find_element("#range-slider .dash-range-slider-min-input")
+    dash_dcc.clear_input(min_input)
+    min_input.send_keys("6")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [6, 15]")
+    assert dash_dcc.find_element("#value").text == "value is [5, 15]"
+
+    dash_dcc.clear_input(min_input)
+    min_input.send_keys("5.4", Keys.TAB)
+    dash_dcc.wait_for_text_to_equal("#value", "value is [5, 15]")
+    dash_dcc.wait_for_text_to_equal("#drag-value", "drag_value is [5, 15]")
+
+    assert_no_browser_errors(dash_dcc)

--- a/components/dash-core-components/tests/integration/sliders/test_sliders_keyboard_input.py
+++ b/components/dash-core-components/tests/integration/sliders/test_sliders_keyboard_input.py
@@ -61,6 +61,7 @@ def test_slkb002_range_input_constrained_by_min_max(dash_dcc):
                 min=1,
                 max=20,
                 value=[5, 7],
+                allowCross=False,
             ),
             html.Div(id="value"),
             html.Div(id="drag_value"),
@@ -104,10 +105,10 @@ def test_slkb002_range_input_constrained_by_min_max(dash_dcc):
     dash_dcc.wait_for_text_to_equal("#value", "value is [1, 5]")
     dash_dcc.wait_for_text_to_equal("#drag_value", "drag_value is [1, 5]")
 
-    # cannot enter a value less than `min`
+    # cannot cross the max handle
     min_inpt.send_keys(Keys.BACKSPACE, 7, Keys.TAB)
     dash_dcc.wait_for_text_to_equal("#value", "value is [5, 5]")
-    dash_dcc.wait_for_text_to_equal("#drag_value", "drag_value is [7, 5]")
+    dash_dcc.wait_for_text_to_equal("#drag_value", "drag_value is [5, 5]")
 
     assert dash_dcc.get_logs() == []
 


### PR DESCRIPTION
# Fix RangeSlider crossing and interaction synchronization

## Summary

This PR fixes `dcc.RangeSlider` interaction regressions around `allowCross`,
`updatemode`, direct input, and thumb identity.

- Enforce `allowCross=False` consistently for pointer, keyboard, Home/End, and
  direct-input changes.
- Preserve the existing default behavior of `allowCross=True` when the prop is
  omitted, while publishing crossed values in canonical ascending order.
- Keep `drag_value` live during `updatemode="mouseup"` interactions and publish
  `value` only when the interaction commits.
- Track the logical active thumb through crossings, duplicate values, track
  clicks, and mixed pointer/keyboard input.
- Synchronize direct-input drafts and active interactions when an authoritative
  external `value` update arrives, including when the number of handles changes.
- Resynchronize `value` and `drag_value` after direct-input blur, including when
  the constrained result returns to the interaction's starting value.

No public API is added or removed. The changes make the existing `allowCross`
and `updatemode` contracts behave consistently across all input methods.

## Steps to reproduce

<details>
  <summary>example.py</summary>
  
```python
from dash import Dash, Input, Output, dcc, html


app = Dash()

app.layout = html.Div(
    style={"width": "620px", "margin": "80px auto", "fontFamily": "sans-serif"},
    children=[
        html.H3("RangeSlider allowCross=False updatemode=mouseup"),
        html.H4("Two Handles"),
        dcc.RangeSlider(
            id="two-handle-slider-up",
            min=0,
            max=100,
            step=1,
            value=[5, 15],
            allowCross=False,
            updatemode="mouseup",
            marks={
                0: {'label': ' ', 'style': {'color': '#77b0b1'}},
                26: {'label': ' '},
                37: {'label': ' '},
                100: {'label': ' ', 'style': {'color': '#f50'}}
            },
            tooltip={"always_visible": True},
        ),
        html.Pre(
            id="two-handle-out-up",
            style={"marginTop": "24px", "marginBottom": "48px", "fontSize": "18px"},
        ),
        html.H4("Multiple Handles"),
        dcc.RangeSlider(
            id="multiple-handle-slider-up",
            min=0,
            max=20,
            step=1,
            value=[4, 8, 12, 16],
            allowCross=False,
            updatemode="mouseup",
            tooltip={"always_visible": True},
        ),
        html.Pre(
            id="multiple-handle-out-up",
            style={"marginTop": "24px", "marginBottom": "48px", "fontSize": "18px"},
        ),
        html.H3("RangeSlider allowCross=False updatemode=drag"),
        html.H4("Two Handles"),
        dcc.RangeSlider(
            id="two-handle-slider",
            min=0,
            max=20,
            step=1,
            value=[5, 15],
            allowCross=False,
            updatemode="drag",
            tooltip={"always_visible": True},
        ),
        html.Pre(
            id="two-handle-out",
            style={"marginTop": "24px", "marginBottom": "48px", "fontSize": "18px"},
        ),
        html.H4("Multiple Handles"),
        dcc.RangeSlider(
            id="multiple-handle-slider",
            min=0,
            max=20,
            step=1,
            value=[4, 8, 12, 16],
            allowCross=False,
            updatemode="drag",
            tooltip={"always_visible": True},
        ),
        html.Pre(
            id="multiple-handle-out",
            style={"marginTop": "24px", "marginBottom": "48px", "fontSize": "18px"},
        ),
        html.H3("RangeSlider allowCross=True updatemode=drag"),
        html.H4("Two Handles"),
        dcc.RangeSlider(
            id="two-handle-allow-cross-slider",
            min=0,
            max=20,
            step=1,
            value=[5, 15],
            allowCross=True,
            updatemode="drag",
            tooltip={"always_visible": True},
        ),
        html.Pre(
            id="two-handle-allow-cross-out",
            style={"marginTop": "24px", "marginBottom": "48px", "fontSize": "18px"},
        ),
        html.H4("Multiple Handles"),
        dcc.RangeSlider(
            id="multiple-handle-allow-cross-slider",
            min=0,
            max=20,
            step=1,
            value=[4, 8, 12, 16],
            allowCross=True,
            updatemode="drag",
            tooltip={"always_visible": True},
        ),
        html.Pre(
            id="multiple-handle-allow-cross-out",
            style={"marginTop": "24px", "fontSize": "18px"},
        ),
    ],
)

@app.callback(Output("two-handle-out-up", "children"), Input("two-handle-slider-up", "value"))
def show_two_handle_value(value):
    return f"value = {value}"


@app.callback(
    Output("multiple-handle-out-up", "children"), Input("multiple-handle-slider-up", "value")
)
def show_multiple_handle_value(value):
    return f"value = {value}"


@app.callback(Output("two-handle-out", "children"), Input("two-handle-slider", "value"))
def show_two_handle_value(value):
    return f"value = {value}"


@app.callback(
    Output("multiple-handle-out", "children"), Input("multiple-handle-slider", "value")
)
def show_multiple_handle_value(value):
    return f"value = {value}"


@app.callback(
    Output("two-handle-allow-cross-out", "children"),
    Input("two-handle-allow-cross-slider", "value"),
)
def show_two_handle_allow_cross_value(value):
    return f"value = {value}"


@app.callback(
    Output("multiple-handle-allow-cross-out", "children"),
    Input("multiple-handle-allow-cross-slider", "value"),
)
def show_multiple_handle_allow_cross_value(value):
    return f"value = {value}"


if __name__ == "__main__":
    app.run(debug=True)

```
</details>

1. From the workspace root, check out the parent revision and start the manual
   RangeSlider app:

   ```bash
   git switch --detach 3d3a9f70f452fba4dc385db94590009ce44031fc
   <rebuild dash>
   python3 example.py
   ```

2. Open <http://127.0.0.1:8050> and find the
   `RangeSlider allowCross=False updatemode=drag` example.
3. Drag the lower handle past the upper handle.
4. Before this fix, the lower handle crosses the upper handle even though
   `allowCross=False`, and the callback value changes from `[5, 15]` to a
   crossed range such as `[15, 18]`.
5. Stop the server, check out this commit, and repeat the same interaction:

   ```bash
   git switch --detach 41cd7f87f54e39100cc2983f320ce7333020ee99
   <rebuild dash>
   python3 example.py
   ```

6. After this fix, the lower handle stops at the upper handle and the callback
   value remains constrained, for example `[15, 15]`.

## Before and after recording

The left panel is the parent revision (`3d3a9f70f`); the right panel is this
commit (`41cd7f87f`). Both panels replay the same pointer path with
`allowCross=False`.

<img width="1200" height="379" alt="range-slider-before-after-41cd7f87f" src="https://github.com/user-attachments/assets/23abd87c-c290-4e78-a818-fa867c293130" />

## Implementation notes

- Introduced explicit pointer and keyboard interaction transactions so
  `mouseup` commits use the interaction's authoritative start and final values.
- Added stable, tagged sorting to retain active-thumb identity while values
  cross or become equal.
- Matched Radix Slider's pointer-to-thumb selection, including first-thumb tie
  resolution for duplicate values, horizontal/vertical orientation, and
  reversed sliders.
- Added step-aware Home/End handling and prevented the custom keyboard path from
  updating disabled sliders.
- Added local-value echo tracking so component-originated `setProps` updates are
  distinguished from same-value authoritative external updates.
- Reworked direct-input editing to retain temporary text while editing and
  publish constrained, canonical values at the correct update boundary.

## Test coverage

Added a focused 15-test Firefox integration suite covering:

- click and direct-input callbacks;
- crossing and clamping with explicit and default `allowCross`;
- `drag` and `mouseup` update modes;
- mouseup release commits and mixed pointer/keyboard gestures;
- keyboard clamping, Home/End, off-step endpoints, and disabled sliders;
- equal and duplicate thumb identity in both movement directions;
- no-op track starts and duplicate-value tie selection;
- external value updates, stale direct-input drafts, and handle-count shrink;
- `drag_value` resynchronization after direct-input blur.

The existing keyboard-input test now sets `allowCross=False` explicitly where it
asserts no-cross behavior.

## Verification

```text
../.venv/bin/python -m pytest \
  components/dash-core-components/tests/integration/sliders/test_rangeslider_allow_cross.py \
  --webdriver Firefox --headless -xvs

15 passed
```

```text
npm run build:js

webpack 5.104.1 compiled with 2 asset-size warnings
```

Additional checks:

- Black: passed
- Prettier: passed
- ESLint: 0 errors (one pre-existing unused `count` warning)
- `git diff --check`: passed
- Chromium browser smoke test using `manual_rangeslider_allow_cross.py`: passed

## Contributor Checklist

- [x] I have broken down my PR scope into the following tasks
  - [x] Fix RangeSlider crossing and interaction lifecycle behavior
  - [x] Synchronize direct inputs and external prop updates
  - [x] Preserve thumb identity across duplicate and crossed values
  - [x] Add regression coverage for all fixed interaction paths
- [x] I have run the tests locally and they passed.
- [x] I have added tests, or extended existing tests, to cover the bugs fixed in
  this PR.

### Optionals

- [ ] I have added an entry in `CHANGELOG.md`.
- [ ] This PR requires a follow-up in Dash documentation or a community thread.
