### PR TITLE
Fix dev CI after the pip dependency bump

### DIFF
--- a/components/dash-table/tests/selenium/test_empty.py
+++ b/components/dash-table/tests/selenium/test_empty.py
@@ -28,8 +28,6 @@ def get_app():
         if n_clicks is None:
             raise PreventUpdate
 
-        nonlocal columns, data
-
         return (data, columns) if n_clicks % 2 == 0 else (None, None)
 
     return app

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,8 @@ flake8==7.3.0
 flaky==3.8.1
 flask-talisman==1.1.0
 ipython<9.0.0
-mimesis<=21.0.0
+mimesis<=12.0.0; python_version < "3.10"
+mimesis<=21.0.0; python_version >= "3.10"
 mock==5.2.0
 numpy<=2.2.6
 orjson>=3.10.11


### PR DESCRIPTION
dev has been red since the pip dependency bump in #3966. Two jobs fail for real (the rest look like the usual flakes):

- **Table Unit/Lint Tests**: flake8 7.3.0 added F824, which flags `nonlocal columns, data` in `components/dash-table/tests/selenium/test_empty.py` because those names are never assigned there. The bump fixed F824 in the main tree but not in dash-table. Removed the statement.
- **DCC Integration Tests (Python 3.9, Group 3)**: `mimesis<=21.0.0` resolves to a release that requires Python 3.10 and fails at import on 3.9 (`TypeError: unsupported operand type(s) for |: 'EnumMeta' and 'type'` in `mimesis/exceptions.py`). Pinned `mimesis<=12.0.0` on Python < 3.10 and kept `<=21.0.0` on 3.10+.

Verified locally: `flake8 dash_table_base tests` passes in dash-table, and `mimesis<=12.0.0` resolves to a wheel for Python 3.9.