### PR TITLE
Run every CI job when shared dependency or config files change

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,28 +28,47 @@ jobs:
         id: filter # Give an ID to this step to reference its outputs
         uses: dorny/paths-filter@v3
         with:
+          # Every job installs from requirements/ and setup.py and runs under
+          # the shared lint and pytest config, so a change there must run every
+          # job. A dependency bump once skipped the table and dcc jobs and only
+          # failed after merging to dev.
           filters: |
+            shared_paths: &shared_paths
+              - 'requirements/**'
+              - 'setup.py'
+              - 'pytest.ini'
+              - '.flake8'
+              - '.pylintrc'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'dash/testing/**'
+              - '.github/workflows/testing.yml'
             table_related_paths:
+              - *shared_paths
               - 'components/dash-table/**'
               - 'dash/dash-renderer/**'
             dcc_related_paths:
+              - *shared_paths
               - 'components/dash-core-components/**'
               - 'dash/dash-renderer/**'
             html_related_paths:
+              - *shared_paths
               - 'components/dash-html-components/**'
               - 'dash/dash-renderer/**'
             background_paths:
+              - *shared_paths
               - 'dash/background_callback/**'
               - 'dash/dash-renderer/**'
               - 'dash/_callback.py'
               - 'dash/_callback_context.py'
               - 'tests/background_callback/**'
               - 'tests/async_tests/**'
-              - 'requirements/**'
             backend_paths:
+              - *shared_paths
               - 'dash/backends/**'
               - 'tests/backend_tests/**'
             websocket_paths:
+              - *shared_paths
               - 'dash/backends/_fastapi.py'
               - 'dash/backends/_quart.py'
               - 'dash/backends/base_server.py'
@@ -60,7 +79,6 @@ jobs:
               - '@dash-websocket-worker/**'
               - 'dash/dash-renderer/src/**'
               - 'tests/websocket/**'
-              - 'requirements/**'
 
   lint-unit:
     name: Lint & Unit Tests (Python ${{ matrix.python-version }})

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@ flake8==7.3.0
 flaky==3.8.1
 flask-talisman==1.1.0
 ipython<9.0.0
-mimesis<=12.0.0; python_version < "3.10"
+mimesis<=11.1.0; python_version < "3.10"
 mimesis<=21.0.0; python_version >= "3.10"
 mock==5.2.0
 numpy<=2.2.6


### PR DESCRIPTION
Follow-up to #3972. The dependabot bump in #3966 went green on its PR because the Table, DCC, HTML and Backend Callback jobs were skipped by the path filters: `requirements/**` was only listed for the background, websocket and streaming filters, while every job installs from those files. The flake8 F824 and mimesis Python 3.9 failures only showed up after the merge to dev.

This adds a `shared_paths` list that every filter includes (dorny/paths-filter supports YAML anchors for this):

- `requirements/**`, `setup.py`
- `pytest.ini`, `.flake8`, `.pylintrc`
- `package.json`, `package-lock.json`
- `dash/testing/**` (the harness all component tests use)
- `.github/workflows/testing.yml`

Since this PR touches the workflow file itself, its own run exercises every job.