### PR TITLE
Use the proxied url as the Jupyter server url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 - [#3916](https://github.com/plotly/dash/pull/3916) Fixed a regression where dragging multiple files into `dcc.Upload` would upload only the first file when `multiple=True`
 - [#3922](https://github.com/plotly/dash/pull/3922) Fix `dcc.Input(type="number")` stepper behavior when only `min` is set.
+- [#3925](https://github.com/plotly/dash/pull/3925) Use the proxied url as the Jupyter server url so `DASH_PROXY` is honored by the external url and inline iframe in notebooks.
 
 ## [4.4.1] - 2026-07-21
 

--- a/dash/dash.py
+++ b/dash/dash.py
@@ -2605,6 +2605,14 @@ class Dash(ObsoleteChecker):
                     extra_files.append(path)
 
         if jupyter_dash.active:
+            if jupyter_server_url is None and proxy:
+                # The app is served on host:port but reached through the proxy,
+                # so the notebook must display the proxied url.
+                proxied_url = urlparse(proxy.split("::")[1])
+                jupyter_server_url = (
+                    f"{proxied_url.scheme}://{proxied_url.hostname}"
+                    + (f":{proxied_url.port}" if proxied_url.port else "")
+                )
             jupyter_dash.run_app(
                 self,
                 mode=jupyter_mode,

--- a/tests/unit/test_configs.py
+++ b/tests/unit/test_configs.py
@@ -5,6 +5,7 @@ import pytest
 from flask import Flask
 
 from dash import Dash, exceptions as _exc
+from dash._jupyter import jupyter_dash
 
 # noinspection PyProtectedMember
 from dash._configs import (
@@ -377,6 +378,21 @@ def test_proxy_success(mocker, caplog, empty_environ, proxy, host, port, path):
     app.run(proxy=proxystr, host=host, port=port)
 
     assert "Dash is running on {}{}\n".format(proxy, path) in caplog.text
+
+
+def test_proxy_jupyter_server_url(mocker, empty_environ):
+    # The app is served on host:port but reached through the proxy, so the
+    # notebook must be given the proxied url.
+    proxy = "https://daash.plot.ly"
+    host, port = "127.0.0.1", 8050
+    app = Dash()
+    mocker.patch.object(app.server, "run")
+    mocker.patch.object(type(jupyter_dash), "active", True)
+    run_app = mocker.patch.object(jupyter_dash, "run_app")
+
+    app.run(proxy="http://{}:{}::{}".format(host, port, proxy), host=host, port=port)
+
+    assert run_app.call_args.kwargs["server_url"] == proxy
 
 
 def test_proxy_failure(mocker, empty_environ):


### PR DESCRIPTION
Fixes #3401.

When `DASH_PROXY` (or `run(proxy=...)`) is set, the app is served on `host:port` but reached through the proxy. `run()` already used the proxied url for the "Dash is running on" log line, but passed nothing to `jupyter_dash.run_app()`, so JupyterDash fell back to `http://host:port` for both the external url and the inline iframe — unreachable behind the proxy. `server_url` is now derived from the proxied half of the proxy string when the caller did not pass `jupyter_server_url` explicitly.

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] pass the proxied url through to `jupyter_dash.run_app()`
   -  [x] add a regression test
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

`tests/unit/test_configs.py` passes (the 2 unrelated failures in that file are missing built JS assets in my source checkout, identical before and after this change). The new `test_proxy_jupyter_server_url` fails without the fix (`server_url` is `None`) and passes with it.

### optionals

- [x] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    -  [ ] this GitHub [#PR number]() updates the dash docs
    -  [ ] here is the show and tell thread in Plotly Dash community

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
