### PR TITLE
Add dedicated Graph config schema test

### DIFF
--- a/components/dash-core-components/tests/integration/graph/test_graph_basics.py
+++ b/components/dash-core-components/tests/integration/graph/test_graph_basics.py
@@ -11,6 +11,52 @@ from dash import Dash, Input, Output, dcc, html
 import dash.testing.wait as wait
 
 
+def test_grbs013_graph_config_matches_plotly_schema(dash_dcc):
+    app = Dash(__name__)
+    app.layout = dcc.Graph(id="graph")
+    dash_dcc.start_server(app)
+    dash_dcc.wait_for_element("#graph .js-plotly-plot")
+
+    config_schema = dash_dcc.driver.execute_script(
+        "return Plotly.PlotSchema.get().config;"
+    )
+    with open(dcc.__path__[0] + "/metadata.json", encoding="utf-8") as metadata_file:
+        graph_metadata = json.load(metadata_file)["src/components/Graph.react.js"]
+    config_prop_shape = graph_metadata["props"]["config"]["type"]["value"]
+
+    ignored_config = {
+        "config.edits.role",
+        "config.globalTransforms",
+        "config.logging",
+        "config.notifyOnLogging",
+        "config.setBackground",
+        "config.showSources",
+        "config.typesetMath",
+    }
+
+    def assert_matching_config(schema, props, path="config"):
+        for prop_name in props:
+            prop_path = f"{path}.{prop_name}"
+            assert prop_name in schema, f"{prop_path} is not in Plotly's schema"
+
+        for item_name, item in schema.items():
+            item_path = f"{path}.{item_name}"
+            if item_path in ignored_config:
+                continue
+
+            assert item_name in props, f"{item_path} is missing from Graph config"
+            if "valType" not in item:
+                assert (
+                    isinstance(props[item_name], dict)
+                    and "value" in props[item_name]
+                    and isinstance(props[item_name]["value"], dict)
+                ), f"{item_path} has no nested 'value' shape"
+                assert_matching_config(item, props[item_name]["value"], item_path)
+
+    assert_matching_config(config_schema, config_prop_shape)
+    assert dash_dcc.get_logs() == []
+
+
 @pytest.mark.parametrize("is_eager", [True, False])
 def test_grbs001_graph_without_ids(dash_dcc, is_eager):
     app = Dash(__name__, eager_loading=is_eager)


### PR DESCRIPTION
Closes #3735

Adds a dedicated Graph integration test that recursively compares the live Plotly config schema with the generated `dcc.Graph` config metadata. Known Plotly-internal paths remain excluded, and assertion messages identify the exact config path when the schemas drift.

Tests:
- `python -m pytest components/dash-core-components/tests/integration/graph/test_graph_basics.py --headless -q` — 14 passed, 1 skipped
- `python -m black --check components/dash-core-components/tests/integration/graph/test_graph_basics.py` — passed

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   - [x] add a dedicated Graph config-schema test
   - [x] verify schema drift produces a path-specific failure
- [x] I have run the tests locally and they passed. (refer to testing section in [contributing](https://github.com/plotly/dash/blob/master/CONTRIBUTING.md))
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR

### optionals

- [ ] I have added entry in the `CHANGELOG.md`
- [ ] If this PR needs a follow-up in **dash docs**, **community thread**, I have mentioned the relevant URLS as follows
    - [ ] this GitHub [#PR number]() updates the dash docs
    - [ ] here is the show and tell thread in Plotly Dash community
