### PR TITLE
fixes aggressive remounting

### DIFF
--- a/dash/dash-renderer/src/wrapper/DashWrapper.tsx
+++ b/dash/dash-renderer/src/wrapper/DashWrapper.tsx
@@ -446,7 +446,7 @@ function DashWrapper({
     };
 
     useEffect(() => {
-        if (_newRender) {
+        if (_newRender && freshRenders.current > 1) {
             dispatch(
                 resetComponentState({
                     itempath: componentPath


### PR DESCRIPTION
fixes:
- https://github.com/plotly/dash/issues/3846
- https://github.com/plotly/dash/issues/3929

Issue was that on the first render of a component, it would trigger it to remount and clear the `layoutHashes` since it wasnt protected to see if it was the very first time that the component was rendering.
