### PR TITLE
chore: Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence
-* @T4rk1n @ndrezn @camdecoster @KoolADE85


### PR DESCRIPTION
### Description

Remove the CODEOWNERS file in favor of GitHub repo access settings.

### Changes

- Remove file

### Testing

- Open a PR and see if anyone gets automatically assigned to it